### PR TITLE
Harden <color> tag parsing with dedicated validator and security tests

### DIFF
--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -807,12 +807,8 @@ entry:
                 [[fallthrough]];
             case u8'C': {
                 // parsing: <color=$1>$2</color>
-                if (auto opt_color_tag = ::pltxt2htm::details::try_parse_equal_sign_tag<ndebug, u8"olor">(
-                        u8string_view_subview<ndebug>(pltext, current_index + 2),
-                        [](char8_t u8chr) static constexpr noexcept {
-                            return (u8'0' <= u8chr && u8chr <= u8'9') || (u8'a' <= u8chr && u8chr <= u8'z') ||
-                                   (u8'A' <= u8chr && u8chr <= u8'Z') || u8chr == u8'#';
-                        });
+                if (auto opt_color_tag = ::pltxt2htm::details::try_parse_color_tag<ndebug>(
+                        u8string_view_subview<ndebug>(pltext, current_index + 2));
                     opt_color_tag.has_value()) {
                     auto&& [tag_len, color] = opt_color_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                     current_index += tag_len + 3;

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -379,6 +379,52 @@ struct TryParseEqualSignTagResult {
 };
 
 /**
+ * @brief Validate a parsed color token for `<color=...>` tags.
+ *
+ * Accepted forms:
+ * - CSS named color (ASCII letters only), e.g. `red`, `LightBlue`.
+ * - Hex colors prefixed by `#` with 3/4/6/8 hex digits, e.g. `#fff`, `#66CcFf`, `#11223344`.
+ *
+ * Rejected forms include punctuation-rich payloads (e.g. `red;...`, `url(...)`)
+ * and malformed hex strings to reduce style-injection/XSS risks.
+ *
+ * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
+ * @param[in] color Parsed color value from tag payload.
+ * @return true if the color token is valid; otherwise false.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr bool is_valid_color(::fast_io::u8string_view color) noexcept {
+    if (color.empty()) {
+        return false;
+    }
+
+    auto const color_size{color.size()};
+    auto const first_chr{::pltxt2htm::details::u8string_view_index<ndebug>(color, 0)};
+    if (first_chr == u8'#') {
+        auto const hex_len{color_size - 1};
+        if (hex_len != 3 && hex_len != 4 && hex_len != 6 && hex_len != 8) {
+            return false;
+        }
+        for (::std::size_t i{1}; i < color_size; ++i) {
+            auto const chr{::pltxt2htm::details::u8string_view_index<ndebug>(color, i)};
+            if (!((u8'0' <= chr && chr <= u8'9') || (u8'a' <= chr && chr <= u8'f') || (u8'A' <= chr && chr <= u8'F'))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    for (::std::size_t i{}; i < color_size; ++i) {
+        auto const chr{::pltxt2htm::details::u8string_view_index<ndebug>(color, i)};
+        if (!((u8'a' <= chr && chr <= u8'z') || (u8'A' <= chr && chr <= u8'Z'))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
  * @brief Parse an HTML tag with a single attribute value (e.g., `<tag=value>`).
  *
  * This function parses HTML tags that have a simple attribute with an equals sign and a value.
@@ -490,6 +536,32 @@ constexpr auto try_parse_non_nestable_equal_sign_tag(
             nested_tag_type == ::pltxt2htm::NodeType::pl_external) {
             return ::exception::nullopt_t{};
         }
+    }
+    return result;
+}
+
+/**
+ * @brief Parse `<color=...>` and validate value against a strict color grammar.
+ * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
+ * @param[in] pltext Input text starting at `olor=...`.
+ * @return Parsed tag result when valid; otherwise nullopt.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_color_tag(::fast_io::u8string_view pltext) noexcept
+    -> ::exception::optional<TryParseEqualSignTagResult> {
+    auto result = ::pltxt2htm::details::try_parse_equal_sign_tag<ndebug, u8"olor">(
+        pltext, [](char8_t u8chr) static constexpr noexcept {
+            return (u8'0' <= u8chr && u8chr <= u8'9') || (u8'a' <= u8chr && u8chr <= u8'z') ||
+                   (u8'A' <= u8chr && u8chr <= u8'Z') || u8chr == u8'#';
+        });
+    if (!result.has_value()) {
+        return ::exception::nullopt_t{};
+    }
+
+    auto const& color{result.template value<ndebug == ::pltxt2htm::Contracts::ignore>().substr};
+    if (!::pltxt2htm::details::is_valid_color<ndebug>(::fast_io::u8string_view{color.data(), color.size()})) {
+        return ::exception::nullopt_t{};
     }
     return result;
 }

--- a/tests/0004.color_tag.cc
+++ b/tests/0004.color_tag.cc
@@ -110,5 +110,21 @@ int main() {
         ::pltxt2htm_test::assert_true(html == answer);
     }
 
+    {
+        // invalid hex length should be rejected
+        auto html = ::pltxt2htm_test::pltxt2advanced_htmld(u8"<color=#12345>test</color>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;color=#12345&gt;test&lt;/color&gt;"};
+        ::pltxt2htm_test::assert_true(html == answer);
+    }
+
+    {
+        // block style injection / XSS payload in color value
+        auto html =
+            ::pltxt2htm_test::pltxt2advanced_htmld(u8"<color=red;background:urljavascriptalert1>test</color>");
+        auto answer =
+            ::fast_io::u8string_view{u8"&lt;color=red;background:urljavascriptalert1&gt;test&lt;/color&gt;"};
+        ::pltxt2htm_test::assert_true(html == answer);
+    }
+
     return 0;
 }


### PR DESCRIPTION
### Motivation

- Tighten parsing for `<color=...>` tags to avoid accepting punctuation-rich payloads that could enable style-injection/XSS and to centralize color validation logic.

### Description

- Add a strict validator `is_valid_color` (template `ndebug`) that accepts ASCII-only named colors and `#`-prefixed hex colors of lengths 3/4/6/8 and rejects other forms. 
- Add `try_parse_color_tag` which reuses `try_parse_equal_sign_tag` to extract the token and then applies `is_valid_color` before accepting the tag.
- Replace the inline lambda usage in `parser.hh` with a call to `try_parse_color_tag<ndebug>` so semantic validation happens at parse time.
- Extend `tests/0004.color_tag.cc` with cases for malformed hex length (e.g. `#12345`) and a style-injection-like payload (e.g. `red;background:...`) to ensure such inputs are rejected and rendered as escaped plain text.

### Testing

- Added/updated unit tests in `tests/0004.color_tag.cc` covering valid colors and the new invalid/XSS-like cases; these tests are included in the repository.
- Attempted to run `xmake` build/test directly (e.g. `xmake config && xmake build 0004.color_tag && xmake run 0004.color_tag`), but the environment reported `xmake: not found` so the build did not run.
- Attempted `python tests/run_all_tests.py`, which failed because it depends on `xmake` (error: `XMake config fail`), therefore no automated test run completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e34aa5cd30832a9f3384a4d00e0ecf)