### PR TITLE
Validate URL port presence and following characters in parser and add tests

### DIFF
--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1410,10 +1410,24 @@ constexpr auto try_parse_url(::fast_io::u8string_view pltext) noexcept -> ::exce
                     return ::exception::nullopt_t{};
                 }
             }
+            if (port_index == 0) {
+                return ::exception::nullopt_t{};
+            }
             if (port > 65535) {
                 return ::exception::nullopt_t{};
             }
             current_index += port_index + 1;
+            if (current_index < pltext.size()) {
+                auto const next_chr = ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, current_index);
+                if (next_chr != u8'/' && next_chr != u8'?' && next_chr != u8'#') {
+                    if constexpr (regard_right_parent_as_end_of_url) {
+                        if (next_chr == u8')') {
+                            return current_index;
+                        }
+                    }
+                    return ::exception::nullopt_t{};
+                }
+            }
             break;
         }
         else {

--- a/tests/0060.url.cc
+++ b/tests/0060.url.cc
@@ -113,6 +113,30 @@ int main() {
         ::pltxt2htm_test::assert_true(::pltxt2htm::details::try_parse_url<false>(url).has_value());
     }
     {
+        auto url = ::fast_io::u8string_view{u8"https://www.example.com:/a/path"};
+        ::pltxt2htm_test::assert_true(::pltxt2htm::details::try_parse_url<false>(url).has_value() == false);
+    }
+    {
+        auto url = ::fast_io::u8string_view{u8"https://www.example.com:abc/a/path"};
+        ::pltxt2htm_test::assert_true(::pltxt2htm::details::try_parse_url<false>(url).has_value() == false);
+    }
+    {
+        auto url = ::fast_io::u8string_view{u8"https://www.example.com:80abc/a/path"};
+        ::pltxt2htm_test::assert_true(::pltxt2htm::details::try_parse_url<false>(url).has_value() == false);
+    }
+    {
+        auto url = ::fast_io::u8string_view{u8"https://www.example.com:80javascript:alert(1)"};
+        ::pltxt2htm_test::assert_true(::pltxt2htm::details::try_parse_url<false>(url).has_value() == false);
+    }
+    {
+        auto url = ::fast_io::u8string_view{u8"https://www.example.com:80?safe=query"};
+        ::pltxt2htm_test::assert_true(::pltxt2htm::details::try_parse_url<false>(url).has_value());
+    }
+    {
+        auto url = ::fast_io::u8string_view{u8"javascript:alert(1)"};
+        ::pltxt2htm_test::assert_true(::pltxt2htm::details::try_parse_url<false>(url).has_value() == false);
+    }
+    {
         auto url = ::fast_io::u8string_view{u8"https://www.example.wtf"};
         ::pltxt2htm_test::assert_true(::pltxt2htm::details::try_parse_url<false>(url).has_value() == false);
     }

--- a/tests/0060.url.cc
+++ b/tests/0060.url.cc
@@ -117,6 +117,10 @@ int main() {
         ::pltxt2htm_test::assert_true(::pltxt2htm::details::try_parse_url<false>(url).has_value() == false);
     }
     {
+        auto url = ::fast_io::u8string_view{u8"https://www.example.com:"};
+        ::pltxt2htm_test::assert_true(::pltxt2htm::details::try_parse_url<false>(url).has_value() == false);
+    }
+    {
         auto url = ::fast_io::u8string_view{u8"https://www.example.com:abc/a/path"};
         ::pltxt2htm_test::assert_true(::pltxt2htm::details::try_parse_url<false>(url).has_value() == false);
     }


### PR DESCRIPTION
### Motivation
- Ensure the URL parser rejects malformed port specifications such as a colon with no digits or ports followed immediately by invalid characters, and to prevent accepting dangerous constructs like `:80javascript:...`.
- Respect the `regard_right_parent_as_end_of_url` behavior when a right parenthesis follows the port so that `)` can be treated as end-of-url in that mode.

### Description
- Added a check `if (port_index == 0) return ::exception::nullopt_t{}` to reject empty ports after a colon in `try_parse_url`.
- After consuming port digits the code now validates that the next character (if present) is one of `/`, `?`, or `#`, and when `regard_right_parent_as_end_of_url` is set the `)` character is treated as end-of-url; otherwise parsing fails.
- Extended `tests/0060.url.cc` with multiple cases covering empty port, non-digit port, mixed alphanumeric port suffixes, query after port, and scheme injection attempts like `javascript:alert(1)`.

### Testing
- Ran the unit tests including `tests/0060.url.cc` which exercise the new port validation cases and edge conditions, and all tests passed.
