### PR TITLE
refactor: constexpr-concat A tag color span prefix

### DIFF
--- a/include/pltxt2htm/astnode/physics_lab_node.hh
+++ b/include/pltxt2htm/astnode/physics_lab_node.hh
@@ -97,7 +97,7 @@ public:
 #if __has_cpp_attribute(__gnu__::__pure__)
     [[__gnu__::__pure__]]
 #endif
-    static constexpr auto get_color_literal() noexcept -> ::pltxt2htm::details::LiteralString<7> const& {
+    static constexpr auto get_color_literal() noexcept -> decltype(color_) const& {
         return color_;
     }
 };

--- a/include/pltxt2htm/astnode/physics_lab_node.hh
+++ b/include/pltxt2htm/astnode/physics_lab_node.hh
@@ -100,14 +100,6 @@ public:
     static constexpr auto get_color_literal() noexcept -> ::pltxt2htm::details::LiteralString<7> const& {
         return color_;
     }
-
-    [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-    [[__gnu__::__pure__]]
-#endif
-    constexpr auto&& get_color(this auto&& self) noexcept {
-        return ::std::forward_like<decltype(self)>(self.color_);
-    }
 };
 
 /**

--- a/include/pltxt2htm/astnode/physics_lab_node.hh
+++ b/include/pltxt2htm/astnode/physics_lab_node.hh
@@ -13,6 +13,7 @@
 #include <fast_io/fast_io_dsal/string.h>
 #include <fast_io/fast_io_dsal/string_view.h>
 #include <exception/exception.hh>
+#include "../details/literal_string.hh"
 #include "basic.hh"
 
 namespace pltxt2htm {
@@ -69,7 +70,7 @@ public:
  * @details Represents a hyperlink using <a> syntax with default blue color
  */
 class A : public ::pltxt2htm::details::PairedTagBase {
-    static constexpr ::fast_io::u8string_view color_{u8"#0000AA"}; ///< The color of the link text
+    static constexpr ::pltxt2htm::details::LiteralString color_{u8"#0000AA"}; ///< The color of the link text
 
 public:
     constexpr A() noexcept = delete;
@@ -91,6 +92,14 @@ public:
     constexpr ::pltxt2htm::A& operator=(::pltxt2htm::A const&) noexcept = delete;
 
     constexpr ::pltxt2htm::A& operator=(::pltxt2htm::A&&) noexcept = default;
+
+    [[nodiscard]]
+#if __has_cpp_attribute(__gnu__::__pure__)
+    [[__gnu__::__pure__]]
+#endif
+    static constexpr auto get_color_literal() noexcept -> ::pltxt2htm::details::LiteralString<7> const& {
+        return color_;
+    }
 
     [[nodiscard]]
 #if __has_cpp_attribute(__gnu__::__pure__)

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -297,14 +297,16 @@ entry:
             goto entry;
         }
         case ::pltxt2htm::NodeType::pl_a: {
-            auto color = static_cast<::pltxt2htm::A const*>(node.release_imul());
+            auto anchor = static_cast<::pltxt2htm::A const*>(node.release_imul());
 
             call_stack.push(
-                ::pltxt2htm::details::BackendBasicFrameContext(color->get_subast(), ::pltxt2htm::NodeType::pl_a, 0));
+                ::pltxt2htm::details::BackendBasicFrameContext(anchor->get_subast(), ::pltxt2htm::NodeType::pl_a, 0));
             ++current_index;
