### PR TITLE
Fix malformed UTF-8 acceptance in 4-byte sequence parser

### DIFF
--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -267,7 +267,7 @@ constexpr auto parse_utf8_code_point(::fast_io::u8string_view const& pltext, ::p
             return 0;
         }
         auto next_char2 = ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, 2);
-        if ((next_char & 0xC0) != 0x80) {
+        if ((next_char2 & 0xC0) != 0x80) {
             result.push_back(::pltxt2htm::HeapGuard<::pltxt2htm::InvalidU8Char>{});
             return 0;
         }

--- a/tests/0024.invalid_utf8_char.cc
+++ b/tests/0024.invalid_utf8_char.cc
@@ -63,7 +63,7 @@ int main() {
     {
         // invalid 4-byte sequence: 3rd byte is not a continuation byte (0x28)
         auto html = ::pltxt2htm_test::pltxt2common_htmld(u8"\xf0\x90\x28\x80");
-        auto answer = ::fast_io::u8string_view{u8"("};
+        auto answer = ::fast_io::u8string_view{u8"�("};
         ::pltxt2htm_test::assert_true(html == answer);
     }
 

--- a/tests/0024.invalid_utf8_char.cc
+++ b/tests/0024.invalid_utf8_char.cc
@@ -63,7 +63,7 @@ int main() {
     {
         // invalid 4-byte sequence: 3rd byte is not a continuation byte (0x28)
         auto html = ::pltxt2htm_test::pltxt2common_htmld(u8"\xf0\x90\x28\x80");
-        auto answer = ::fast_io::u8string_view{u8"�(�"};
+        auto answer = ::fast_io::u8string_view{u8"("};
         ::pltxt2htm_test::assert_true(html == answer);
     }
 

--- a/tests/0024.invalid_utf8_char.cc
+++ b/tests/0024.invalid_utf8_char.cc
@@ -60,6 +60,12 @@ int main() {
         auto answer = ::fast_io::u8string_view{u8"�"};
         ::pltxt2htm_test::assert_true(html == answer);
     }
+    {
+        // invalid 4-byte sequence: 3rd byte is not a continuation byte (0x28)
+        auto html = ::pltxt2htm_test::pltxt2common_htmld(u8"\xf0\x90\x28\x80");
+        auto answer = ::fast_io::u8string_view{u8"�(�"};
+        ::pltxt2htm_test::assert_true(html == answer);
+    }
 
     {
         auto html = ::pltxt2htm_test::pltxt2common_htmld(u8"\xed\xa0\x80");


### PR DESCRIPTION
### Motivation
- `parse_utf8_code_point` incorrectly validated the second continuation byte twice when parsing 4-byte UTF-8 sequences, allowing some malformed sequences to be treated as valid and bypass downstream assumptions.
- Malformed UTF-8 can lead to incorrect AST nodes and may undermine escaping/sanitization, so the parser must strictly reject invalid continuation bytes.

### Description
- Fix the 4-byte UTF-8 validation by checking `next_char2` instead of re-checking `next_char` in `parse_utf8_code_point` (`include/pltxt2htm/details/parser/try_parse.hh`).
- Add a regression test for the malformed sequence `\xF0\x90\x28\x80` to `tests/0024.invalid_utf8_char.cc` to ensure the invalid third byte is handled via the invalid-character path.
- Changes are minimal and local to UTF-8 parsing and tests; logic for producing `InvalidU8Char` nodes is preserved.

### Testing
- Attempted to run the test suite via `python ./run_all_tests.py` / `xmake`, but `xmake` is not available in the environment so the test runner was not executed (error: `command not found: xmake`).
- Tried to compile and run the single updated test with `clang++ -std=c++23 -Iinclude -Itests tests/precompile.cpp tests/0024.invalid_utf8_char.cc -O0 -g -o /tmp/t0024 && /tmp/t0024`, but the project requires newer toolchain/library features (errors related to `std::forward_like` and the project's compiler version guard), so the test binary could not be built in this environment.
- No automated tests were completed in CI here due to local tooling constraints; the added unit test should pass in the repository CI or a developer environment meeting the project's toolchain requirements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e047319e6c832a80c79a0b7eaf577b)