### PR TITLE
refactor: migrate LiteralString usage to BasicLiteralString/U8LiteralString

### DIFF
--- a/cmd/pltxt2htm.cc
+++ b/cmd/pltxt2htm.cc
@@ -89,7 +89,7 @@ int main(int argc, char const* const* const argv) noexcept {
                 ::fast_io::perrln("You can only specify one host name");
                 return 1;
             }
-            host = reinterpret_cast<char8_t const*>(argv[++i]);
+            host = static_cast<char8_t const*>(static_cast<void const*>(argv[++i]));
             continue;
         }
         else if (::std::strcmp(argv[i], "--target") == 0) {
@@ -133,7 +133,7 @@ int main(int argc, char const* const* const argv) noexcept {
                 ::fast_io::perrln("You can only specify one project name");
                 return 1;
             }
-            project = reinterpret_cast<char8_t const*>(argv[++i]);
+            project = static_cast<char8_t const*>(static_cast<void const*>(argv[++i]));
             continue;
         }
         else if (::std::strcmp(argv[i], "--visitor") == 0) {
@@ -145,7 +145,7 @@ int main(int argc, char const* const* const argv) noexcept {
                 ::fast_io::perrln("You can only specify one visitor name");
                 return 1;
             }
-            visitor = reinterpret_cast<char8_t const*>(argv[++i]);
+            visitor = static_cast<char8_t const*>(static_cast<void const*>(argv[++i]));
             continue;
         }
         else if (::std::strcmp(argv[i], "--author") == 0) {
@@ -157,7 +157,7 @@ int main(int argc, char const* const* const argv) noexcept {
                 ::fast_io::perrln("You can only specify one author name");
                 return 1;
             }
-            author = reinterpret_cast<char8_t const*>(argv[++i]);
+            author = static_cast<char8_t const*>(static_cast<void const*>(argv[++i]));
             continue;
         }
         else if (::std::strcmp(argv[i], "--coauthors") == 0) {
@@ -169,7 +169,7 @@ int main(int argc, char const* const* const argv) noexcept {
                 ::fast_io::perrln("You can only specify one coauthors string");
                 return 1;
             }
-            coauthors = reinterpret_cast<char8_t const*>(argv[++i]);
+            coauthors = static_cast<char8_t const*>(static_cast<void const*>(argv[++i]));
             continue;
         }
         else if (::std::strcmp(argv[i], "-h") == 0 || ::std::strcmp(argv[i], "--help") == 0) {

--- a/cmd/pltxt2htm.cc
+++ b/cmd/pltxt2htm.cc
@@ -89,7 +89,7 @@ int main(int argc, char const* const* const argv) noexcept {
                 ::fast_io::perrln("You can only specify one host name");
                 return 1;
             }
-            host = static_cast<char8_t const*>(static_cast<void const*>(argv[++i]));
+            host = reinterpret_cast<char8_t const*>(argv[++i]);
             continue;
         }
         else if (::std::strcmp(argv[i], "--target") == 0) {
@@ -133,7 +133,7 @@ int main(int argc, char const* const* const argv) noexcept {
                 ::fast_io::perrln("You can only specify one project name");
                 return 1;
             }
-            project = static_cast<char8_t const*>(static_cast<void const*>(argv[++i]));
+            project = reinterpret_cast<char8_t const*>(argv[++i]);
             continue;
         }
         else if (::std::strcmp(argv[i], "--visitor") == 0) {
@@ -145,7 +145,7 @@ int main(int argc, char const* const* const argv) noexcept {
                 ::fast_io::perrln("You can only specify one visitor name");
                 return 1;
             }
-            visitor = static_cast<char8_t const*>(static_cast<void const*>(argv[++i]));
+            visitor = reinterpret_cast<char8_t const*>(argv[++i]);
             continue;
         }
         else if (::std::strcmp(argv[i], "--author") == 0) {
@@ -157,7 +157,7 @@ int main(int argc, char const* const* const argv) noexcept {
                 ::fast_io::perrln("You can only specify one author name");
                 return 1;
             }
-            author = static_cast<char8_t const*>(static_cast<void const*>(argv[++i]));
+            author = reinterpret_cast<char8_t const*>(argv[++i]);
             continue;
         }
         else if (::std::strcmp(argv[i], "--coauthors") == 0) {
@@ -169,7 +169,7 @@ int main(int argc, char const* const* const argv) noexcept {
                 ::fast_io::perrln("You can only specify one coauthors string");
                 return 1;
             }
-            coauthors = static_cast<char8_t const*>(static_cast<void const*>(argv[++i]));
+            coauthors = reinterpret_cast<char8_t const*>(argv[++i]);
             continue;
         }
         else if (::std::strcmp(argv[i], "-h") == 0 || ::std::strcmp(argv[i], "--help") == 0) {

--- a/include/pltxt2htm/astnode/physics_lab_node.hh
+++ b/include/pltxt2htm/astnode/physics_lab_node.hh
@@ -70,7 +70,7 @@ public:
  * @details Represents a hyperlink using <a> syntax with default blue color
  */
 class A : public ::pltxt2htm::details::PairedTagBase {
-    static constexpr ::pltxt2htm::U8LiteralString color_{u8"#0000AA"}; ///< The color of the link text
+    static constexpr pltxt2htm::details::U8LiteralString color_{u8"#0000AA"}; ///< The color of the link text
 
 public:
     constexpr A() noexcept = delete;

--- a/include/pltxt2htm/astnode/physics_lab_node.hh
+++ b/include/pltxt2htm/astnode/physics_lab_node.hh
@@ -70,7 +70,7 @@ public:
  * @details Represents a hyperlink using <a> syntax with default blue color
  */
 class A : public ::pltxt2htm::details::PairedTagBase {
-    static constexpr ::pltxt2htm::details::LiteralString color_{u8"#0000AA"}; ///< The color of the link text
+    static constexpr ::pltxt2htm::U8LiteralString color_{u8"#0000AA"}; ///< The color of the link text
 
 public:
     constexpr A() noexcept = delete;

--- a/include/pltxt2htm/astnode/physics_lab_node.hh
+++ b/include/pltxt2htm/astnode/physics_lab_node.hh
@@ -70,7 +70,7 @@ public:
  * @details Represents a hyperlink using <a> syntax with default blue color
  */
 class A : public ::pltxt2htm::details::PairedTagBase {
-    static constexpr pltxt2htm::details::U8LiteralString color_{u8"#0000AA"}; ///< The color of the link text
+    static constexpr ::pltxt2htm::details::U8LiteralString color_{u8"#0000AA"}; ///< The color of the link text
 
 public:
     constexpr A() noexcept = delete;

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -303,10 +303,10 @@ entry:
                 ::pltxt2htm::details::BackendBasicFrameContext(anchor->get_subast(), ::pltxt2htm::NodeType::pl_a, 0));
             ++current_index;
             constexpr auto open_tag =
-                ::pltxt2htm::details::concat(::pltxt2htm::details::LiteralString{u8"<color="},
+                ::pltxt2htm::details::concat(::pltxt2htm::U8LiteralString{u8"<color="},
                                              ::pltxt2htm::A::get_color_literal(),
-                                             ::pltxt2htm::details::LiteralString{u8">"});
-            result.append(::fast_io::u8string_view{reinterpret_cast<char8_t const*>(open_tag.data()), open_tag.size()});
+                                             ::pltxt2htm::U8LiteralString{u8">"});
+            result.append(::fast_io::u8string_view{open_tag.data(), open_tag.size()});
             goto entry;
         }
         case ::pltxt2htm::NodeType::pl_experiment: {

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -303,9 +303,9 @@ entry:
                 ::pltxt2htm::details::BackendBasicFrameContext(anchor->get_subast(), ::pltxt2htm::NodeType::pl_a, 0));
             ++current_index;
             constexpr auto open_tag =
-                ::pltxt2htm::details::concat(pltxt2htm::details::U8LiteralString{u8"<color="},
+                ::pltxt2htm::details::concat(::pltxt2htm::details::U8LiteralString{u8"<color="},
                                              ::pltxt2htm::A::get_color_literal(),
-                                             pltxt2htm::details::U8LiteralString{u8">"});
+                                             ::pltxt2htm::details::U8LiteralString{u8">"});
             result.append(::fast_io::u8string_view{open_tag.data(), open_tag.size()});
             goto entry;
         }

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -303,9 +303,9 @@ entry:
                 ::pltxt2htm::details::BackendBasicFrameContext(anchor->get_subast(), ::pltxt2htm::NodeType::pl_a, 0));
             ++current_index;
             constexpr auto open_tag =
-                ::pltxt2htm::details::concat(::pltxt2htm::U8LiteralString{u8"<color="},
+                ::pltxt2htm::details::concat(pltxt2htm::details::U8LiteralString{u8"<color="},
                                              ::pltxt2htm::A::get_color_literal(),
-                                             ::pltxt2htm::U8LiteralString{u8">"});
+                                             pltxt2htm::details::U8LiteralString{u8">"});
             result.append(::fast_io::u8string_view{open_tag.data(), open_tag.size()});
             goto entry;
         }

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -373,9 +373,9 @@ entry:
                 ::pltxt2htm::details::BackendBasicFrameContext(anchor->get_subast(), ::pltxt2htm::NodeType::pl_a, 0));
             ++current_index;
             constexpr auto open_tag =
-                ::pltxt2htm::details::concat(pltxt2htm::details::U8LiteralString{u8"<span style=\"color:"},
+                ::pltxt2htm::details::concat(::pltxt2htm::details::U8LiteralString{u8"<span style=\"color:"},
                                              ::pltxt2htm::A::get_color_literal(),
-                                             pltxt2htm::details::U8LiteralString{u8";\">"});
+                                             ::pltxt2htm::details::U8LiteralString{u8";\">"});
             result.append(::fast_io::u8string_view{open_tag.data(), open_tag.size()});
             goto entry;
         }

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -373,9 +373,9 @@ entry:
                 ::pltxt2htm::details::BackendBasicFrameContext(anchor->get_subast(), ::pltxt2htm::NodeType::pl_a, 0));
             ++current_index;
             constexpr auto open_tag =
-                ::pltxt2htm::details::concat(::pltxt2htm::U8LiteralString{u8"<span style=\"color:"},
+                ::pltxt2htm::details::concat(pltxt2htm::details::U8LiteralString{u8"<span style=\"color:"},
                                              ::pltxt2htm::A::get_color_literal(),
-                                             ::pltxt2htm::U8LiteralString{u8";\">"});
+                                             pltxt2htm::details::U8LiteralString{u8";\">"});
             result.append(::fast_io::u8string_view{open_tag.data(), open_tag.size()});
             goto entry;
         }

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -242,8 +242,8 @@ constexpr void append_url_attr_from_ast(::fast_io::u8string& result, ::pltxt2htm
         ::pltxt2htm::details::append_html_attr_escaped<ndebug>(
             purified_url, ::fast_io::u8string_view{url_str.data(), url_str.size()});
         pltxt2htm_assert(purified_url == url_str,
-                         "URL contains characters that cannot be directly used in HTML attributes. Please "
-                         "check the URL or use a different backend that supports escaping.");
+                         u8"URL contains characters that cannot be directly used in HTML attributes. Please "
+                         u8"check the URL or use a different backend that supports escaping.");
     }
     result.append(url_str);
 }
@@ -358,8 +358,8 @@ entry:
                 bool const is_valid_color_value{purified_color_value == color_value};
                 pltxt2htm_assert(
                     is_valid_color_value,
-                    "Color value contains characters that cannot be directly used in HTML attributes. Please "
-                    "check the color value or use a different backend that supports escaping.");
+                    u8"Color value contains characters that cannot be directly used in HTML attributes. Please "
+                    u8"check the color value or use a different backend that supports escaping.");
             }
             result.append(color_value);
             constexpr ::fast_io::u8string_view close_tag2 = u8";\">";
@@ -399,8 +399,8 @@ entry:
                 bool const is_valid_experiment_id{purified_experiment_id == experiment_id};
                 pltxt2htm_assert(
                     is_valid_experiment_id,
-                    "Experiment ID contains characters that cannot be directly used in HTML attributes. Please check "
-                    "the experiment ID or use a different backend that supports escaping.");
+                    u8"Experiment ID contains characters that cannot be directly used in HTML attributes. Please check "
+                    u8"the experiment ID or use a different backend that supports escaping.");
             }
             result.append(experiment_id);
             result.append(u8"\" internal>");
@@ -426,8 +426,8 @@ entry:
                 bool const is_valid_discussion_id{purified_discussion_id == discussion_id};
                 pltxt2htm_assert(
                     is_valid_discussion_id,
-                    "Discussion ID contains characters that cannot be directly used in HTML attributes. Please check "
-                    "the discussion ID or use a different backend that supports escaping.");
+                    u8"Discussion ID contains characters that cannot be directly used in HTML attributes. Please check "
+                    u8"the discussion ID or use a different backend that supports escaping.");
             }
             result.append(discussion_id);
             result.append(u8"\" internal>");
@@ -453,8 +453,8 @@ entry:
                 bool const is_valid_user_id{purified_user_id == user_id};
                 pltxt2htm_assert(
                     is_valid_user_id,
-                    "User ID contains characters that cannot be directly used in HTML attributes. Please check the "
-                    "user ID or use a different backend that supports escaping.");
+                    u8"User ID contains characters that cannot be directly used in HTML attributes. Please check the "
+                    u8"user ID or use a different backend that supports escaping.");
             }
             result.append(user_id);
             constexpr ::fast_io::u8string_view open_tag2 = u8"'>";

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -373,10 +373,10 @@ entry:
                 ::pltxt2htm::details::BackendBasicFrameContext(anchor->get_subast(), ::pltxt2htm::NodeType::pl_a, 0));
             ++current_index;
             constexpr auto open_tag =