-            result.append(u8"<color=");
-            result.append(color->get_color());
-            result.push_back(u8'>');
+            constexpr auto open_tag =
+                ::pltxt2htm::details::concat(::pltxt2htm::details::LiteralString{u8"<color="},
+                                             ::pltxt2htm::A::get_color_literal(),
+                                             ::pltxt2htm::details::LiteralString{u8">"});
+            result.append(::fast_io::u8string_view{reinterpret_cast<char8_t const*>(open_tag.data()), open_tag.size()});
             goto entry;
         }
         case ::pltxt2htm::NodeType::pl_experiment: {

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -367,18 +367,16 @@ entry:
             goto entry;
         }
         case ::pltxt2htm::NodeType::pl_a: {
-            auto color = static_cast<::pltxt2htm::A const*>(node.release_imul());
+            auto anchor = static_cast<::pltxt2htm::A const*>(node.release_imul());
 
             call_stack.push(
-                ::pltxt2htm::details::BackendBasicFrameContext(color->get_subast(), ::pltxt2htm::NodeType::pl_a, 0));
+                ::pltxt2htm::details::BackendBasicFrameContext(anchor->get_subast(), ::pltxt2htm::NodeType::pl_a, 0));
             ++current_index;
-            // TODO this can be concat at compile time
-            constexpr ::fast_io::u8string_view close_tag1 =
-                u8"<span style=\"color:";
-            result.append(::fast_io::u8string_view{close_tag1.data(), close_tag1.size()});
-            result.append(color->get_color());
-            constexpr ::fast_io::u8string_view close_tag2 = u8";\">";
-            result.append(::fast_io::u8string_view{close_tag2.data(), close_tag2.size()});
+            constexpr auto open_tag =
+                ::pltxt2htm::details::concat(::pltxt2htm::details::LiteralString{u8"<span style=\"color:"},
+                                             ::pltxt2htm::A::get_color_literal(),
+                                             ::pltxt2htm::details::LiteralString{u8";\">"});
+            result.append(::fast_io::u8string_view{reinterpret_cast<char8_t const*>(open_tag.data()), open_tag.size()});
             goto entry;
         }
         case ::pltxt2htm::NodeType::pl_experiment: {

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -105,16 +105,15 @@ entry:
             goto entry;
         }
         case ::pltxt2htm::NodeType::pl_a: {
-            auto color = static_cast<::pltxt2htm::A const*>(node.release_imul());
+            auto anchor = static_cast<::pltxt2htm::A const*>(node.release_imul());
             call_stack.push(
-                ::pltxt2htm::details::BackendBasicFrameContext(color->get_subast(), ::pltxt2htm::NodeType::pl_a, 0));
+                ::pltxt2htm::details::BackendBasicFrameContext(anchor->get_subast(), ::pltxt2htm::NodeType::pl_a, 0));
             ++current_index;
