### PR TITLE
refactor(backend): use u8 string literals for escape sequences

### DIFF
--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -56,8 +56,7 @@ constexpr auto convert_simple_pltxt_ast_to_plunity_richtext(::pltxt2htm::Ast con
             continue;
         }
         case ::pltxt2htm::NodeType::invalid_u8char: {
-            auto const escape_str = ::fast_io::array{char8_t{0xef}, 0xbf, 0xbd};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"\uFFFD");
             continue;
         }
         case ::pltxt2htm::NodeType::space: {
@@ -238,8 +237,7 @@ entry:
             continue;
         }
         case ::pltxt2htm::NodeType::invalid_u8char: {
-            auto const escape_str = ::fast_io::array{char8_t{0xef}, 0xbf, 0xbd};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"\uFFFD");
             continue;
         }
         case ::pltxt2htm::NodeType::text: {

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -37,55 +37,45 @@ constexpr auto convert_simple_pltxt_ast_to_plweb_text(::pltxt2htm::Ast const& as
             continue;
         }
         case ::pltxt2htm::NodeType::invalid_u8char: {
-            auto const escape_str = ::fast_io::array{char8_t{0xef}, 0xbf, 0xbd};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"\uFFFD");
             continue;
         }
         case ::pltxt2htm::NodeType::space: {
-            auto const escape_str = ::fast_io::array{u8'&', u8'n', u8'b', u8's', u8'p', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&nbsp;");
             continue;
         }
         case ::pltxt2htm::NodeType::md_escape_ampersand:
             [[fallthrough]];
         case ::pltxt2htm::NodeType::ampersand: {
-            auto const escape_str = ::fast_io::array{u8'&', u8'a', u8'm', u8'p', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&amp;");
             continue;
         }
         case ::pltxt2htm::NodeType::md_escape_single_quote:
             [[fallthrough]];
         case ::pltxt2htm::NodeType::single_quote: {
-            auto const escape_str = ::fast_io::array{u8'&', u8'a', u8'p', u8'o', u8's', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&apos;");
             continue;
         }
         case ::pltxt2htm::NodeType::md_escape_double_quote:
             [[fallthrough]];
         case ::pltxt2htm::NodeType::double_quote: {
-            auto const escape_str = ::fast_io::array{u8'&', u8'q', u8'u', u8'o', u8't', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&quot;");
             continue;
         }
         case ::pltxt2htm::NodeType::md_escape_less_than:
             [[fallthrough]];
         case ::pltxt2htm::NodeType::less_than: {
-            auto const escape_str = ::fast_io::array{u8'&', u8'l', u8't', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&lt;");
             continue;
         }
         case ::pltxt2htm::NodeType::md_escape_greater_than:
             [[fallthrough]];
         case ::pltxt2htm::NodeType::greater_than: {
-            auto const escape_str = ::fast_io::array{u8'&', u8'g', u8't', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&gt;");
             continue;
         }
         case ::pltxt2htm::NodeType::tab: {
-            auto const escape_str =
-                ::fast_io::array{u8'&', u8'n', u8'b', u8's', u8'p', u8';', u8'&', u8'n', u8'b', u8's', u8'p', u8';',
-                                 u8'&', u8'n', u8'b', u8's', u8'p', u8';', u8'&', u8'n', u8'b', u8's', u8'p', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&nbsp;&nbsp;&nbsp;&nbsp;");
             continue;
         }
         case ::pltxt2htm::NodeType::md_escape_backslash: {
@@ -296,8 +286,7 @@ entry:
             continue;
         }
         case ::pltxt2htm::NodeType::invalid_u8char: {
-            auto const escape_str = ::fast_io::array{char8_t{0xef}, 0xbf, 0xbd};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"\uFFFD");
             continue;
         }
         case ::pltxt2htm::NodeType::text: {
@@ -308,50 +297,41 @@ entry:
             goto entry;
         }
         case ::pltxt2htm::NodeType::space: {
-            auto const escape_str = ::fast_io::array{u8'&', u8'n', u8'b', u8's', u8'p', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&nbsp;");
             continue;
         }
         case ::pltxt2htm::NodeType::md_escape_ampersand:
             [[fallthrough]];
         case ::pltxt2htm::NodeType::ampersand: {
-            auto const escape_str = ::fast_io::array{u8'&', u8'a', u8'm', u8'p', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&amp;");
             continue;
         }
         case ::pltxt2htm::NodeType::md_escape_single_quote:
             [[fallthrough]];
         case ::pltxt2htm::NodeType::single_quote: {
-            auto const escape_str = ::fast_io::array{u8'&', u8'a', u8'p', u8'o', u8's', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&apos;");
             continue;
         }
         case ::pltxt2htm::NodeType::md_escape_double_quote:
             [[fallthrough]];
         case ::pltxt2htm::NodeType::double_quote: {
-            auto const escape_str = ::fast_io::array{u8'&', u8'q', u8'u', u8'o', u8't', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&quot;");
             continue;
         }
         case ::pltxt2htm::NodeType::md_escape_less_than:
             [[fallthrough]];
         case ::pltxt2htm::NodeType::less_than: {
-            auto const escape_str = ::fast_io::array{u8'&', u8'l', u8't', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&lt;");
             continue;
         }
         case ::pltxt2htm::NodeType::md_escape_greater_than:
             [[fallthrough]];
         case ::pltxt2htm::NodeType::greater_than: {
-            auto const escape_str = ::fast_io::array{u8'&', u8'g', u8't', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&gt;");
             continue;
         }
         case ::pltxt2htm::NodeType::tab: {
-            auto const escape_str =
-                ::fast_io::array{u8'&', u8'n', u8'b', u8's', u8'p', u8';', u8'&', u8'n', u8'b', u8's', u8'p', u8';',
-                                 u8'&', u8'n', u8'b', u8's', u8'p', u8';', u8'&', u8'n', u8'b', u8's', u8'p', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&nbsp;&nbsp;&nbsp;&nbsp;");
             continue;
         }
         case ::pltxt2htm::NodeType::pl_color: {

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -45,55 +45,45 @@ entry:
             continue;
         }
         case ::pltxt2htm::NodeType::invalid_u8char: {
-            auto const escape_str = ::fast_io::array{char8_t{0xef}, 0xbf, 0xbd};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"\uFFFD");
             continue;
         }
         case ::pltxt2htm::NodeType::space: {
-            auto const escape_str = ::fast_io::array{u8'&', u8'n', u8'b', u8's', u8'p', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&nbsp;");
             continue;
         }
         case ::pltxt2htm::NodeType::md_escape_ampersand:
             [[fallthrough]];
         case ::pltxt2htm::NodeType::ampersand: {
-            auto const escape_str = ::fast_io::array{u8'&', u8'a', u8'm', u8'p', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&amp;");
             continue;
         }
         case ::pltxt2htm::NodeType::md_escape_single_quote:
             [[fallthrough]];
         case ::pltxt2htm::NodeType::single_quote: {
-            auto const escape_str = ::fast_io::array{u8'&', u8'a', u8'p', u8'o', u8's', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&apos;");
             continue;
         }
         case ::pltxt2htm::NodeType::md_escape_double_quote:
             [[fallthrough]];
         case ::pltxt2htm::NodeType::double_quote: {
-            auto const escape_str = ::fast_io::array{u8'&', u8'q', u8'u', u8'o', u8't', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&quot;");
             continue;
         }
         case ::pltxt2htm::NodeType::md_escape_less_than:
             [[fallthrough]];
         case ::pltxt2htm::NodeType::less_than: {
-            auto const escape_str = ::fast_io::array{u8'&', u8'l', u8't', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&lt;");
             continue;
         }
         case ::pltxt2htm::NodeType::md_escape_greater_than:
             [[fallthrough]];
         case ::pltxt2htm::NodeType::greater_than: {
-            auto const escape_str = ::fast_io::array{u8'&', u8'g', u8't', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&gt;");
             continue;
         }
         case ::pltxt2htm::NodeType::tab: {
-            auto const escape_str =
-                ::fast_io::array{u8'&', u8'n', u8'b', u8's', u8'p', u8';', u8'&', u8'n', u8'b', u8's', u8'p', u8';',
-                                 u8'&', u8'n', u8'b', u8's', u8'p', u8';', u8'&', u8'n', u8'b', u8's', u8'p', u8';'};
-            result.append(::fast_io::u8string_view{escape_str.data(), escape_str.size()});
+            result.append(u8"&nbsp;&nbsp;&nbsp;&nbsp;");
             continue;
         }
         case ::pltxt2htm::NodeType::line_break:


### PR DESCRIPTION
### Motivation
- Simplify backend output construction by replacing small `::fast_io::array{...}` buffers used only for HTML/entity escapes with direct `u8"..."` literals for clarity and fewer temporaries.
- Make the code easier to read and maintain by using explicit UTF-8 string literals for common escape fragments and the Unicode replacement character.
- Reduce repeated `u8string_view` creation for tiny constant fragments and make intent explicit where these fragments are appended to `result`.

### Description
- Replaced array-built escape constants for invalid UTF-8, spaces, HTML entities (`&amp;`, `&apos;`, `&quot;`, `&lt;`, `&gt;`) and tab expansion with direct `u8"..."` calls to `result.append()` in `include/pltxt2htm/details/backend/for_plweb_title.hh`.
- Applied the same replacements in both the simple and full backend paths in `include/pltxt2htm/details/backend/for_plweb_text.hh` to append `u8"\uFFFD"`, `u8"&nbsp;"`, `u8"&amp;"`, `u8"&apos;"`, `u8"&quot;"`, `u8"&lt;"`, `u8"&gt;"`, and `u8"&nbsp;&nbsp;&nbsp;&nbsp;"` where appropriate.
- Updated two occurrences of the invalid-character output in `include/pltxt2htm/details/backend/for_plunity_text.hh` to use `u8"\uFFFD"`.

### Testing
- Ran `python3 tests/run_all_tests.py` to exercise the repository test harness, but the script failed during configuration because `xmake` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e35b93d9fc832a906ef3cdca47a5ef)