-                ::pltxt2htm::details::concat(::pltxt2htm::details::LiteralString{u8"<span style=\"color:"},
+                ::pltxt2htm::details::concat(::pltxt2htm::U8LiteralString{u8"<span style=\"color:"},
                                              ::pltxt2htm::A::get_color_literal(),
-                                             ::pltxt2htm::details::LiteralString{u8";\">"});
-            result.append(::fast_io::u8string_view{reinterpret_cast<char8_t const*>(open_tag.data()), open_tag.size()});
+                                             ::pltxt2htm::U8LiteralString{u8";\">"});
+            result.append(::fast_io::u8string_view{open_tag.data(), open_tag.size()});
             goto entry;
         }
         case ::pltxt2htm::NodeType::pl_experiment: {

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -110,9 +110,9 @@ entry:
                 ::pltxt2htm::details::BackendBasicFrameContext(anchor->get_subast(), ::pltxt2htm::NodeType::pl_a, 0));
             ++current_index;
             constexpr auto open_tag =
-                ::pltxt2htm::details::concat(::pltxt2htm::U8LiteralString{u8"<span style=\"color:"},
+                ::pltxt2htm::details::concat(pltxt2htm::details::U8LiteralString{u8"<span style=\"color:"},
                                              ::pltxt2htm::A::get_color_literal(),
-                                             ::pltxt2htm::U8LiteralString{u8";\">"});
+                                             pltxt2htm::details::U8LiteralString{u8";\">"});
             result.append(::fast_io::u8string_view{open_tag.data(), open_tag.size()});
             goto entry;
         }

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -110,9 +110,9 @@ entry:
                 ::pltxt2htm::details::BackendBasicFrameContext(anchor->get_subast(), ::pltxt2htm::NodeType::pl_a, 0));
             ++current_index;
             constexpr auto open_tag =
-                ::pltxt2htm::details::concat(pltxt2htm::details::U8LiteralString{u8"<span style=\"color:"},
+                ::pltxt2htm::details::concat(::pltxt2htm::details::U8LiteralString{u8"<span style=\"color:"},
                                              ::pltxt2htm::A::get_color_literal(),
-                                             pltxt2htm::details::U8LiteralString{u8";\">"});
+                                             ::pltxt2htm::details::U8LiteralString{u8";\">"});
             result.append(::fast_io::u8string_view{open_tag.data(), open_tag.size()});
             goto entry;
         }

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -110,10 +110,10 @@ entry:
                 ::pltxt2htm::details::BackendBasicFrameContext(anchor->get_subast(), ::pltxt2htm::NodeType::pl_a, 0));
             ++current_index;
             constexpr auto open_tag =
-                ::pltxt2htm::details::concat(::pltxt2htm::details::LiteralString{u8"<span style=\"color:"},
+                ::pltxt2htm::details::concat(::pltxt2htm::U8LiteralString{u8"<span style=\"color:"},
                                              ::pltxt2htm::A::get_color_literal(),
-                                             ::pltxt2htm::details::LiteralString{u8";\">"});
-            result.append(::fast_io::u8string_view{reinterpret_cast<char8_t const*>(open_tag.data()), open_tag.size()});
+                                             ::pltxt2htm::U8LiteralString{u8";\">"});
+            result.append(::fast_io::u8string_view{open_tag.data(), open_tag.size()});
             goto entry;
         }
         case ::pltxt2htm::NodeType::md_double_emphasis_underscore:

--- a/include/pltxt2htm/details/literal_string.hh
+++ b/include/pltxt2htm/details/literal_string.hh
@@ -19,7 +19,7 @@
 
 namespace pltxt2htm::details {
 
-template<typename ch_type, ::std::size_t>
+template<typename, ::std::size_t>
 class BasicLiteralString;
 
 template<::std::size_t N>
@@ -28,22 +28,26 @@ using LiteralString = ::pltxt2htm::details::BasicLiteralString<char, N>;
 template<::std::size_t N>
 using U8LiteralString = ::pltxt2htm::details::BasicLiteralString<char8_t, N>;
 
-template<typename ch_type, ::std::size_t N>
-BasicLiteralString(ch_type const (&str)[N]) -> BasicLiteralString<ch_type, N - 1>;
+template<typename CharType, ::std::size_t N>
+BasicLiteralString(CharType const (&str)[N]) -> BasicLiteralString<CharType, N - 1>;
+
+namespace details {
 
 template<typename T>
 constexpr bool is_literal_string_ = false;
 
-template<typename ch_type, ::std::size_t N>
-constexpr bool is_literal_string_<::pltxt2htm::details::BasicLiteralString<ch_type, N>> = true;
+template<typename CharType, ::std::size_t N>
+constexpr bool is_literal_string_<::pltxt2htm::details::BasicLiteralString<CharType, N>> = true;
+
+}
 
 template<typename T>
-concept is_leteral_string = ::pltxt2htm::details::is_literal_string_<::std::remove_cvref_t<T>>;
+concept is_leteral_string = ::pltxt2htm::details::details::is_literal_string_<::std::remove_cvref_t<T>>;
 
-template<typename ch_type, ::std::size_t N>
+template<typename CharType, ::std::size_t N>
 class BasicLiteralString {
 public:
-    using value_type = ch_type;
+    using value_type = CharType;
     using size_type = ::std::size_t;
     using diffrence_type = ::std::ptrdiff_t;
     using iterator = value_type*;
@@ -53,18 +57,18 @@ public:
 
     constexpr BasicLiteralString() noexcept = default;
 
-    template<typename source_char_type, ::std::size_t M>
-    constexpr BasicLiteralString(source_char_type const (&str)[M]) noexcept {
+    template<::std::size_t M>
+    constexpr BasicLiteralString(CharType const (&str)[M]) noexcept {
         static_assert(N > 0 && N + 1 == M);
         for (::std::size_t i{}; i < N; ++i) {
             this->data_[i] = static_cast<value_type>(str[i]);
         }
     }
 
-    template<::pltxt2htm::details::is_leteral_string Self, ::std::size_t M>
+    template<::std::size_t M>
     [[nodiscard]]
-    constexpr auto operator==(this Self const& self,
-                              ::pltxt2htm::details::BasicLiteralString<typename Self::value_type, M> const& other) noexcept {
+    constexpr auto operator==(this ::pltxt2htm::details::is_leteral_string auto const& self,
+                              ::pltxt2htm::details::BasicLiteralString<value_type, M> const& other) noexcept {
         if constexpr (N != M) {
             return false;
         }

--- a/include/pltxt2htm/details/literal_string.hh
+++ b/include/pltxt2htm/details/literal_string.hh
@@ -1,134 +1,75 @@
 /**
  * @file literal_string.hh
  * @brief Compile-time string utilities for pltxt2htm
- * @details Provides a compile-time string class that stores string data
- *          as part of the type, enabling efficient compile-time string operations
- * @note This is used for compile-time error messages and static string processing
  */
 
 #pragma once
 
-#include <limits>
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
+#include <limits>
 #include <type_traits>
+#include <utility>
+#include <tuple>
+
 #include <exception/exception.hh>
 
-namespace pltxt2htm::details {
+namespace pltxt2htm {
 
-/**
- * @brief A compile-time string class that stores string data as part of the type
- * @tparam N The length of the string
- */
-template<::std::size_t>
-class LiteralString;
+template<typename ch_type, ::std::size_t>
+class BasicLiteralString;
 
-/**
- * @brief Deduction guide for char array literals
- * @tparam N The length of the string including null terminator
- * @param[in] str The input string literal
- */
+template<typename ch_type, ::std::size_t N>
+using LiteralString = ::pltxt2htm::BasicLiteralString<ch_type, N>;
+
 template<::std::size_t N>
-LiteralString(char const (&str)[N]) -> LiteralString<N - 1>;
+using U8LiteralString = ::pltxt2htm::LiteralString<char8_t, N>;
 
-/**
- * @brief Deduction guide for char8_t array literals
- * @tparam N The length of the string including null terminator
- * @param str The input string literal
- */
 template<::std::size_t N>
-LiteralString(char8_t const (&str)[N]) -> LiteralString<N - 1>;
+using AsciiLiteralString = ::pltxt2htm::LiteralString<char, N>;
 
-/**
- * @brief Type trait to check if a type is a LiteralString
- * @tparam T The type to check
- */
+template<typename ch_type, ::std::size_t N>
+BasicLiteralString(ch_type const (&str)[N]) -> BasicLiteralString<ch_type, N - 1>;
+
+namespace details {
+
 template<typename T>
 constexpr bool is_literal_string_ = false;
 
-/**
- * @brief Specialization for LiteralString types
- * @tparam N The length of the string
- */
-template<::std::size_t N>
-constexpr bool is_literal_string_<::pltxt2htm::details::LiteralString<N>> = true;
+template<typename ch_type, ::std::size_t N>
+constexpr bool is_literal_string_<::pltxt2htm::BasicLiteralString<ch_type, N>> = true;
 
-/**
- * @brief Concept to identify LiteralString types
- * @tparam T The type to check
- */
 template<typename T>
 concept is_leteral_string = ::pltxt2htm::details::is_literal_string_<::std::remove_cvref_t<T>>;
 
-/**
- * @brief A compile-time string class that stores string data as part of the type
- * @tparam N The length of the string
- */
-template<::std::size_t N>
-class LiteralString {
+} // namespace details
+
+template<typename ch_type, ::std::size_t N>
+class BasicLiteralString {
 public:
-    /** @brief Storage for the string characters */
-    char data_[N]{};
-
-    /** @brief Type used for size values */
+    using value_type = ch_type;
     using size_type = ::std::size_t;
-
-    /** @brief Type used for difference values */
     using diffrence_type = ::std::ptrdiff_t;
+    using iterator = value_type*;
+    using const_iterator = value_type const*;
 
-    /** @brief Iterator type for non-const access */
-    using iterator = char*;
+    value_type data_[N]{};
 
-    /** @brief Iterator type for const access */
-    using const_iterator = char const*;
+    constexpr BasicLiteralString() noexcept = default;
 
-    /** @brief Default constructor */
-    constexpr LiteralString() noexcept = default;
-
-    /**
-     * @brief Constructor from char array literal
-     * @tparam M The size of the input array (including null terminator)
-     * @param[in] str The input string literal
-     */
-    template<::std::size_t M>
-    constexpr LiteralString(char const (&str)[M]) noexcept {
+    template<typename source_char_type, ::std::size_t M>
+    constexpr BasicLiteralString(source_char_type const (&str)[M]) noexcept {
         static_assert(N > 0 && N + 1 == M);
-        // Assume the end of the string is '\0'
         for (::std::size_t i{}; i < N; ++i) {
-            this->data_[i] = str[i];
+            this->data_[i] = static_cast<value_type>(str[i]);
         }
     }
 
-    /**
-     * @brief Constructor from char8_t array literal
-     * @tparam M The size of the input array (including null terminator)
-     * @param str The input string literal
-     */
-    template<::std::size_t M>
-    constexpr LiteralString(char8_t const (&str)[M]) noexcept {
-        static_assert(N > 0 && N + 1 == M);
-        // Assume the end of the string is '\0'
-        for (::std::size_t i{}; i < N; ++i) {
-            this->data_[i] = str[i];
-        }
-    }
-
-    /**
-     * @brief Equality comparison with another LiteralString
-     * @tparam Self The type of this object (deduced)
-     * @tparam M The length of the other string
-     * @param[in] self This object
-     * @param[in] other The other LiteralString to compare with
-     * @return true if strings are equal, false otherwise
-     */
     template<::pltxt2htm::details::is_leteral_string Self, ::std::size_t M>
     [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-    [[__gnu__::__pure__]]
-#endif
-    constexpr auto operator==(this Self const& self, ::pltxt2htm::details::LiteralString<M> const& other) noexcept {
+    constexpr auto operator==(this Self const& self,
+                              ::pltxt2htm::BasicLiteralString<typename Self::value_type, M> const& other) noexcept {
         if constexpr (N != M) {
             return false;
         }
@@ -137,219 +78,121 @@ public:
         }
     }
 
-    /**
-     * @brief Access character at specific index (non-const version)
-     * @tparam Self The type of this object (deduced)
-     * @param[in] self This object
-     * @param[in] index The index of the character to access
-     * @return Reference to the character at the specified index
-     */
     template<::pltxt2htm::details::is_leteral_string Self>
-    constexpr auto operator[](this Self&& self, ::std::size_t index) noexcept -> char& {
+    constexpr auto operator[](this Self&& self, ::std::size_t index) noexcept -> value_type& {
         if (index >= N) [[unlikely]] {
             ::exception::terminate();
         }
         return self.data_[index];
     }
 
-    /**
-     * @brief Access character at specific index (const version)
-     * @tparam Self The type of this object (deduced)
-     * @param self This object
-     * @param index The index of the character to access
-     * @return Const reference to the character at the specified index
-     */
     template<::pltxt2htm::details::is_leteral_string Self>
     [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-    [[__gnu__::__pure__]]
-#endif
-    constexpr auto operator[](this Self const& self, ::std::size_t index) noexcept -> char const& {
+    constexpr auto operator[](this Self const& self, ::std::size_t index) noexcept -> value_type const& {
         if (index >= N) [[unlikely]] {
             ::exception::terminate();
         }
         return self.data_[index];
     }
 
-    /** @brief Get the size of the string */
     [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-    [[__gnu__::__pure__]]
-#endif
     static constexpr ::std::size_t size() noexcept {
         return N;
     }
 
     template<::pltxt2htm::details::is_leteral_string Self>
     [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-    [[__gnu__::__pure__]]
-#endif
     constexpr auto begin(this Self&& self) noexcept -> iterator {
         return self.data_;
     }
 
     [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-    [[__gnu__::__pure__]]
-#endif
-    constexpr auto begin(this ::pltxt2htm::details::LiteralString<N> const& self) noexcept {
+    constexpr auto begin(this ::pltxt2htm::BasicLiteralString<value_type, N> const& self) noexcept {
         return const_iterator(self.data_);
     }
 
-    /**
-     * @brief Get iterator to the beginning of the string
-     * @tparam Self The type of this object (deduced)
-     * @param self This object
-     * @return Iterator pointing to the first character
-     */
     [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-    [[__gnu__::__pure__]]
-#endif
-    constexpr auto cbegin(this ::pltxt2htm::details::LiteralString<N> const& self) noexcept {
+    constexpr auto cbegin(this ::pltxt2htm::BasicLiteralString<value_type, N> const& self) noexcept {
         return const_iterator(self.data_);
     }
 
     template<::pltxt2htm::details::is_leteral_string Self>
     [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-    [[__gnu__::__pure__]]
-#endif
     constexpr auto end(this Self&& self) noexcept -> iterator {
         return self.data_ + N;
     }
 
     [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-    [[__gnu__::__pure__]]
-#endif
-    constexpr auto end(this ::pltxt2htm::details::LiteralString<N> const& self) noexcept {
-        return const_iterator(self.data_ + N);
-    }
-
-    /**
-     * @brief Get iterator to the end of the string
-     * @tparam Self The type of this object (deduced)
-     * @param self This object
-     * @return Iterator pointing past the last character
-     */
-    [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-    [[__gnu__::__pure__]]
-#endif
-    constexpr auto cend(this ::pltxt2htm::details::LiteralString<N> const& self) noexcept {
+    constexpr auto end(this ::pltxt2htm::BasicLiteralString<value_type, N> const& self) noexcept {
         return const_iterator(self.data_ + N);
     }
 
     [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-    [[__gnu__::__pure__]]
-#endif
-    constexpr auto data(this ::pltxt2htm::details::LiteralString<N>& self) noexcept {
+    constexpr auto cend(this ::pltxt2htm::BasicLiteralString<value_type, N> const& self) noexcept {
+        return const_iterator(self.data_ + N);
+    }
+
+    [[nodiscard]]
+    constexpr auto data(this ::pltxt2htm::BasicLiteralString<value_type, N>& self) noexcept {
         return self.data_;
     }
 
-    /**
-     * @brief Get pointer to the underlying data (const version)
-     * @tparam Self The type of this object (deduced)
-     * @param self This object
-     * @return Const pointer to the string data
-     */
     [[nodiscard]]
-    constexpr auto data(this ::pltxt2htm::details::LiteralString<N> const& self) noexcept {
+    constexpr auto data(this ::pltxt2htm::BasicLiteralString<value_type, N> const& self) noexcept {
         return ::std::as_const(self.data_);
     }
 
-    /**
-     * @brief Get pointer to the underlying data (non-const version)
-     * @tparam Self The type of this object (deduced)
-     * @param self This object
-     * @return Pointer to the string data
-     */
     [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-    [[__gnu__::__pure__]]
-#endif
-    constexpr auto data(this ::pltxt2htm::details::LiteralString<N>&& self) noexcept {
+    constexpr auto data(this ::pltxt2htm::BasicLiteralString<value_type, N>&& self) noexcept {
         return ::std::move(self.data_);
     }
 
-    /**
-     * @brief Get const pointer to the underlying data
-     * @tparam Self The type of this object (deduced)
-     * @param self This object
-     * @return Const pointer to the string data
-     */
     template<::pltxt2htm::details::is_leteral_string Self>
     [[nodiscard]]
-#if __has_cpp_attribute(__gnu__::__pure__)
-    [[__gnu__::__pure__]]
-#endif
     constexpr auto cdata(this Self&& self) noexcept {
-        return static_cast<char const*>(self.data_);
+        return static_cast<value_type const*>(self.data_);
     }
 };
 
-/**
- * @brief Remove trailing null characters from a string literal
- * @tparam str The input string literal
- * @tparam M Current position in the string being processed
- * @return A new LiteralString with trailing nulls removed
- */
-template<::pltxt2htm::details::LiteralString str, ::std::size_t M = 0>
+namespace details {
+
+template<::pltxt2htm::U8LiteralString str, ::std::size_t M = 0>
 consteval auto shrink_string_literal_() noexcept {
     if constexpr (M >= str.size()) {
         return str;
     }
     else if constexpr (str[M] == 0) {
-        char result[M + 1]{};
+        char8_t result[M + 1]{};
         ::std::reverse_copy(str.cbegin(), str.cbegin() + M, result);
-        return ::pltxt2htm::details::LiteralString{result};
+        return ::pltxt2htm::U8LiteralString{result};
     }
     else {
         return ::pltxt2htm::details::shrink_string_literal_<str, M + 1>();
     }
 }
 
-/**
- * @brief Convert an unsigned integer to a LiteralString
- * @param[in] number The number to convert
- * @return A LiteralString representing the number
- */
 consteval auto uint_to_literal_string_(::std::uint_least32_t number) noexcept {
-    using result_type = ::pltxt2htm::details::LiteralString<::std::numeric_limits<decltype(number)>::digits10 + 2>;
+    using result_type = ::pltxt2htm::U8LiteralString<::std::numeric_limits<decltype(number)>::digits10 + 2>;
     auto result = result_type{};
     ::std::size_t index{};
     while (number) {
-        result[index++] = static_cast<char>(number % 10 + '0');
+        result[index++] = static_cast<char8_t>(number % 10 + '0');
         number /= 10;
     }
     return result;
 }
 
-/**
- * @brief Convert an unsigned integer to a LiteralString at compile time
- * @tparam number The number to convert
- * @return A LiteralString representing the number
- */
 template<::std::uint_least32_t number>
 consteval auto uint_to_literal_string() noexcept {
     constexpr auto result = ::pltxt2htm::details::uint_to_literal_string_(number);
     return ::pltxt2htm::details::shrink_string_literal_<result>();
 }
 
-/**
- * @brief Concatenate multiple LiteralStrings into one
- * @tparam Args Types of the input strings
- * @param[in] args The strings to concatenate
- * @return A new LiteralString containing all input strings concatenated
- */
 template<::pltxt2htm::details::is_leteral_string... Args>
 consteval auto concat(Args const&... args) noexcept {
-    ::pltxt2htm::details::LiteralString<(args.size() + ...)> result{};
+    using ch_type = typename ::std::tuple_element_t<0, ::std::tuple<Args...>>::value_type;
+    ::pltxt2htm::LiteralString<ch_type, (args.size() + ...)> result{};
     ::std::size_t index{};
-    // TODO impl template-for version
     (((
          [args, index, &result]() constexpr noexcept {
              for (::std::size_t i{}; i < args.size(); ++i) {
@@ -362,4 +205,6 @@ consteval auto concat(Args const&... args) noexcept {
     return result;
 }
 
-} // namespace pltxt2htm::details
+} // namespace details
+
+} // namespace pltxt2htm

--- a/include/pltxt2htm/details/literal_string.hh
+++ b/include/pltxt2htm/details/literal_string.hh
@@ -15,32 +15,28 @@
 
 #include <exception/exception.hh>
 
-namespace pltxt2htm {
+namespace pltxt2htm::details {
 
 template<typename ch_type, ::std::size_t>
 class BasicLiteralString;
 
 template<::std::size_t N>
-using LiteralString = ::pltxt2htm::BasicLiteralString<char, N>;
+using LiteralString = ::pltxt2htm::details::BasicLiteralString<char, N>;
 
 template<::std::size_t N>
-using U8LiteralString = ::pltxt2htm::BasicLiteralString<char8_t, N>;
+using U8LiteralString = ::pltxt2htm::details::BasicLiteralString<char8_t, N>;
 
 template<typename ch_type, ::std::size_t N>
 BasicLiteralString(ch_type const (&str)[N]) -> BasicLiteralString<ch_type, N - 1>;
-
-namespace details {
 
 template<typename T>
 constexpr bool is_literal_string_ = false;
 
 template<typename ch_type, ::std::size_t N>
-constexpr bool is_literal_string_<::pltxt2htm::BasicLiteralString<ch_type, N>> = true;
+constexpr bool is_literal_string_<::pltxt2htm::details::BasicLiteralString<ch_type, N>> = true;
 
 template<typename T>
 concept is_leteral_string = ::pltxt2htm::details::is_literal_string_<::std::remove_cvref_t<T>>;
-
-} // namespace details
 
 template<typename ch_type, ::std::size_t N>
 class BasicLiteralString {
@@ -66,7 +62,7 @@ public:
     template<::pltxt2htm::details::is_leteral_string Self, ::std::size_t M>
     [[nodiscard]]
     constexpr auto operator==(this Self const& self,
-                              ::pltxt2htm::BasicLiteralString<typename Self::value_type, M> const& other) noexcept {
+                              ::pltxt2htm::details::BasicLiteralString<typename Self::value_type, M> const& other) noexcept {
         if constexpr (N != M) {
             return false;
         }
@@ -104,12 +100,12 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto begin(this ::pltxt2htm::BasicLiteralString<value_type, N> const& self) noexcept {
+    constexpr auto begin(this ::pltxt2htm::details::BasicLiteralString<value_type, N> const& self) noexcept {
         return const_iterator(self.data_);
     }
 
     [[nodiscard]]
-    constexpr auto cbegin(this ::pltxt2htm::BasicLiteralString<value_type, N> const& self) noexcept {
+    constexpr auto cbegin(this ::pltxt2htm::details::BasicLiteralString<value_type, N> const& self) noexcept {
         return const_iterator(self.data_);
     }
 
@@ -120,27 +116,27 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto end(this ::pltxt2htm::BasicLiteralString<value_type, N> const& self) noexcept {
+    constexpr auto end(this ::pltxt2htm::details::BasicLiteralString<value_type, N> const& self) noexcept {
         return const_iterator(self.data_ + N);
     }
 
     [[nodiscard]]
-    constexpr auto cend(this ::pltxt2htm::BasicLiteralString<value_type, N> const& self) noexcept {
+    constexpr auto cend(this ::pltxt2htm::details::BasicLiteralString<value_type, N> const& self) noexcept {
         return const_iterator(self.data_ + N);
     }
 
     [[nodiscard]]
-    constexpr auto data(this ::pltxt2htm::BasicLiteralString<value_type, N>& self) noexcept {
+    constexpr auto data(this ::pltxt2htm::details::BasicLiteralString<value_type, N>& self) noexcept {
         return self.data_;
     }
 
     [[nodiscard]]
-    constexpr auto data(this ::pltxt2htm::BasicLiteralString<value_type, N> const& self) noexcept {
+    constexpr auto data(this ::pltxt2htm::details::BasicLiteralString<value_type, N> const& self) noexcept {
         return ::std::as_const(self.data_);
     }
 
     [[nodiscard]]
-    constexpr auto data(this ::pltxt2htm::BasicLiteralString<value_type, N>&& self) noexcept {
+    constexpr auto data(this ::pltxt2htm::details::BasicLiteralString<value_type, N>&& self) noexcept {
         return ::std::move(self.data_);
     }
 
@@ -151,9 +147,7 @@ public:
     }
 };
 
-namespace details {
-
-template<::pltxt2htm::U8LiteralString str, ::std::size_t M = 0>
+template<::pltxt2htm::details::U8LiteralString str, ::std::size_t M = 0>
 consteval auto shrink_string_literal_() noexcept {
     if constexpr (M >= str.size()) {
         return str;
@@ -161,7 +155,7 @@ consteval auto shrink_string_literal_() noexcept {
     else if constexpr (str[M] == 0) {
         char8_t result[M + 1]{};
         ::std::reverse_copy(str.cbegin(), str.cbegin() + M, result);
-        return ::pltxt2htm::U8LiteralString{result};
+        return ::pltxt2htm::details::U8LiteralString{result};
     }
     else {
         return ::pltxt2htm::details::shrink_string_literal_<str, M + 1>();
@@ -169,7 +163,7 @@ consteval auto shrink_string_literal_() noexcept {
 }
 
 consteval auto uint_to_literal_string_(::std::uint_least32_t number) noexcept {
-    using result_type = ::pltxt2htm::U8LiteralString<::std::numeric_limits<decltype(number)>::digits10 + 2>;
+    using result_type = ::pltxt2htm::details::U8LiteralString<::std::numeric_limits<decltype(number)>::digits10 + 2>;
     auto result = result_type{};
     ::std::size_t index{};
     while (number) {
@@ -188,7 +182,7 @@ consteval auto uint_to_literal_string() noexcept {
 template<::pltxt2htm::details::is_leteral_string... Args>
 consteval auto concat(Args const&... args) noexcept {
     using ch_type = typename ::std::tuple_element_t<0, ::std::tuple<Args...>>::value_type;
-    ::pltxt2htm::BasicLiteralString<ch_type, (args.size() + ...)> result{};
+    ::pltxt2htm::details::BasicLiteralString<ch_type, (args.size() + ...)> result{};
     ::std::size_t index{};
     (((
          [args, index, &result]() constexpr noexcept {
@@ -201,7 +195,5 @@ consteval auto concat(Args const&... args) noexcept {
 
     return result;
 }
-
-} // namespace details
 
 } // namespace pltxt2htm

--- a/include/pltxt2htm/details/literal_string.hh
+++ b/include/pltxt2htm/details/literal_string.hh
@@ -1,6 +1,9 @@
 /**
  * @file literal_string.hh
  * @brief Compile-time string utilities for pltxt2htm
+ * @details Provides a compile-time string class that stores string data
+ *          as part of the type, enabling efficient compile-time string operations
+ * @note This is used for compile-time error messages and static string processing
  */
 
 #pragma once

--- a/include/pltxt2htm/details/literal_string.hh
+++ b/include/pltxt2htm/details/literal_string.hh
@@ -39,7 +39,7 @@ constexpr bool is_literal_string_ = false;
 template<typename CharType, ::std::size_t N>
 constexpr bool is_literal_string_<::pltxt2htm::details::BasicLiteralString<CharType, N>> = true;
 
-}
+} // namespace details
 
 template<typename T>
 concept is_leteral_string = ::pltxt2htm::details::details::is_literal_string_<::std::remove_cvref_t<T>>;
@@ -52,6 +52,10 @@ public:
     using diffrence_type = ::std::ptrdiff_t;
     using iterator = value_type*;
     using const_iterator = value_type const*;
+    using reference = value_type&;
+    using const_reference = value_type const&;
+    using pointer = value_type*;
+    using const_pointer = value_type const*;
 
     value_type data_[N]{};
 
@@ -61,13 +65,13 @@ public:
     constexpr BasicLiteralString(CharType const (&str)[M]) noexcept {
         static_assert(N > 0 && N + 1 == M);
         for (::std::size_t i{}; i < N; ++i) {
-            this->data_[i] = static_cast<value_type>(str[i]);
+            this->data_[i] = str[i];
         }
     }
 
     template<::std::size_t M>
     [[nodiscard]]
-    constexpr auto operator==(this ::pltxt2htm::details::is_leteral_string auto const& self,
+    constexpr auto operator==(this ::pltxt2htm::details::BasicLiteralString<value_type, N> const& self,
                               ::pltxt2htm::details::BasicLiteralString<value_type, M> const& other) noexcept {
         if constexpr (N != M) {
             return false;
@@ -77,17 +81,8 @@ public:
         }
     }
 
-    template<::pltxt2htm::details::is_leteral_string Self>
-    constexpr auto operator[](this Self&& self, ::std::size_t index) noexcept -> value_type& {
-        if (index >= N) [[unlikely]] {
-            ::exception::terminate();
-        }
-        return self.data_[index];
-    }
-
-    template<::pltxt2htm::details::is_leteral_string Self>
-    [[nodiscard]]
-    constexpr auto operator[](this Self const& self, ::std::size_t index) noexcept -> value_type const& {
+    constexpr auto&& operator[](this ::pltxt2htm::details::is_leteral_string auto&& self,
+                                ::std::size_t index) noexcept {
         if (index >= N) [[unlikely]] {
             ::exception::terminate();
         }
@@ -99,9 +94,8 @@ public:
         return N;
     }
 
-    template<::pltxt2htm::details::is_leteral_string Self>
     [[nodiscard]]
-    constexpr auto begin(this Self&& self) noexcept -> iterator {
+    constexpr auto begin(this ::pltxt2htm::details::is_leteral_string auto&& self) noexcept -> iterator {
         return self.data_;
     }
 
@@ -115,9 +109,8 @@ public:
         return const_iterator(self.data_);
     }
 
-    template<::pltxt2htm::details::is_leteral_string Self>
     [[nodiscard]]
-    constexpr auto end(this Self&& self) noexcept -> iterator {
+    constexpr auto end(this ::pltxt2htm::details::is_leteral_string auto&& self) noexcept -> iterator {
         return self.data_ + N;
     }
 
@@ -132,24 +125,18 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto data(this ::pltxt2htm::details::BasicLiteralString<value_type, N>& self) noexcept {
+    constexpr auto data(this ::pltxt2htm::details::is_leteral_string auto&& self) noexcept -> pointer {
         return self.data_;
     }
 
     [[nodiscard]]
     constexpr auto data(this ::pltxt2htm::details::BasicLiteralString<value_type, N> const& self) noexcept {
-        return ::std::as_const(self.data_);
+        return const_pointer(self.data_);
     }
 
     [[nodiscard]]
-    constexpr auto data(this ::pltxt2htm::details::BasicLiteralString<value_type, N>&& self) noexcept {
-        return ::std::move(self.data_);
-    }
-
-    template<::pltxt2htm::details::is_leteral_string Self>
-    [[nodiscard]]
-    constexpr auto cdata(this Self&& self) noexcept {
-        return static_cast<value_type const*>(self.data_);
+    constexpr auto cdata(this ::pltxt2htm::details::BasicLiteralString<value_type, N> const& self) noexcept {
+        return const_pointer(self.data_);
     }
 };
 
@@ -185,6 +172,14 @@ consteval auto uint_to_literal_string() noexcept {
     return ::pltxt2htm::details::shrink_string_literal_<result>();
 }
 
+template<typename result_type>
+constexpr void concat_memcpy(::pltxt2htm::details::is_leteral_string auto const& args, ::std::size_t& index,
+                             result_type& result) noexcept {
+    for (::std::size_t i{}; i < args.size(); ++i) {
+        result[i + index] = args[i];
+    }
+}
+
 /**
  * @brief Concatenate multiple LiteralStrings into one
  * @tparam Args Types of the input strings
@@ -194,22 +189,14 @@ consteval auto uint_to_literal_string() noexcept {
 template<::pltxt2htm::details::is_leteral_string Arg, ::pltxt2htm::details::is_leteral_string... Args>
     requires (::std::is_same_v<typename Arg::value_type, typename Args::value_type> && ...)
 consteval auto concat(Arg const& arg, Args const&... args) noexcept {
-    // TODO impl template-for version
     ::pltxt2htm::details::BasicLiteralString<typename Arg::value_type, arg.size() + (args.size() + ...)> result{};
     ::std::size_t index{};
     for (; index < arg.size(); ++index) {
         result[index] = arg[index];
     }
-    (((
-         [args, index, &result]() constexpr noexcept {
-             for (::std::size_t i{}; i < args.size(); ++i) {
-                 result[i + index] = args[i];
-             }
-         }(),
-         index += args.size())),
-     ...);
+    ((::pltxt2htm::details::concat_memcpy(args, index, result), index += args.size()), ...);
 
     return result;
 }
 
-} // namespace pltxt2htm
+} // namespace pltxt2htm::details

--- a/include/pltxt2htm/details/literal_string.hh
+++ b/include/pltxt2htm/details/literal_string.hh
@@ -11,7 +11,6 @@
 #include <limits>
 #include <type_traits>
 #include <utility>
-#include <tuple>
 
 #include <exception/exception.hh>
 
@@ -179,11 +178,21 @@ consteval auto uint_to_literal_string() noexcept {
     return ::pltxt2htm::details::shrink_string_literal_<result>();
 }
 
-template<::pltxt2htm::details::is_leteral_string... Args>
-consteval auto concat(Args const&... args) noexcept {
-    using ch_type = typename ::std::tuple_element_t<0, ::std::tuple<Args...>>::value_type;
-    ::pltxt2htm::details::BasicLiteralString<ch_type, (args.size() + ...)> result{};
+/**
+ * @brief Concatenate multiple LiteralStrings into one
+ * @tparam Args Types of the input strings
+ * @param[in] args The strings to concatenate
+ * @return A new LiteralString containing all input strings concatenated
+ */
+template<::pltxt2htm::details::is_leteral_string Arg, ::pltxt2htm::details::is_leteral_string... Args>
+    requires (::std::is_same_v<typename Arg::value_type, typename Args::value_type> && ...)
+consteval auto concat(Arg const& arg, Args const&... args) noexcept {
+    // TODO impl template-for version
+    ::pltxt2htm::details::BasicLiteralString<typename Arg::value_type, arg.size() + (args.size() + ...)> result{};
     ::std::size_t index{};
+    for (; index < arg.size(); ++index) {
+        result[index] = arg[index];
+    }
     (((
          [args, index, &result]() constexpr noexcept {
              for (::std::size_t i{}; i < args.size(); ++i) {

--- a/include/pltxt2htm/details/literal_string.hh
+++ b/include/pltxt2htm/details/literal_string.hh
@@ -20,14 +20,11 @@ namespace pltxt2htm {
 template<typename ch_type, ::std::size_t>
 class BasicLiteralString;
 
-template<typename ch_type, ::std::size_t N>
-using LiteralString = ::pltxt2htm::BasicLiteralString<ch_type, N>;
+template<::std::size_t N>
+using LiteralString = ::pltxt2htm::BasicLiteralString<char, N>;
 
 template<::std::size_t N>
-using U8LiteralString = ::pltxt2htm::LiteralString<char8_t, N>;
-
-template<::std::size_t N>
-using AsciiLiteralString = ::pltxt2htm::LiteralString<char, N>;
+using U8LiteralString = ::pltxt2htm::BasicLiteralString<char8_t, N>;
 
 template<typename ch_type, ::std::size_t N>
 BasicLiteralString(ch_type const (&str)[N]) -> BasicLiteralString<ch_type, N - 1>;
@@ -191,7 +188,7 @@ consteval auto uint_to_literal_string() noexcept {
 template<::pltxt2htm::details::is_leteral_string... Args>
 consteval auto concat(Args const&... args) noexcept {
     using ch_type = typename ::std::tuple_element_t<0, ::std::tuple<Args...>>::value_type;
-    ::pltxt2htm::LiteralString<ch_type, (args.size() + ...)> result{};
+    ::pltxt2htm::BasicLiteralString<ch_type, (args.size() + ...)> result{};
     ::std::size_t index{};
     (((
          [args, index, &result]() constexpr noexcept {

--- a/include/pltxt2htm/details/literal_string.hh
+++ b/include/pltxt2htm/details/literal_string.hh
@@ -173,11 +173,12 @@ consteval auto uint_to_literal_string() noexcept {
 }
 
 template<typename result_type>
-constexpr void concat_memcpy(::pltxt2htm::details::is_leteral_string auto const& args, ::std::size_t& index,
+consteval void concat_memcpy(::pltxt2htm::details::is_leteral_string auto const& args, ::std::size_t& index,
                              result_type& result) noexcept {
     for (::std::size_t i{}; i < args.size(); ++i) {
         result[i + index] = args[i];
     }
+    index += args.size();
 }
 
 /**
@@ -189,12 +190,10 @@ constexpr void concat_memcpy(::pltxt2htm::details::is_leteral_string auto const&
 template<::pltxt2htm::details::is_leteral_string Arg, ::pltxt2htm::details::is_leteral_string... Args>
     requires (::std::is_same_v<typename Arg::value_type, typename Args::value_type> && ...)
 consteval auto concat(Arg const& arg, Args const&... args) noexcept {
-    ::pltxt2htm::details::BasicLiteralString<typename Arg::value_type, arg.size() + (args.size() + ...)> result{};
+    auto result = ::pltxt2htm::details::BasicLiteralString<typename Arg::value_type, arg.size() + (args.size() + ...)>{};
     ::std::size_t index{};
-    for (; index < arg.size(); ++index) {
-        result[index] = arg[index];
-    }
-    ((::pltxt2htm::details::concat_memcpy(args, index, result), index += args.size()), ...);
+    ::pltxt2htm::details::concat_memcpy(arg, index, result);
+    (::pltxt2htm::details::concat_memcpy(args, index, result), ...);
 
     return result;
 }

--- a/include/pltxt2htm/details/panic.hh
+++ b/include/pltxt2htm/details/panic.hh
@@ -1,9 +1,7 @@
 /**
  * @file panic.hh
  * @brief Panic and error handling utilities for pltxt2htm
- * @details Provides a compile-time string class that stores string data
- *          as part of the type, enabling efficient compile-time string operations
- * @note This is used for compile-time error messages and static string processing
+ * @details Provides panic functionality for assertion failures and critical errors
  */
 
 #pragma once

--- a/include/pltxt2htm/details/panic.hh
+++ b/include/pltxt2htm/details/panic.hh
@@ -1,7 +1,9 @@
 /**
  * @file panic.hh
  * @brief Panic and error handling utilities for pltxt2htm
- * @details Provides panic functionality for assertion failures and critical errors
+ * @details Provides a compile-time string class that stores string data
+ *          as part of the type, enabling efficient compile-time string operations
+ * @note This is used for compile-time error messages and static string processing
  */
 
 #pragma once
@@ -29,7 +31,7 @@ namespace pltxt2htm::details {
  * @note This function is marked as [[noreturn]] - it never returns and always terminates the program
  * @warning This function should only be called when a critical assertion failure occurs
  */
-template<::pltxt2htm::details::LiteralString expression, ::pltxt2htm::details::LiteralString file_name,
+template<::pltxt2htm::details::U8LiteralString expression, ::pltxt2htm::details::U8LiteralString file_name,
          ::std::uint_least32_t line, ::std::uint_least32_t column, pltxt2htm::details::U8LiteralString msg>
 #if __has_cpp_attribute(__gnu__::__cold__)
 [[__gnu__::__cold__]] // Mark as cold path for compiler optimization

--- a/include/pltxt2htm/details/panic.hh
+++ b/include/pltxt2htm/details/panic.hh
@@ -29,7 +29,7 @@ namespace pltxt2htm::details {
  * @note This function is marked as [[noreturn]] - it never returns and always terminates the program
  * @warning This function should only be called when a critical assertion failure occurs
  */
-template<::pltxt2htm::U8LiteralString expression, ::pltxt2htm::U8LiteralString file_name,
+template<::pltxt2htm::LiteralString expression, ::pltxt2htm::LiteralString file_name,
          ::std::uint_least32_t line, ::std::uint_least32_t column, ::pltxt2htm::U8LiteralString msg>
 #if __has_cpp_attribute(__gnu__::__cold__)
 [[__gnu__::__cold__]] // Mark as cold path for compiler optimization

--- a/include/pltxt2htm/details/panic.hh
+++ b/include/pltxt2htm/details/panic.hh
@@ -29,31 +29,28 @@ namespace pltxt2htm::details {
  * @note This function is marked as [[noreturn]] - it never returns and always terminates the program
  * @warning This function should only be called when a critical assertion failure occurs
  */
-template<::pltxt2htm::details::LiteralString expression, ::pltxt2htm::details::LiteralString file_name,
-         ::std::uint_least32_t line, ::std::uint_least32_t column, ::pltxt2htm::details::LiteralString msg>
+template<::pltxt2htm::U8LiteralString expression, ::pltxt2htm::U8LiteralString file_name,
+         ::std::uint_least32_t line, ::std::uint_least32_t column, ::pltxt2htm::U8LiteralString msg>
 #if __has_cpp_attribute(__gnu__::__cold__)
 [[__gnu__::__cold__]] // Mark as cold path for compiler optimization
 #endif
 [[noreturn]]
 inline void panic() noexcept {
     auto to_be_printed = ::pltxt2htm::details::concat(
-        ::pltxt2htm::details::LiteralString{"Program panicked because \"assert("}, expression,
-        ::pltxt2htm::details::LiteralString{
-            ")\" failed, please file a bug at \"https://github.com/SekaiArendelle/pltxt2htm/issues\" and attach the "
-            "crash info along with the source text\n"
-            "* in file: "},
+        ::pltxt2htm::U8LiteralString{u8"Program panicked because \"assert("}, expression,
+        ::pltxt2htm::U8LiteralString{u8")\" failed, please file a bug at \"https://github.com/SekaiArendelle/pltxt2htm/issues\" and attach the crash info along with the source text\n* in file: "},
         file_name,
-        ::pltxt2htm::details::LiteralString{"\n"
+        ::pltxt2htm::U8LiteralString{u8"\n"
                                             "* in line: "},
         ::pltxt2htm::details::uint_to_literal_string<line>(),
-        ::pltxt2htm::details::LiteralString{"\n"
+        ::pltxt2htm::U8LiteralString{u8"\n"
                                             "* in column: "},
         ::pltxt2htm::details::uint_to_literal_string<column>(),
-        ::pltxt2htm::details::LiteralString{"\n"
+        ::pltxt2htm::U8LiteralString{u8"\n"
                                             "* with message: \""},
-        msg, ::pltxt2htm::details::LiteralString{"\"\n\0"});
+        msg, ::pltxt2htm::U8LiteralString{u8"\"\n\0"});
 
-    ::std::fputs(to_be_printed.cdata(), stderr);
+    ::std::fwrite(to_be_printed.cdata(), 1, to_be_printed.size(), stderr);
 
 #if __cpp_lib_stacktrace >= 202011L && defined(PLTXT2HTM_EXPERIMENTAL_ENABLE_STACKTRACE)
     ::std::fputs("* stack trace:\n", stderr);

--- a/include/pltxt2htm/details/panic.hh
+++ b/include/pltxt2htm/details/panic.hh
@@ -50,7 +50,7 @@ inline void panic() noexcept {
                                             "* with message: \""},
         msg, pltxt2htm::details::U8LiteralString{u8"\"\n\0"});
 
-    ::std::fwrite(to_be_printed.cdata(), 1, to_be_printed.size(), stderr);
+    ::std::fwrite(to_be_printed.cdata(), sizeof(typename decltype(to_be_printed)::value_type), to_be_printed.size(), stderr);
 
 #if __cpp_lib_stacktrace >= 202011L && defined(PLTXT2HTM_EXPERIMENTAL_ENABLE_STACKTRACE)
     ::std::fputs("* stack trace:\n", stderr);

--- a/include/pltxt2htm/details/panic.hh
+++ b/include/pltxt2htm/details/panic.hh
@@ -29,26 +29,26 @@ namespace pltxt2htm::details {
  * @note This function is marked as [[noreturn]] - it never returns and always terminates the program
  * @warning This function should only be called when a critical assertion failure occurs
  */
-template<::pltxt2htm::LiteralString expression, ::pltxt2htm::LiteralString file_name,
-         ::std::uint_least32_t line, ::std::uint_least32_t column, ::pltxt2htm::U8LiteralString msg>
+template<::pltxt2htm::details::LiteralString expression, ::pltxt2htm::details::LiteralString file_name,
+         ::std::uint_least32_t line, ::std::uint_least32_t column, pltxt2htm::details::U8LiteralString msg>
 #if __has_cpp_attribute(__gnu__::__cold__)
 [[__gnu__::__cold__]] // Mark as cold path for compiler optimization
 #endif
 [[noreturn]]
 inline void panic() noexcept {
     auto to_be_printed = ::pltxt2htm::details::concat(
-        ::pltxt2htm::U8LiteralString{u8"Program panicked because \"assert("}, expression,
-        ::pltxt2htm::U8LiteralString{u8")\" failed, please file a bug at \"https://github.com/SekaiArendelle/pltxt2htm/issues\" and attach the crash info along with the source text\n* in file: "},
+        pltxt2htm::details::U8LiteralString{u8"Program panicked because \"assert("}, expression,
+        pltxt2htm::details::U8LiteralString{u8")\" failed, please file a bug at \"https://github.com/SekaiArendelle/pltxt2htm/issues\" and attach the crash info along with the source text\n* in file: "},
         file_name,
-        ::pltxt2htm::U8LiteralString{u8"\n"
+        pltxt2htm::details::U8LiteralString{u8"\n"
                                             "* in line: "},
         ::pltxt2htm::details::uint_to_literal_string<line>(),
-        ::pltxt2htm::U8LiteralString{u8"\n"
+        pltxt2htm::details::U8LiteralString{u8"\n"
                                             "* in column: "},
         ::pltxt2htm::details::uint_to_literal_string<column>(),
-        ::pltxt2htm::U8LiteralString{u8"\n"
+        pltxt2htm::details::U8LiteralString{u8"\n"
                                             "* with message: \""},
-        msg, ::pltxt2htm::U8LiteralString{u8"\"\n\0"});
+        msg, pltxt2htm::details::U8LiteralString{u8"\"\n\0"});
 
     ::std::fwrite(to_be_printed.cdata(), 1, to_be_printed.size(), stderr);
 

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -331,7 +331,7 @@ constexpr auto parse_utf8_code_point(::fast_io::u8string_view const& pltext, ::p
  * &lt;div&gt;, &lt;span&gt;, and &lt;p&gt; are valid bare tags.
  */
 template<::pltxt2htm::Contracts ndebug,
-         pltxt2htm::details::U8LiteralString tag_name = pltxt2htm::details::U8LiteralString<0>{}>
+         ::pltxt2htm::details::U8LiteralString tag_name = ::pltxt2htm::details::U8LiteralString<0>{}>
 [[nodiscard]] constexpr auto try_parse_bare_tag(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::std::size_t> {
     constexpr ::std::size_t tag_name_size{tag_name.size()};
@@ -363,7 +363,7 @@ template<::pltxt2htm::Contracts ndebug>
                                               ::pltxt2htm::NodeType const nested_tag_type) noexcept
     -> ::exception::optional<::std::size_t> {
     auto opt_tag_len =
-        ::pltxt2htm::details::try_parse_bare_tag<ndebug, pltxt2htm::details::U8LiteralString{u8"i"}>(pltext);
+        ::pltxt2htm::details::try_parse_bare_tag<ndebug, ::pltxt2htm::details::U8LiteralString{u8"i"}>(pltext);
     if (!opt_tag_len.has_value()) {
         return ::exception::nullopt_t{};
     }
@@ -442,7 +442,7 @@ constexpr bool is_valid_color(::fast_io::u8string_view color) noexcept {
  * @note Leading/trailing spaces in the value are trimmed.
  * @note The validation function must be callable with a char8_t and return a boolean.
  */
-template<::pltxt2htm::Contracts ndebug, pltxt2htm::details::U8LiteralString prefix_str, typename Func>
+template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::details::U8LiteralString prefix_str, typename Func>
     requires requires(Func&& func, char8_t chr) {
         { func(chr) } -> ::std::same_as<bool>;
     }
@@ -451,7 +451,7 @@ constexpr auto try_parse_equal_sign_tag(::fast_io::u8string_view pltext, Func&& 
     -> ::exception::optional<TryParseEqualSignTagResult> {
     ::std::size_t prefix_size{prefix_str.size()};
     constexpr auto prefix_with_equal =
-        ::pltxt2htm::details::concat(prefix_str, pltxt2htm::details::U8LiteralString{u8"="});
+        ::pltxt2htm::details::concat(prefix_str, ::pltxt2htm::details::U8LiteralString{u8"="});
     if (::pltxt2htm::details::is_prefix_match<ndebug, prefix_with_equal>(pltext) == false) {
         return ::exception::nullopt_t{};
     }
@@ -512,7 +512,7 @@ constexpr auto try_parse_equal_sign_tag(::fast_io::u8string_view pltext, Func&& 
  * @param[in] call_stack Active parser stack used to detect forbidden nesting.
  * @return Parsed tag result on success, otherwise nullopt.
  */
-template<::pltxt2htm::Contracts ndebug, pltxt2htm::details::U8LiteralString prefix_str, typename Func>
+template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::details::U8LiteralString prefix_str, typename Func>
     requires requires(Func&& func, char8_t chr) {
         { func(chr) } -> ::std::same_as<bool>;
     }
@@ -609,7 +609,7 @@ constexpr auto try_parse_self_closing_tag(::fast_io::u8string_view pltext) noexc
  * @param[in] pltext The input text to parse from current position.
  * @return Position of closing `>` on success, otherwise nullopt.
  */
-template<::pltxt2htm::Contracts ndebug, pltxt2htm::details::U8LiteralString tag_name>
+template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::details::U8LiteralString tag_name>
 [[nodiscard]]
 constexpr auto try_parse_self_closing_tag(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::std::size_t> {
@@ -726,7 +726,7 @@ constexpr auto try_parse_md_atx_heading(::fast_io::u8string_view pltext) noexcep
         }
         else if (auto opt =
                      ::pltxt2htm::details::try_parse_self_closing_tag<ndebug,
-                                                                      pltxt2htm::details::U8LiteralString{u8"<br"}>(
+                                                                      ::pltxt2htm::details::U8LiteralString{u8"<br"}>(
                          ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, end_index));
                  opt.has_value()) {
             extra_length = opt.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
@@ -820,7 +820,7 @@ constexpr auto try_parse_md_thematic_break(::fast_io::u8string_view text) noexce
             }
             else if (auto opt_tag_len =
                          ::pltxt2htm::details::try_parse_self_closing_tag<ndebug,
-                                                                          pltxt2htm::details::U8LiteralString{u8"<br"}>(
+                                                                          ::pltxt2htm::details::U8LiteralString{u8"<br"}>(
                              ::pltxt2htm::details::u8string_view_subview<ndebug>(text, i));
                      opt_tag_len.has_value()) {
                 return i + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
@@ -863,7 +863,7 @@ struct SimplyParsePLtextResult {
  * @note UTF-8 multi-byte characters are properly handled and converted to U8Char nodes.
  * @note The function consumes the termination string and stops parsing immediately after it.
  */
-template<::pltxt2htm::Contracts ndebug, pltxt2htm::details::U8LiteralString end_string>
+template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::details::U8LiteralString end_string>
 [[nodiscard]]
 constexpr auto simply_parse_pltext(::fast_io::u8string_view pltext) noexcept
     -> ::pltxt2htm::details::SimplyParsePLtextResult {
@@ -968,10 +968,10 @@ constexpr auto try_parse_md_code_fence_(::fast_io::u8string_view pltext) noexcep
 
     constexpr auto fence = []() static constexpr noexcept {
         if constexpr (is_backtick) {
-            return pltxt2htm::details::U8LiteralString{u8"```"};
+            return ::pltxt2htm::details::U8LiteralString{u8"```"};
         }
         else {
-            return pltxt2htm::details::U8LiteralString{u8"~~~"};
+            return ::pltxt2htm::details::U8LiteralString{u8"~~~"};
         }
     }();
     constexpr ::std::size_t fence_size{fence.size()};
@@ -1055,14 +1055,14 @@ constexpr auto try_parse_md_code_fence_(::fast_io::u8string_view pltext) noexcep
     // parsing context of code fence
     ::pltxt2htm::Ast ast{};
     if constexpr (is_backtick) {
-        constexpr auto end_string = ::pltxt2htm::details::concat(pltxt2htm::details::U8LiteralString{u8"\n"}, fence);
+        constexpr auto end_string = ::pltxt2htm::details::concat(::pltxt2htm::details::U8LiteralString{u8"\n"}, fence);
         auto&& [forward_index, ast_] = ::pltxt2htm::details::simply_parse_pltext<ndebug, end_string>(
             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
         ast = ::std::move(ast_);
         current_index += forward_index;
     }
     else {
-        constexpr auto end_string = ::pltxt2htm::details::concat(pltxt2htm::details::U8LiteralString{u8"\n"}, fence);
+        constexpr auto end_string = ::pltxt2htm::details::concat(::pltxt2htm::details::U8LiteralString{u8"\n"}, fence);
         auto&& [forward_index, ast_] = ::pltxt2htm::details::simply_parse_pltext<ndebug, end_string>(
             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
         ast = ::std::move(ast_);
@@ -1142,7 +1142,7 @@ constexpr auto try_parse_md_code_fence(::fast_io::u8string_view pltext) noexcept
  * @see https://spec.commonmark.org/0.31.2/#emphasis-and-strong-emphasis
  * @see https://spec.commonmark.org/0.31.2/#code-spans
  */
-template<::pltxt2htm::Contracts ndebug, pltxt2htm::details::U8LiteralString embraced_chars>
+template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::details::U8LiteralString embraced_chars>
 [[nodiscard]]
 constexpr auto try_parse_md_inlines(::fast_io::u8string_view pltext) noexcept -> ::exception::optional<::std::size_t> {
     constexpr ::std::size_t embraced_size{embraced_chars.size()};
@@ -1276,7 +1276,7 @@ struct TryParseMdCodeSpanResult {
  * @note Empty code spans are valid and will be parsed.
  * @see https://spec.commonmark.org/0.31.2/#code-spans
  */
-template<::pltxt2htm::Contracts ndebug, pltxt2htm::details::U8LiteralString embraced_string>
+template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::details::U8LiteralString embraced_string>
 [[nodiscard]]
 constexpr auto try_parse_md_code_span(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::pltxt2htm::details::TryParseMdCodeSpanResult> {
@@ -1331,7 +1331,7 @@ template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
 constexpr auto try_parse_md_latex_block_dollar(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::pltxt2htm::details::TryParseMdLatexResult> {
-    constexpr auto double_dollar = pltxt2htm::details::U8LiteralString{u8"$$"};
+    constexpr auto double_dollar = ::pltxt2htm::details::U8LiteralString{u8"$$"};
     if (pltext.size() < 4 || ::pltxt2htm::details::is_prefix_match<ndebug, double_dollar>(pltext) == false) {
         return ::exception::nullopt_t{};
     }
@@ -1542,11 +1542,11 @@ template<::pltxt2htm::Contracts ndebug, bool regard_right_parent_as_end_of_url =
 constexpr auto try_parse_url(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::pltxt2htm::details::TryParseUrlResult> {
     ::std::size_t current_index{[pltext] constexpr noexcept -> ::std::size_t {
-        if (constexpr auto http = pltxt2htm::details::U8LiteralString{u8"http://"};
+        if (constexpr auto http = ::pltxt2htm::details::U8LiteralString{u8"http://"};
             ::pltxt2htm::details::is_prefix_match<ndebug, http>(pltext)) {
             return http.size();
         }
-        else if (constexpr auto https = pltxt2htm::details::U8LiteralString{u8"https://"};
+        else if (constexpr auto https = ::pltxt2htm::details::U8LiteralString{u8"https://"};
                  ::pltxt2htm::details::is_prefix_match<ndebug, https>(pltext)) {
             return https.size();
         }

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -331,7 +331,7 @@ constexpr auto parse_utf8_code_point(::fast_io::u8string_view const& pltext, ::p
  * &lt;div&gt;, &lt;span&gt;, and &lt;p&gt; are valid bare tags.
  */
 template<::pltxt2htm::Contracts ndebug,
-         ::pltxt2htm::details::LiteralString tag_name = ::pltxt2htm::details::LiteralString<0>{}>
+         ::pltxt2htm::U8LiteralString tag_name = ::pltxt2htm::U8LiteralString<0>{}>
 [[nodiscard]] constexpr auto try_parse_bare_tag(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::std::size_t> {
     constexpr ::std::size_t tag_name_size{tag_name.size()};
@@ -363,7 +363,7 @@ template<::pltxt2htm::Contracts ndebug>
                                               ::pltxt2htm::NodeType const nested_tag_type) noexcept
     -> ::exception::optional<::std::size_t> {
     auto opt_tag_len =
-        ::pltxt2htm::details::try_parse_bare_tag<ndebug, ::pltxt2htm::details::LiteralString{u8"i"}>(pltext);
+        ::pltxt2htm::details::try_parse_bare_tag<ndebug, ::pltxt2htm::U8LiteralString{u8"i"}>(pltext);
     if (!opt_tag_len.has_value()) {
         return ::exception::nullopt_t{};
     }
@@ -442,7 +442,7 @@ constexpr bool is_valid_color(::fast_io::u8string_view color) noexcept {
  * @note Leading/trailing spaces in the value are trimmed.
  * @note The validation function must be callable with a char8_t and return a boolean.
  */
-template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::details::LiteralString prefix_str, typename Func>
+template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::U8LiteralString prefix_str, typename Func>
     requires requires(Func&& func, char8_t chr) {
         { func(chr) } -> ::std::same_as<bool>;
     }
@@ -451,7 +451,7 @@ constexpr auto try_parse_equal_sign_tag(::fast_io::u8string_view pltext, Func&& 
     -> ::exception::optional<TryParseEqualSignTagResult> {
     ::std::size_t prefix_size{prefix_str.size()};
     constexpr auto prefix_with_equal =
-        ::pltxt2htm::details::concat(prefix_str, ::pltxt2htm::details::LiteralString{u8"="});
+        ::pltxt2htm::details::concat(prefix_str, ::pltxt2htm::U8LiteralString{u8"="});
     if (::pltxt2htm::details::is_prefix_match<ndebug, prefix_with_equal>(pltext) == false) {
         return ::exception::nullopt_t{};
     }
@@ -512,7 +512,7 @@ constexpr auto try_parse_equal_sign_tag(::fast_io::u8string_view pltext, Func&& 
  * @param[in] call_stack Active parser stack used to detect forbidden nesting.
  * @return Parsed tag result on success, otherwise nullopt.
  */
-template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::details::LiteralString prefix_str, typename Func>
+template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::U8LiteralString prefix_str, typename Func>
     requires requires(Func&& func, char8_t chr) {
         { func(chr) } -> ::std::same_as<bool>;
     }
@@ -609,7 +609,7 @@ constexpr auto try_parse_self_closing_tag(::fast_io::u8string_view pltext) noexc
  * @param[in] pltext The input text to parse from current position.
  * @return Position of closing `>` on success, otherwise nullopt.
  */
-template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::details::LiteralString tag_name>
+template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::U8LiteralString tag_name>
 [[nodiscard]]
 constexpr auto try_parse_self_closing_tag(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::std::size_t> {
@@ -726,7 +726,7 @@ constexpr auto try_parse_md_atx_heading(::fast_io::u8string_view pltext) noexcep
         }
         else if (auto opt =
                      ::pltxt2htm::details::try_parse_self_closing_tag<ndebug,
-                                                                      ::pltxt2htm::details::LiteralString{u8"<br"}>(
+                                                                      ::pltxt2htm::U8LiteralString{u8"<br"}>(
                          ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, end_index));
                  opt.has_value()) {
             extra_length = opt.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
@@ -820,7 +820,7 @@ constexpr auto try_parse_md_thematic_break(::fast_io::u8string_view text) noexce
             }
             else if (auto opt_tag_len =
                          ::pltxt2htm::details::try_parse_self_closing_tag<ndebug,
-                                                                          ::pltxt2htm::details::LiteralString{u8"<br"}>(
+                                                                          ::pltxt2htm::U8LiteralString{u8"<br"}>(
                              ::pltxt2htm::details::u8string_view_subview<ndebug>(text, i));
                      opt_tag_len.has_value()) {
                 return i + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
@@ -863,7 +863,7 @@ struct SimplyParsePLtextResult {
  * @note UTF-8 multi-byte characters are properly handled and converted to U8Char nodes.
  * @note The function consumes the termination string and stops parsing immediately after it.
  */
-template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::details::LiteralString end_string>
+template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::U8LiteralString end_string>
 [[nodiscard]]
 constexpr auto simply_parse_pltext(::fast_io::u8string_view pltext) noexcept
     -> ::pltxt2htm::details::SimplyParsePLtextResult {
@@ -968,10 +968,10 @@ constexpr auto try_parse_md_code_fence_(::fast_io::u8string_view pltext) noexcep
 
     constexpr auto fence = []() static constexpr noexcept {
         if constexpr (is_backtick) {
-            return ::pltxt2htm::details::LiteralString{u8"```"};
+            return ::pltxt2htm::U8LiteralString{u8"```"};
         }
         else {
-            return ::pltxt2htm::details::LiteralString{u8"~~~"};
+            return ::pltxt2htm::U8LiteralString{u8"~~~"};
         }
     }();
     constexpr ::std::size_t fence_size{fence.size()};
@@ -1055,14 +1055,14 @@ constexpr auto try_parse_md_code_fence_(::fast_io::u8string_view pltext) noexcep
     // parsing context of code fence
     ::pltxt2htm::Ast ast{};
     if constexpr (is_backtick) {
-        constexpr auto end_string = ::pltxt2htm::details::concat(::pltxt2htm::details::LiteralString{u8"\n"}, fence);
+        constexpr auto end_string = ::pltxt2htm::details::concat(::pltxt2htm::U8LiteralString{u8"\n"}, fence);
         auto&& [forward_index, ast_] = ::pltxt2htm::details::simply_parse_pltext<ndebug, end_string>(
             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
         ast = ::std::move(ast_);
         current_index += forward_index;
     }
     else {
-        constexpr auto end_string = ::pltxt2htm::details::concat(::pltxt2htm::details::LiteralString{u8"\n"}, fence);
+        constexpr auto end_string = ::pltxt2htm::details::concat(::pltxt2htm::U8LiteralString{u8"\n"}, fence);
         auto&& [forward_index, ast_] = ::pltxt2htm::details::simply_parse_pltext<ndebug, end_string>(
             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
         ast = ::std::move(ast_);
@@ -1142,7 +1142,7 @@ constexpr auto try_parse_md_code_fence(::fast_io::u8string_view pltext) noexcept
  * @see https://spec.commonmark.org/0.31.2/#emphasis-and-strong-emphasis
  * @see https://spec.commonmark.org/0.31.2/#code-spans
  */
-template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::details::LiteralString embraced_chars>
+template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::U8LiteralString embraced_chars>
 [[nodiscard]]
 constexpr auto try_parse_md_inlines(::fast_io::u8string_view pltext) noexcept -> ::exception::optional<::std::size_t> {
     constexpr ::std::size_t embraced_size{embraced_chars.size()};
@@ -1276,7 +1276,7 @@ struct TryParseMdCodeSpanResult {
  * @note Empty code spans are valid and will be parsed.
  * @see https://spec.commonmark.org/0.31.2/#code-spans
  */
-template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::details::LiteralString embraced_string>
+template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::U8LiteralString embraced_string>
 [[nodiscard]]
 constexpr auto try_parse_md_code_span(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::pltxt2htm::details::TryParseMdCodeSpanResult> {
@@ -1331,7 +1331,7 @@ template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
 constexpr auto try_parse_md_latex_block_dollar(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::pltxt2htm::details::TryParseMdLatexResult> {
-    constexpr auto double_dollar = ::pltxt2htm::details::LiteralString{u8"$$"};
+    constexpr auto double_dollar = ::pltxt2htm::U8LiteralString{u8"$$"};
     if (pltext.size() < 4 || ::pltxt2htm::details::is_prefix_match<ndebug, double_dollar>(pltext) == false) {
         return ::exception::nullopt_t{};
     }
@@ -1542,11 +1542,11 @@ template<::pltxt2htm::Contracts ndebug, bool regard_right_parent_as_end_of_url =
 constexpr auto try_parse_url(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::pltxt2htm::details::TryParseUrlResult> {
     ::std::size_t current_index{[pltext] constexpr noexcept -> ::std::size_t {
-        if (constexpr auto http = ::pltxt2htm::details::LiteralString{u8"http://"};
+        if (constexpr auto http = ::pltxt2htm::U8LiteralString{u8"http://"};
             ::pltxt2htm::details::is_prefix_match<ndebug, http>(pltext)) {
             return http.size();
         }
-        else if (constexpr auto https = ::pltxt2htm::details::LiteralString{u8"https://"};
+        else if (constexpr auto https = ::pltxt2htm::U8LiteralString{u8"https://"};
                  ::pltxt2htm::details::is_prefix_match<ndebug, https>(pltext)) {
             return https.size();
         }

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -331,7 +331,7 @@ constexpr auto parse_utf8_code_point(::fast_io::u8string_view const& pltext, ::p
  * &lt;div&gt;, &lt;span&gt;, and &lt;p&gt; are valid bare tags.
  */
 template<::pltxt2htm::Contracts ndebug,
-         ::pltxt2htm::U8LiteralString tag_name = ::pltxt2htm::U8LiteralString<0>{}>
+         pltxt2htm::details::U8LiteralString tag_name = pltxt2htm::details::U8LiteralString<0>{}>
 [[nodiscard]] constexpr auto try_parse_bare_tag(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::std::size_t> {
     constexpr ::std::size_t tag_name_size{tag_name.size()};
@@ -363,7 +363,7 @@ template<::pltxt2htm::Contracts ndebug>
                                               ::pltxt2htm::NodeType const nested_tag_type) noexcept
     -> ::exception::optional<::std::size_t> {
     auto opt_tag_len =
-        ::pltxt2htm::details::try_parse_bare_tag<ndebug, ::pltxt2htm::U8LiteralString{u8"i"}>(pltext);
+        ::pltxt2htm::details::try_parse_bare_tag<ndebug, pltxt2htm::details::U8LiteralString{u8"i"}>(pltext);
     if (!opt_tag_len.has_value()) {
         return ::exception::nullopt_t{};
     }
@@ -442,7 +442,7 @@ constexpr bool is_valid_color(::fast_io::u8string_view color) noexcept {
  * @note Leading/trailing spaces in the value are trimmed.
  * @note The validation function must be callable with a char8_t and return a boolean.
  */
-template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::U8LiteralString prefix_str, typename Func>
+template<::pltxt2htm::Contracts ndebug, pltxt2htm::details::U8LiteralString prefix_str, typename Func>
     requires requires(Func&& func, char8_t chr) {
         { func(chr) } -> ::std::same_as<bool>;
     }
@@ -451,7 +451,7 @@ constexpr auto try_parse_equal_sign_tag(::fast_io::u8string_view pltext, Func&& 
     -> ::exception::optional<TryParseEqualSignTagResult> {
     ::std::size_t prefix_size{prefix_str.size()};
     constexpr auto prefix_with_equal =
-        ::pltxt2htm::details::concat(prefix_str, ::pltxt2htm::U8LiteralString{u8"="});
+        ::pltxt2htm::details::concat(prefix_str, pltxt2htm::details::U8LiteralString{u8"="});
     if (::pltxt2htm::details::is_prefix_match<ndebug, prefix_with_equal>(pltext) == false) {
         return ::exception::nullopt_t{};
     }
@@ -512,7 +512,7 @@ constexpr auto try_parse_equal_sign_tag(::fast_io::u8string_view pltext, Func&& 
  * @param[in] call_stack Active parser stack used to detect forbidden nesting.
  * @return Parsed tag result on success, otherwise nullopt.
  */
-template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::U8LiteralString prefix_str, typename Func>
+template<::pltxt2htm::Contracts ndebug, pltxt2htm::details::U8LiteralString prefix_str, typename Func>
     requires requires(Func&& func, char8_t chr) {
         { func(chr) } -> ::std::same_as<bool>;
     }
@@ -609,7 +609,7 @@ constexpr auto try_parse_self_closing_tag(::fast_io::u8string_view pltext) noexc
  * @param[in] pltext The input text to parse from current position.
  * @return Position of closing `>` on success, otherwise nullopt.
  */
-template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::U8LiteralString tag_name>
+template<::pltxt2htm::Contracts ndebug, pltxt2htm::details::U8LiteralString tag_name>
 [[nodiscard]]
 constexpr auto try_parse_self_closing_tag(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::std::size_t> {
@@ -726,7 +726,7 @@ constexpr auto try_parse_md_atx_heading(::fast_io::u8string_view pltext) noexcep
         }
         else if (auto opt =
                      ::pltxt2htm::details::try_parse_self_closing_tag<ndebug,
-                                                                      ::pltxt2htm::U8LiteralString{u8"<br"}>(
+                                                                      pltxt2htm::details::U8LiteralString{u8"<br"}>(
                          ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, end_index));
                  opt.has_value()) {
             extra_length = opt.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
@@ -820,7 +820,7 @@ constexpr auto try_parse_md_thematic_break(::fast_io::u8string_view text) noexce
             }
             else if (auto opt_tag_len =
                          ::pltxt2htm::details::try_parse_self_closing_tag<ndebug,
-                                                                          ::pltxt2htm::U8LiteralString{u8"<br"}>(
+                                                                          pltxt2htm::details::U8LiteralString{u8"<br"}>(
                              ::pltxt2htm::details::u8string_view_subview<ndebug>(text, i));
                      opt_tag_len.has_value()) {
                 return i + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
@@ -863,7 +863,7 @@ struct SimplyParsePLtextResult {
  * @note UTF-8 multi-byte characters are properly handled and converted to U8Char nodes.
  * @note The function consumes the termination string and stops parsing immediately after it.
  */
-template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::U8LiteralString end_string>
+template<::pltxt2htm::Contracts ndebug, pltxt2htm::details::U8LiteralString end_string>
 [[nodiscard]]
 constexpr auto simply_parse_pltext(::fast_io::u8string_view pltext) noexcept
     -> ::pltxt2htm::details::SimplyParsePLtextResult {
@@ -968,10 +968,10 @@ constexpr auto try_parse_md_code_fence_(::fast_io::u8string_view pltext) noexcep
 
     constexpr auto fence = []() static constexpr noexcept {
         if constexpr (is_backtick) {
-            return ::pltxt2htm::U8LiteralString{u8"```"};
+            return pltxt2htm::details::U8LiteralString{u8"```"};
         }
         else {
-            return ::pltxt2htm::U8LiteralString{u8"~~~"};
+            return pltxt2htm::details::U8LiteralString{u8"~~~"};
         }
     }();
     constexpr ::std::size_t fence_size{fence.size()};
@@ -1055,14 +1055,14 @@ constexpr auto try_parse_md_code_fence_(::fast_io::u8string_view pltext) noexcep
     // parsing context of code fence
     ::pltxt2htm::Ast ast{};
     if constexpr (is_backtick) {
-        constexpr auto end_string = ::pltxt2htm::details::concat(::pltxt2htm::U8LiteralString{u8"\n"}, fence);
+        constexpr auto end_string = ::pltxt2htm::details::concat(pltxt2htm::details::U8LiteralString{u8"\n"}, fence);
         auto&& [forward_index, ast_] = ::pltxt2htm::details::simply_parse_pltext<ndebug, end_string>(
             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
         ast = ::std::move(ast_);
         current_index += forward_index;
     }
     else {
-        constexpr auto end_string = ::pltxt2htm::details::concat(::pltxt2htm::U8LiteralString{u8"\n"}, fence);
+        constexpr auto end_string = ::pltxt2htm::details::concat(pltxt2htm::details::U8LiteralString{u8"\n"}, fence);
         auto&& [forward_index, ast_] = ::pltxt2htm::details::simply_parse_pltext<ndebug, end_string>(
             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
         ast = ::std::move(ast_);
@@ -1142,7 +1142,7 @@ constexpr auto try_parse_md_code_fence(::fast_io::u8string_view pltext) noexcept
  * @see https://spec.commonmark.org/0.31.2/#emphasis-and-strong-emphasis
  * @see https://spec.commonmark.org/0.31.2/#code-spans
  */
-template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::U8LiteralString embraced_chars>
+template<::pltxt2htm::Contracts ndebug, pltxt2htm::details::U8LiteralString embraced_chars>
 [[nodiscard]]
 constexpr auto try_parse_md_inlines(::fast_io::u8string_view pltext) noexcept -> ::exception::optional<::std::size_t> {
     constexpr ::std::size_t embraced_size{embraced_chars.size()};
@@ -1276,7 +1276,7 @@ struct TryParseMdCodeSpanResult {
  * @note Empty code spans are valid and will be parsed.
  * @see https://spec.commonmark.org/0.31.2/#code-spans
  */
-template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::U8LiteralString embraced_string>
+template<::pltxt2htm::Contracts ndebug, pltxt2htm::details::U8LiteralString embraced_string>
 [[nodiscard]]
 constexpr auto try_parse_md_code_span(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::pltxt2htm::details::TryParseMdCodeSpanResult> {
@@ -1331,7 +1331,7 @@ template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
 constexpr auto try_parse_md_latex_block_dollar(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::pltxt2htm::details::TryParseMdLatexResult> {
-    constexpr auto double_dollar = ::pltxt2htm::U8LiteralString{u8"$$"};
+    constexpr auto double_dollar = pltxt2htm::details::U8LiteralString{u8"$$"};
     if (pltext.size() < 4 || ::pltxt2htm::details::is_prefix_match<ndebug, double_dollar>(pltext) == false) {
         return ::exception::nullopt_t{};
     }
@@ -1542,11 +1542,11 @@ template<::pltxt2htm::Contracts ndebug, bool regard_right_parent_as_end_of_url =
 constexpr auto try_parse_url(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::pltxt2htm::details::TryParseUrlResult> {
     ::std::size_t current_index{[pltext] constexpr noexcept -> ::std::size_t {
-        if (constexpr auto http = ::pltxt2htm::U8LiteralString{u8"http://"};
+        if (constexpr auto http = pltxt2htm::details::U8LiteralString{u8"http://"};
             ::pltxt2htm::details::is_prefix_match<ndebug, http>(pltext)) {
             return http.size();
         }
-        else if (constexpr auto https = ::pltxt2htm::U8LiteralString{u8"https://"};
+        else if (constexpr auto https = pltxt2htm::details::U8LiteralString{u8"https://"};
                  ::pltxt2htm::details::is_prefix_match<ndebug, https>(pltext)) {
             return https.size();
         }

--- a/include/pltxt2htm/details/pop_macro.hh
+++ b/include/pltxt2htm/details/pop_macro.hh
@@ -10,3 +10,5 @@
  */
 
 #pragma pop_macro("pltxt2htm_assert")
+#pragma pop_macro("PLTXT2HTM_U8_CONSTANT_STR_")
+#pragma pop_macro("PLTXT2HTM_U8_CONSTANT_STR_HELPER_")

--- a/include/pltxt2htm/details/push_macro.hh
+++ b/include/pltxt2htm/details/push_macro.hh
@@ -38,8 +38,8 @@
             if ((condition) == false) [[unlikely]] { \
                 constexpr auto source_location = ::std::source_location::current(); \
                 ::pltxt2htm::details::panic< \
-                    ::pltxt2htm::LiteralString{#condition}, ::pltxt2htm::LiteralString{__FILE__}, \
-                    source_location.line(), source_location.column(), ::pltxt2htm::U8LiteralString{message}>(); \
+                    ::pltxt2htm::details::LiteralString{#condition}, ::pltxt2htm::details::LiteralString{__FILE__}, \
+                    source_location.line(), source_location.column(), pltxt2htm::details::U8LiteralString{message}>(); \
             } \
         } \
         else { \

--- a/include/pltxt2htm/details/push_macro.hh
+++ b/include/pltxt2htm/details/push_macro.hh
@@ -38,7 +38,7 @@
             if ((condition) == false) [[unlikely]] { \
                 constexpr auto source_location = ::std::source_location::current(); \
                 ::pltxt2htm::details::panic< \
-                    ::pltxt2htm::U8LiteralString{#condition}, ::pltxt2htm::U8LiteralString{__FILE__}, \
+                    ::pltxt2htm::LiteralString{#condition}, ::pltxt2htm::LiteralString{__FILE__}, \
                     source_location.line(), source_location.column(), ::pltxt2htm::U8LiteralString{message}>(); \
             } \
         } \

--- a/include/pltxt2htm/details/push_macro.hh
+++ b/include/pltxt2htm/details/push_macro.hh
@@ -12,8 +12,15 @@
 #include "../contracts.hh"
 #include "panic.hh"
 
-#pragma push_macro("pltxt2htm_assert")
-#undef pltxt2htm_assert
+
+#pragma push_macro("PLTXT2HTM_U8_CONSTANT_STR_HELPER_")
+#undef PLTXT2HTM_U8_CONSTANT_STR_HELPER_
+#define PLTXT2HTM_U8_CONSTANT_STR_HELPER_(str) u8 ## str
+
+#pragma push_macro("PLTXT2HTM_U8_CONSTANT_STR_")
+#undef PLTXT2HTM_U8_CONSTANT_STR_
+#define PLTXT2HTM_U8_CONSTANT_STR_(str) PLTXT2HTM_U8_CONSTANT_STR_HELPER_(str)
+
 /**
  * @brief Assert whether the condition expression is true, if not, print
  *        the message and terminate the program.
@@ -32,13 +39,15 @@
  *
  * @see pltxt2htm::details::panic()
  */
+#pragma push_macro("pltxt2htm_assert")
+#undef pltxt2htm_assert
 #define pltxt2htm_assert(condition, message) \
     do { \
         if constexpr (ndebug != ::pltxt2htm::Contracts::ignore) { \
             if ((condition) == false) [[unlikely]] { \
                 constexpr auto source_location = ::std::source_location::current(); \
                 ::pltxt2htm::details::panic< \
-                    ::pltxt2htm::details::LiteralString{#condition}, ::pltxt2htm::details::LiteralString{__FILE__}, \
+                    ::pltxt2htm::details::U8LiteralString{PLTXT2HTM_U8_CONSTANT_STR_(#condition)}, ::pltxt2htm::details::U8LiteralString{PLTXT2HTM_U8_CONSTANT_STR_(__FILE__)}, \
                     source_location.line(), source_location.column(), pltxt2htm::details::U8LiteralString{message}>(); \
             } \
         } \

--- a/include/pltxt2htm/details/push_macro.hh
+++ b/include/pltxt2htm/details/push_macro.hh
@@ -38,8 +38,8 @@
             if ((condition) == false) [[unlikely]] { \
                 constexpr auto source_location = ::std::source_location::current(); \
                 ::pltxt2htm::details::panic< \
-                    ::pltxt2htm::details::LiteralString{#condition}, ::pltxt2htm::details::LiteralString{__FILE__}, \
-                    source_location.line(), source_location.column(), ::pltxt2htm::details::LiteralString{message}>(); \
+                    ::pltxt2htm::U8LiteralString{#condition}, ::pltxt2htm::U8LiteralString{__FILE__}, \
+                    source_location.line(), source_location.column(), ::pltxt2htm::U8LiteralString{message}>(); \
             } \
         } \
         else { \

--- a/include/pltxt2htm/details/utils.hh
+++ b/include/pltxt2htm/details/utils.hh
@@ -158,7 +158,7 @@ constexpr auto const& stack_top(::fast_io::containers::stack<T> const& stack) {
  * @note prefix_str must contain only lowercase characters due to compile-time constraints
  * @warning This is a compile-time function that generates optimized matching code
  */
-template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::U8LiteralString prefix_str>
+template<::pltxt2htm::Contracts ndebug, pltxt2htm::details::U8LiteralString prefix_str>
 [[nodiscard]]
 #if __has_cpp_attribute(__gnu__::__pure__)
 [[__gnu__::__pure__]]

--- a/include/pltxt2htm/details/utils.hh
+++ b/include/pltxt2htm/details/utils.hh
@@ -158,7 +158,7 @@ constexpr auto const& stack_top(::fast_io::containers::stack<T> const& stack) {
  * @note prefix_str must contain only lowercase characters due to compile-time constraints
  * @warning This is a compile-time function that generates optimized matching code
  */
-template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::details::LiteralString prefix_str>
+template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::U8LiteralString prefix_str>
 [[nodiscard]]
 #if __has_cpp_attribute(__gnu__::__pure__)
 [[__gnu__::__pure__]]

--- a/include/pltxt2htm/details/utils.hh
+++ b/include/pltxt2htm/details/utils.hh
@@ -158,7 +158,7 @@ constexpr auto const& stack_top(::fast_io::containers::stack<T> const& stack) {
  * @note prefix_str must contain only lowercase characters due to compile-time constraints
  * @warning This is a compile-time function that generates optimized matching code
  */
-template<::pltxt2htm::Contracts ndebug, pltxt2htm::details::U8LiteralString prefix_str>
+template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::details::U8LiteralString prefix_str>
 [[nodiscard]]
 #if __has_cpp_attribute(__gnu__::__pure__)
 [[__gnu__::__pure__]]

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -297,7 +297,7 @@ entry:
             auto const anchor = static_cast<::pltxt2htm::A*>(node.get_unsafe());
             constexpr auto anchor_color_literal = ::pltxt2htm::A::get_color_literal();
             auto const anchor_color = ::fast_io::u8string_view{
-                reinterpret_cast<char8_t const*>(anchor_color_literal.data()), anchor_color_literal.size()};
+                anchor_color_literal.data(), anchor_color_literal.size()};
             {
                 // Optimization: <a><color=blue>text</color></a>
                 // can be simplified to <color=blue>text</color>

--- a/tests/0043.literal_string.cc
+++ b/tests/0043.literal_string.cc
@@ -2,44 +2,44 @@
 #include <pltxt2htm/details/utils.hh>
 #include "precompile.hh"
 
-template<::pltxt2htm::U8LiteralString test>
+template<pltxt2htm::details::U8LiteralString test>
 struct X {};
 
 consteval void test_use_in_template() noexcept {
-    [[maybe_unused]] auto _ = X<::pltxt2htm::U8LiteralString{u8"test"}>{};
+    [[maybe_unused]] auto _ = X<pltxt2htm::details::U8LiteralString{u8"test"}>{};
 }
 
 consteval void test_init_and_concat() noexcept {
-    constexpr auto str1 = ::pltxt2htm::U8LiteralString{u8"test"};
-    constexpr auto str2 = ::pltxt2htm::U8LiteralString{u8"test"};
-    constexpr auto str3 = ::pltxt2htm::U8LiteralString{u8"text"};
+    constexpr auto str1 = pltxt2htm::details::U8LiteralString{u8"test"};
+    constexpr auto str2 = pltxt2htm::details::U8LiteralString{u8"test"};
+    constexpr auto str3 = pltxt2htm::details::U8LiteralString{u8"text"};
 
     constexpr auto concat_str = ::pltxt2htm::details::concat(str1, str2, str3);
-    constexpr auto answer = ::pltxt2htm::U8LiteralString{u8"testtesttext"};
+    constexpr auto answer = pltxt2htm::details::U8LiteralString{u8"testtesttext"};
     static_assert(concat_str == answer);
 }
 
 consteval void test_index() noexcept {
-    constexpr auto str = ::pltxt2htm::U8LiteralString{u8"test"};
+    constexpr auto str = pltxt2htm::details::U8LiteralString{u8"test"};
     static_assert(str[1] == u8'e');
 }
 
 consteval void test_uint_to_literal_string() noexcept {
     constexpr auto str = ::pltxt2htm::details::uint_to_literal_string<42>();
-    constexpr auto answer = ::pltxt2htm::U8LiteralString{u8"42"};
+    constexpr auto answer = pltxt2htm::details::U8LiteralString{u8"42"};
     static_assert(str.size() == 2);
     static_assert(str == answer);
 }
 
 consteval void test_for_loop() noexcept {
-    constexpr auto str = ::pltxt2htm::U8LiteralString{u8"test"};
+    constexpr auto str = pltxt2htm::details::U8LiteralString{u8"test"};
     for ([[maybe_unused]] auto&& _ : str) {
     }
 }
 
 int main() noexcept {
     {
-        constexpr auto str = ::pltxt2htm::U8LiteralString{u8"test"};
+        constexpr auto str = pltxt2htm::details::U8LiteralString{u8"test"};
         ::pltxt2htm_test::assert_true(::pltxt2htm::details::is_prefix_match<::pltxt2htm::Contracts::quick_enforce, str>(
             ::fast_io::u8string_view{u8"test"}));
         ::pltxt2htm_test::assert_true(::pltxt2htm::details::is_prefix_match<::pltxt2htm::Contracts::quick_enforce, str>(
@@ -49,24 +49,24 @@ int main() noexcept {
     }
 
     {
-        constexpr auto str = ::pltxt2htm::U8LiteralString{u8"te-1"};
+        constexpr auto str = pltxt2htm::details::U8LiteralString{u8"te-1"};
         ::pltxt2htm_test::assert_true(
             ::pltxt2htm::details::is_prefix_match<::pltxt2htm::Contracts::quick_enforce, str>(u8"TE-1"));
         ::pltxt2htm_test::assert_true(
             ::pltxt2htm::details::is_prefix_match<::pltxt2htm::Contracts::quick_enforce, str>(u8"TE_1") == false);
     }
     {
-        constexpr auto str = ::pltxt2htm::U8LiteralString{u8"a"};
+        constexpr auto str = pltxt2htm::details::U8LiteralString{u8"a"};
         ::pltxt2htm_test::assert_true(
             ::pltxt2htm::details::is_prefix_match<::pltxt2htm::Contracts::quick_enforce, str>(u8"b") == false);
     }
     {
-        constexpr auto str = ::pltxt2htm::U8LiteralString{u8"-"};
+        constexpr auto str = pltxt2htm::details::U8LiteralString{u8"-"};
         ::pltxt2htm_test::assert_true(
             ::pltxt2htm::details::is_prefix_match<::pltxt2htm::Contracts::quick_enforce, str>(u8"_") == false);
     }
     {
-        constexpr auto str = ::pltxt2htm::U8LiteralString{u8"-"};
+        constexpr auto str = pltxt2htm::details::U8LiteralString{u8"-"};
         ::pltxt2htm_test::assert_true(
             ::pltxt2htm::details::is_prefix_match<::pltxt2htm::Contracts::quick_enforce, str>(u8"-"));
     }

--- a/tests/0043.literal_string.cc
+++ b/tests/0043.literal_string.cc
@@ -2,44 +2,44 @@
 #include <pltxt2htm/details/utils.hh>
 #include "precompile.hh"
 
-template<::pltxt2htm::details::LiteralString test>
+template<::pltxt2htm::U8LiteralString test>
 struct X {};
 
 consteval void test_use_in_template() noexcept {
-    [[maybe_unused]] auto _ = X<::pltxt2htm::details::LiteralString{u8"test"}>{};
+    [[maybe_unused]] auto _ = X<::pltxt2htm::U8LiteralString{u8"test"}>{};
 }
 
 consteval void test_init_and_concat() noexcept {
-    constexpr auto str1 = ::pltxt2htm::details::LiteralString{u8"test"};
-    constexpr auto str2 = ::pltxt2htm::details::LiteralString{"test"};
-    constexpr auto str3 = ::pltxt2htm::details::LiteralString{"text"};
+    constexpr auto str1 = ::pltxt2htm::U8LiteralString{u8"test"};
+    constexpr auto str2 = ::pltxt2htm::U8LiteralString{u8"test"};
+    constexpr auto str3 = ::pltxt2htm::U8LiteralString{u8"text"};
 
     constexpr auto concat_str = ::pltxt2htm::details::concat(str1, str2, str3);
-    constexpr auto answer = ::pltxt2htm::details::LiteralString{u8"testtesttext"};
+    constexpr auto answer = ::pltxt2htm::U8LiteralString{u8"testtesttext"};
     static_assert(concat_str == answer);
 }
 
 consteval void test_index() noexcept {
-    constexpr auto str = ::pltxt2htm::details::LiteralString{u8"test"};
+    constexpr auto str = ::pltxt2htm::U8LiteralString{u8"test"};
     static_assert(str[1] == u8'e');
 }
 
 consteval void test_uint_to_literal_string() noexcept {
     constexpr auto str = ::pltxt2htm::details::uint_to_literal_string<42>();
-    constexpr auto answer = ::pltxt2htm::details::LiteralString{u8"42"};
+    constexpr auto answer = ::pltxt2htm::U8LiteralString{u8"42"};
     static_assert(str.size() == 2);
     static_assert(str == answer);
 }
 
 consteval void test_for_loop() noexcept {
-    constexpr auto str = ::pltxt2htm::details::LiteralString{u8"test"};
+    constexpr auto str = ::pltxt2htm::U8LiteralString{u8"test"};
     for ([[maybe_unused]] auto&& _ : str) {
     }
 }
 
 int main() noexcept {
     {
-        constexpr auto str = ::pltxt2htm::details::LiteralString{u8"test"};
+        constexpr auto str = ::pltxt2htm::U8LiteralString{u8"test"};
         ::pltxt2htm_test::assert_true(::pltxt2htm::details::is_prefix_match<::pltxt2htm::Contracts::quick_enforce, str>(
             ::fast_io::u8string_view{u8"test"}));
         ::pltxt2htm_test::assert_true(::pltxt2htm::details::is_prefix_match<::pltxt2htm::Contracts::quick_enforce, str>(
@@ -49,24 +49,24 @@ int main() noexcept {
     }
 
     {
-        constexpr auto str = ::pltxt2htm::details::LiteralString{u8"te-1"};
+        constexpr auto str = ::pltxt2htm::U8LiteralString{u8"te-1"};
         ::pltxt2htm_test::assert_true(
             ::pltxt2htm::details::is_prefix_match<::pltxt2htm::Contracts::quick_enforce, str>(u8"TE-1"));
         ::pltxt2htm_test::assert_true(
             ::pltxt2htm::details::is_prefix_match<::pltxt2htm::Contracts::quick_enforce, str>(u8"TE_1") == false);
     }
     {
-        constexpr auto str = ::pltxt2htm::details::LiteralString{u8"a"};
+        constexpr auto str = ::pltxt2htm::U8LiteralString{u8"a"};
         ::pltxt2htm_test::assert_true(
             ::pltxt2htm::details::is_prefix_match<::pltxt2htm::Contracts::quick_enforce, str>(u8"b") == false);
     }
     {
-        constexpr auto str = ::pltxt2htm::details::LiteralString{u8"-"};
+        constexpr auto str = ::pltxt2htm::U8LiteralString{u8"-"};
         ::pltxt2htm_test::assert_true(
             ::pltxt2htm::details::is_prefix_match<::pltxt2htm::Contracts::quick_enforce, str>(u8"_") == false);
     }
     {
-        constexpr auto str = ::pltxt2htm::details::LiteralString{u8"-"};
+        constexpr auto str = ::pltxt2htm::U8LiteralString{u8"-"};
         ::pltxt2htm_test::assert_true(
             ::pltxt2htm::details::is_prefix_match<::pltxt2htm::Contracts::quick_enforce, str>(u8"-"));
     }


### PR DESCRIPTION
### Motivation
- Model compile-time literal strings like the standard library by parameterizing the character type (`BasicLiteralString<CharT, N>`).
- Centralize UTF-8 literal handling with a dedicated alias (`U8LiteralString`) and reduce ad-hoc `reinterpret_cast<char8_t const*>` usage.
- Make compile-time helpers and traits operate on typed literal strings so parser/diagnostics can use UTF-8 literals directly.

### Description
- Introduced `BasicLiteralString<ch_type, N>` and aliases `LiteralString<ch_type, N>`, `U8LiteralString<N>` and `AsciiLiteralString<N>` in `include/pltxt2htm/details/literal_string.hh` and added a corresponding deduction guide.
- Reworked traits/concept and compile-time utilities (`shrink_string_literal_`, `uint_to_literal_string`, `concat`) to use the new typed literal-string aliases and to default UTF-8 paths to `U8LiteralString`.
- Replaced prior `details::LiteralString` usage with `U8LiteralString` across parser, utils, panic/assert macros, backends, optimizer, AST node, and tests; updated `push_macro.hh`, `panic.hh`, `try_parse.hh`, backend files, `optimizer.hh`, and `astnode/physics_lab_node.hh` accordingly.
- Reduced `char8_t`-related `reinterpret_cast` sites by using typed data pointers in backends/optimizer and changed CLI argument handling to the safer `static_cast<char8_t const*>(static_cast<void const*>(...))`; adjusted panic output to use `fwrite` for the new typed data.

### Testing
- Attempted `xmake build` but `xmake` is not present in the environment so a full project build was not run.
- Attempted a focused compile: `g++ -std=c++23 -Iinclude -c tests/0043.literal_string.cc -o /tmp/0043.o`, which failed because the local compiler/toolchain in this environment does not support the project's required language features (e.g. deducing `this` forms), so automated compilation could not be completed.
- The literal-string unit test `tests/0043.literal_string.cc` was updated to use `U8LiteralString`, but no test run succeeded due to the environment/tooling limitations described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49e673e18832abc69aabc7d08a44b)