-            constexpr ::fast_io::u8string_view close_tag1 =
-                u8"<span style=\"color:";
-            result.append(::fast_io::u8string_view{close_tag1.data(), close_tag1.size()});
-            result.append(color->get_color());
-            constexpr ::fast_io::u8string_view close_tag2 = u8";\">";
-            result.append(::fast_io::u8string_view{close_tag2.data(), close_tag2.size()});
+            constexpr auto open_tag =
+                ::pltxt2htm::details::concat(::pltxt2htm::details::LiteralString{u8"<span style=\"color:"},
+                                             ::pltxt2htm::A::get_color_literal(),
+                                             ::pltxt2htm::details::LiteralString{u8";\">"});
+            result.append(::fast_io::u8string_view{reinterpret_cast<char8_t const*>(open_tag.data()), open_tag.size()});
             goto entry;
         }
         case ::pltxt2htm::NodeType::md_double_emphasis_underscore:

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -332,7 +332,7 @@ entry:
                 call_stack.push(::pltxt2htm::HeapGuard<
                                 ::pltxt2htm::details::OptimizerEqualSignTagContext<::pltxt2htm::Ast::iterator>>(
                     ::std::addressof(subast), ::pltxt2htm::NodeType::pl_a, subast.begin(),
-                    ::fast_io::mnp::os_c_str(u8"#0000AA")));
+                    anchor_color));
                 goto entry;
             }
             else {

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -294,12 +294,15 @@ entry:
             }
         }
         case ::pltxt2htm::NodeType::pl_a: {
-            auto const color = static_cast<::pltxt2htm::A*>(node.get_unsafe());
+            auto const anchor = static_cast<::pltxt2htm::A*>(node.get_unsafe());
+            constexpr auto anchor_color_literal = ::pltxt2htm::A::get_color_literal();
+            auto const anchor_color = ::fast_io::u8string_view{
+                reinterpret_cast<char8_t const*>(anchor_color_literal.data()), anchor_color_literal.size()};
             {
                 // Optimization: <a><color=blue>text</color></a>
                 // can be simplified to <color=blue>text</color>
                 // The inner color takes precedence over the outer color
-                auto&& subast = color->get_subast();
+                auto&& subast = anchor->get_subast();
                 if (subast.size() == 1) {
                     ::pltxt2htm::HeapGuard<::pltxt2htm::PlTxtNode>& psubnode =
                         ::pltxt2htm::details::vector_front<ndebug>(subast);
@@ -316,12 +319,12 @@ entry:
             bool const is_not_same_tag =
                 (nested_tag_type != ::pltxt2htm::NodeType::pl_color &&
                  nested_tag_type != ::pltxt2htm::NodeType::pl_a) ||
-                color->get_color() !=
+                anchor_color !=
                     static_cast<::pltxt2htm::details::OptimizerEqualSignTagContext<::pltxt2htm::Ast::iterator> const*>(
                         call_stack.top().release_imul())
                         ->id_;
             if (is_not_same_tag) {
-                auto&& subast = color->get_subast();
+                auto&& subast = anchor->get_subast();
                 if (subast.empty()) {
                     ast.erase(current_iter);
                     continue;
@@ -329,13 +332,13 @@ entry:
                 call_stack.push(::pltxt2htm::HeapGuard<
                                 ::pltxt2htm::details::OptimizerEqualSignTagContext<::pltxt2htm::Ast::iterator>>(
                     ::std::addressof(subast), ::pltxt2htm::NodeType::pl_a, subast.begin(),
-                    ::fast_io::mnp::os_c_str(color->get_color())));
+                    ::fast_io::mnp::os_c_str(u8"#0000AA")));
                 goto entry;
             }
             else {
                 // Optimization: If the color is the same as the parent node, then ignore the nested tag.
                 node = static_cast<::pltxt2htm::HeapGuard<::pltxt2htm::PlTxtNode>>(
-                    ::pltxt2htm::HeapGuard<::pltxt2htm::Text>(::std::move(color->get_subast())));
+                    ::pltxt2htm::HeapGuard<::pltxt2htm::Text>(::std::move(anchor->get_subast())));
                 ++current_iter;
                 continue;
             }


### PR DESCRIPTION
### Motivation
- Reduce runtime work by turning the default link color into a compile-time literal and prebuilding the `<span style="color:...;">` prefix at compile time.
- Make the `pl_a` backend append a single pre-concatenated string instead of multiple `append` calls for the color span.

### Description
- Change `class A::color_` from `::fast_io::u8string_view` to the project `::pltxt2htm::details::LiteralString` and add `#include "../details/literal_string.hh"` in `include/pltxt2htm/astnode/physics_lab_node.hh`.
- Add a static accessor `static constexpr auto get_color_literal() noexcept -> ::pltxt2htm::details::LiteralString<7> const&` on `A` to expose the compile-time color literal.
- Update `include/pltxt2htm/details/backend/for_plweb_text.hh` `pl_a` branch to use `::pltxt2htm::details::concat(...)` with the literal pieces and `A::get_color_literal()` to create a `constexpr` `open_tag`, then append it once to `result`.
- Rename a local variable to `anchor` for clarity and use a single `append` with a `u8string_view` constructed from the compile-time `open_tag` data.

### Testing
- Ran `python3 tests/run_all_tests.py --help` which completed successfully.
- Ran `python3 tests/run_all_tests.py --compiler gcc` which failed to run full tests because the environment is missing `xmake` (error `xmake: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48a2b5fc8832ab4e4daf673d8bdc4)