### PR TITLE
Add `[[nodiscard]]` to many APIs and remove incorrect `[[__gnu__::__pure__]]` attributes

### DIFF
--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -44,6 +44,7 @@ public:
 };
 
 template<bool ndebug>
+[[nodiscard]]
 constexpr auto convert_simple_pltxt_ast_to_plunity_richtext(::pltxt2htm::Ast const& ast) noexcept
     -> ::fast_io::u8string {
     ::fast_io::u8string result{};
@@ -216,9 +217,6 @@ constexpr auto convert_simple_pltxt_ast_to_plunity_richtext(::pltxt2htm::Ast con
 
 template<bool ndebug>
 [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-[[__gnu__::__pure__]]
-#endif
 constexpr auto plunity_text_backend(::pltxt2htm::Ast const& ast_init, ::fast_io::u8string_view project,
                                     ::fast_io::u8string_view visitor, ::fast_io::u8string_view author,
                                     ::fast_io::u8string_view coauthors) noexcept -> ::fast_io::u8string {

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -24,6 +24,7 @@
 namespace pltxt2htm::details {
 
 template<bool ndebug>
+[[nodiscard]]
 constexpr auto convert_simple_pltxt_ast_to_plweb_text(::pltxt2htm::Ast const& ast) noexcept -> ::fast_io::u8string {
     ::fast_io::u8string result{};
     for (auto&& node : ast) {
@@ -218,9 +219,6 @@ constexpr auto convert_simple_pltxt_ast_to_plweb_text(::pltxt2htm::Ast const& as
  */
 template<bool ndebug>
 [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-[[__gnu__::__pure__]]
-#endif
 constexpr auto plweb_text_backend(::pltxt2htm::Ast const& ast_init, ::fast_io::u8string_view host,
                                   ::fast_io::u8string_view project, ::fast_io::u8string_view visitor,
                                   ::fast_io::u8string_view author, ::fast_io::u8string_view coauthors) noexcept

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -27,9 +27,6 @@ namespace pltxt2htm::details {
  */
 template<bool ndebug>
 [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-[[__gnu__::__pure__]]
-#endif
 constexpr auto plweb_title_backend(::pltxt2htm::Ast const& ast_init) noexcept -> ::fast_io::u8string {
     ::fast_io::u8string result{};
     ::fast_io::stack<::pltxt2htm::details::BackendBasicFrameContext> call_stack{};

--- a/include/pltxt2htm/details/literal_string.hh
+++ b/include/pltxt2htm/details/literal_string.hh
@@ -256,6 +256,7 @@ public:
      * @param self This object
      * @return Const pointer to the string data
      */
+    [[nodiscard]]
     constexpr auto data(this ::pltxt2htm::details::LiteralString<N> const& self) noexcept {
         return ::std::as_const(self.data_);
     }

--- a/include/pltxt2htm/details/parser/md_list.hh
+++ b/include/pltxt2htm/details/parser/md_list.hh
@@ -135,17 +135,21 @@ public:
     constexpr auto operator=(::pltxt2htm::details::MdListUlNode&&) & noexcept
         -> ::pltxt2htm::details::MdListUlNode& = default;
 
+    [[nodiscard]]
     constexpr auto operator==(this ::pltxt2htm::details::MdListUlNode const& self,
                               ::pltxt2htm::details::MdListUlNode const& other) noexcept -> bool;
 
+    [[nodiscard]]
     constexpr auto&& get_sublist(this ::pltxt2htm::details::MdListUlNode& self) noexcept {
         return self.sublist;
     }
 
+    [[nodiscard]]
     constexpr auto&& get_sublist(this ::pltxt2htm::details::MdListUlNode const& self) noexcept {
         return ::std::as_const(self.sublist);
     }
 
+    [[nodiscard]]
     constexpr auto&& get_sublist(this ::pltxt2htm::details::MdListUlNode&& self) noexcept {
         return ::std::move(self.sublist);
     }
@@ -175,22 +179,27 @@ public:
     constexpr auto operator=(::pltxt2htm::details::MdListOlNode&&) & noexcept
         -> ::pltxt2htm::details::MdListOlNode& = default;
 
+    [[nodiscard]]
     constexpr auto operator==(this ::pltxt2htm::details::MdListOlNode const& self,
                               ::pltxt2htm::details::MdListOlNode const& other) noexcept -> bool;
 
+    [[nodiscard]]
     constexpr auto&& get_sublist(this ::pltxt2htm::details::MdListOlNode& self) noexcept {
         return self.sublist;
     }
 
+    [[nodiscard]]
     constexpr auto&& get_sublist(this ::pltxt2htm::details::MdListOlNode const& self) noexcept {
         return ::std::as_const(self.sublist);
     }
 
+    [[nodiscard]]
     constexpr auto&& get_sublist(this ::pltxt2htm::details::MdListOlNode&& self) noexcept {
         return ::std::move(self.sublist);
     }
 };
 
+[[nodiscard]]
 constexpr auto operator==(::pltxt2htm::details::MdListBaseNode const& self,
                           ::pltxt2htm::details::MdListBaseNode const& other) noexcept -> bool {
     if (self.get_type() != other.get_type()) {
@@ -220,11 +229,13 @@ constexpr auto operator==(::pltxt2htm::details::MdListBaseNode const& self,
     ::exception::unreachable<false>();
 }
 
+[[nodiscard]]
 constexpr auto MdListUlNode::operator==(this ::pltxt2htm::details::MdListUlNode const& self,
                                         ::pltxt2htm::details::MdListUlNode const& other) noexcept -> bool {
     return self.sublist == other.sublist;
 }
 
+[[nodiscard]]
 constexpr auto MdListOlNode::operator==(this ::pltxt2htm::details::MdListOlNode const& self,
                                         ::pltxt2htm::details::MdListOlNode const& other) noexcept -> bool {
     return self.sublist == other.sublist;
@@ -278,6 +289,7 @@ public:
                              ::pltxt2htm::details::MdListFrameContext&&) noexcept
         -> ::pltxt2htm::details::MdListFrameContext& = default;
 
+    [[nodiscard]]
     constexpr auto&& get_item_kind(this ::pltxt2htm::details::MdListFrameContext const& self) noexcept {
         return ::std::as_const(self.item_kind);
     }

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -363,9 +363,6 @@ constexpr auto get_pltext_from_parser_frame_context(
  */
 template<bool ndebug>
 [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-[[__gnu__::__pure__]]
-#endif
 constexpr auto parse_pltxt(
     ::fast_io::stack<::pltxt2htm::HeapGuard<::pltxt2htm::details::BasicFrameContext>>& call_stack) noexcept
     -> ::pltxt2htm::Ast {

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -35,9 +35,6 @@ namespace pltxt2htm::details {
  * @see https://spec.commonmark.org/0.31.2/#backslash-escapes
  */
 [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-[[__gnu__::__pure__]]
-#endif
 constexpr ::exception::optional<::pltxt2htm::HeapGuard<::pltxt2htm::PlTxtNode>> switch_escape_char(
     char8_t u8char) noexcept {
     switch (u8char) {

--- a/include/pltxt2htm/heap_guard.hh
+++ b/include/pltxt2htm/heap_guard.hh
@@ -135,6 +135,7 @@ public:
         }
     }
 
+    [[nodiscard]]
     constexpr auto operator->(this ::pltxt2htm::is_heap_guard auto&& self) noexcept -> T* {
         return self.ptr_;
     }

--- a/include/pltxt2htm/parser.hh
+++ b/include/pltxt2htm/parser.hh
@@ -43,9 +43,6 @@ namespace pltxt2htm {
  */
 template<bool ndebug>
 [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-[[__gnu__::__pure__]]
-#endif
 constexpr auto parse_pltxt(::fast_io::u8string_view pltext) noexcept -> ::pltxt2htm::Ast {
     // fast_io::deque contains bug about RAII, use fast_io::list instead
     // This stack is used to track nested tag contexts during parsing

--- a/include/pltxt2htm/pltxt2htm.h
+++ b/include/pltxt2htm/pltxt2htm.h
@@ -32,9 +32,6 @@ namespace details {
  */
 template<auto Func, typename... Args>
 [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-[[__gnu__::__pure__]]
-#endif
 #if __has_cpp_attribute(__gnu__::__nonnull__)
 [[__gnu__::__nonnull__]]
 #endif
@@ -68,9 +65,6 @@ constexpr char8_t const* c_ptr_style_wrapper(Args&&... args) noexcept(
  */
 template<bool ndebug = false>
 [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-[[__gnu__::__pure__]]
-#endif
 #if __has_cpp_attribute(__gnu__::__nonnull__)
 [[__gnu__::__nonnull__]]
 #endif
@@ -99,9 +93,6 @@ constexpr char8_t const* advanced_parser(char8_t const* const text) noexcept {
  */
 template<bool ndebug = false>
 [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-[[__gnu__::__pure__]]
-#endif
 #if __has_cpp_attribute(__gnu__::__nonnull__)
 [[__gnu__::__nonnull__]]
 #endif
@@ -128,9 +119,6 @@ constexpr char8_t const* fixedadv_parser(char8_t const* const text, char8_t cons
  */
 template<bool ndebug = false>
 [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-[[__gnu__::__pure__]]
-#endif
 #if __has_cpp_attribute(__gnu__::__nonnull__)
 [[__gnu__::__nonnull__]]
 #endif
@@ -157,9 +145,6 @@ constexpr char8_t const* common_parser(char8_t const* const text) noexcept {
  */
 template<bool ndebug = false>
 [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-[[__gnu__::__pure__]]
-#endif
 #if __has_cpp_attribute(__gnu__::__nonnull__)
 [[__gnu__::__nonnull__]]
 #endif

--- a/include/pltxt2htm/pltxt2htm.hh
+++ b/include/pltxt2htm/pltxt2htm.hh
@@ -47,9 +47,6 @@ namespace pltxt2htm {
  */
 template<bool ndebug = false, bool optimize = true>
 [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-[[__gnu__::__pure__]]
-#endif
 constexpr auto pltxt2advanced_html(::fast_io::u8string_view pltext) noexcept {
     auto ast = ::pltxt2htm::parse_pltxt<ndebug>(pltext);
     if constexpr (optimize) {
@@ -73,9 +70,6 @@ constexpr auto pltxt2advanced_html(::fast_io::u8string_view pltext) noexcept {
  */
 template<bool ndebug = false, bool optimize = true>
 [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-[[__gnu__::__pure__]]
-#endif
 constexpr auto pltxt2fixedadv_html(::fast_io::u8string_view pltext, ::fast_io::u8string_view host,
                                    ::fast_io::u8string_view project, ::fast_io::u8string_view visitor,
                                    ::fast_io::u8string_view author, ::fast_io::u8string_view coauthors) noexcept {
@@ -102,9 +96,6 @@ constexpr auto pltxt2fixedadv_html(::fast_io::u8string_view pltext, ::fast_io::u
  */
 template<bool ndebug = false, bool optimize = true>
 [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-[[__gnu__::__pure__]]
-#endif
 constexpr auto pltxt2plunity_introduction(::fast_io::u8string_view pltext, ::fast_io::u8string_view project,
                                           ::fast_io::u8string_view visitor, ::fast_io::u8string_view author,
                                           ::fast_io::u8string_view coauthors) noexcept {
@@ -138,9 +129,6 @@ constexpr auto pltxt2plunity_introduction(::fast_io::u8string_view pltext, ::fas
  */
 template<bool ndebug = false, bool optimize = false>
 [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-[[__gnu__::__pure__]]
-#endif
 constexpr auto pltxt2common_html(::fast_io::u8string_view pltext) noexcept {
     auto ast = ::pltxt2htm::parse_pltxt<ndebug>(pltext);
     if constexpr (optimize) {


### PR DESCRIPTION
### Motivation
- Mark more functions that return values with `[[nodiscard]]` to help catch ignored return values. 
- Remove incorrectly-applied `[[__gnu__::__pure__]]` on functions that allocate or mutate parsing/backend state to avoid invalid optimizer assumptions.

### Description
- Added `[[nodiscard]]` to a range of return-value APIs in `include/pltxt2htm`, including list-parser node accessors/comparisons, backend helper converters, `HeapGuard::operator->`, and `LiteralString::data() const`.
- Removed `[[__gnu__::__pure__]]` from top-level conversion/parsing/back-end functions that perform allocations or mutate state (examples: `pltxt2advanced_html`, `pltxt2fixedadv_html`, `pltxt2plunity_introduction`, `pltxt2common_html`, `parse_pltxt`, `details::parse_pltxt`, `switch_escape_char`, `plweb_*`/`plunity_text_backend` etc.).
- Target files changed: `pltxt2htm.hh`, `pltxt2htm.h`, `parser.hh`, `details/parser/parser.hh`, `details/parser/try_parse.hh`, `details/backend/for_plweb_title.hh`, `details/backend/for_plweb_text.hh`, `details/backend/for_plunity_text.hh`, `details/literal_string.hh`, `details/parser/md_list.hh`, `heap_guard.hh`.
- Preserved semantics of `operator=` (no `[[nodiscard]]` added) and only removed `pure` where it was not semantically correct.

### Testing
- Attempted to build with `cmake -S . -B build && cmake --build build -j2`, which failed because the repository root contains no `CMakeLists.txt` (build not performed). (failed)
- Checked for `xmake` via `xmake --version`, but `xmake` is not installed in the environment so no build was attempted with that tool. (no-op)
- Confirmed changes are limited to header/attribute/signature annotations via repository diffs and grep inspection (local static checks only). (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1ff240564832a8d247be3db9adac2)