### PR TITLE
rust: auto-build C bridge in libpltxt2htm-sys

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -1,7 +1,9 @@
 # Use `pltxt2htm` in Rust
 Note that this is experimental.
 
-You should manually build a static library of [c/](../c/README.md), specify `RUSTFLAGS` env variable to link it.
+`libpltxt2htm-sys` now compiles the C bridge automatically at build time, so no manual static-library build/copy step is needed.
+
+It requires a C++23 toolchain on your machine because the C bridge (`c/src/pltxt2htm.cc`) is compiled during `cargo build`/`cargo run`.
 
 ## examples
 

--- a/rust/libpltxt2htm-sys/Cargo.toml
+++ b/rust/libpltxt2htm-sys/Cargo.toml
@@ -1,6 +1,11 @@
 [package]
 name = "libpltxt2htm-sys"
 edition = "2021"
+build = "build.rs"
+links = "pltxt2htm"
 
 [dependencies]
 libc = "0.2"
+
+[build-dependencies]
+cc = "1"

--- a/rust/libpltxt2htm-sys/build.rs
+++ b/rust/libpltxt2htm-sys/build.rs
@@ -1,0 +1,105 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn profile_mode() -> &'static str {
+    if std::env::var("PROFILE").map(|v| v == "release").unwrap_or(false) {
+        "release"
+    } else {
+        "debug"
+    }
+}
+
+fn try_run_xmake(c_root: &Path, out_dir: &Path) -> Result<(), String> {
+    let install_dir = out_dir.join("pltxt2htm-install");
+
+    let config_status = Command::new("xmake")
+        .arg("config")
+        .arg("-P")
+        .arg(c_root)
+        .arg("-k")
+        .arg("static")
+        .arg("-m")
+        .arg(profile_mode())
+        .status()
+        .map_err(|e| format!("failed to invoke xmake config: {e}"))?;
+    if !config_status.success() {
+        return Err("xmake config failed".to_owned());
+    }
+
+    let build_status = Command::new("xmake")
+        .arg("build")
+        .arg("-P")
+        .arg(c_root)
+        .status()
+        .map_err(|e| format!("failed to invoke xmake build: {e}"))?;
+    if !build_status.success() {
+        return Err("xmake build failed".to_owned());
+    }
+
+    let install_status = Command::new("xmake")
+        .arg("install")
+        .arg("-P")
+        .arg(c_root)
+        .arg("-o")
+        .arg(&install_dir)
+        .status()
+        .map_err(|e| format!("failed to invoke xmake install: {e}"))?;
+    if !install_status.success() {
+        return Err("xmake install failed".to_owned());
+    }
+
+    println!("cargo:rustc-link-search=native={}", install_dir.join("lib").display());
+    Ok(())
+}
+
+fn fallback_build_by_cc(c_root: &Path) {
+    let mut build = cc::Build::new();
+    build
+        .cpp(true)
+        .std("c++23")
+        .file(c_root.join("src/pltxt2htm.cc"))
+        .include(c_root.join("include"))
+        .include("../../include")
+        .warnings(false);
+
+    if Command::new("clang++-20").arg("--version").status().is_ok() {
+        build.compiler("clang++-20");
+    }
+
+    if profile_mode() == "release" {
+        build.define("NDEBUG", None);
+    }
+
+    build.compile("pltxt2htm");
+}
+
+fn main() {
+    let c_root = PathBuf::from("..").join("..").join("c");
+    println!("cargo:rerun-if-changed={}", c_root.join("src/pltxt2htm.cc").display());
+    println!("cargo:rerun-if-changed={}", c_root.join("include/pltxt2htm.h").display());
+    println!("cargo:rerun-if-changed={}", c_root.join("include/push_macros.h").display());
+    println!("cargo:rerun-if-changed=../../include/pltxt2htm");
+
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR is not set"));
+
+    match try_run_xmake(&c_root, &out_dir) {
+        Ok(()) => {}
+        Err(reason) => {
+            println!("cargo:warning=Using cc-rs fallback because {reason}");
+            fallback_build_by_cc(&c_root);
+        }
+    }
+
+    println!("cargo:rustc-link-lib=static=pltxt2htm");
+
+    let target = std::env::var("TARGET").unwrap_or_default();
+    if target.contains("msvc") {
+        return;
+    }
+    let stdlib = if target.contains("apple") || target.contains("freebsd") || target.contains("openbsd") {
+        "c++"
+    } else {
+        "stdc++"
+    };
+    println!("cargo:rustc-link-lib={stdlib}");
+}

--- a/rust/libpltxt2htm-sys/build.rs
+++ b/rust/libpltxt2htm-sys/build.rs
@@ -71,7 +71,7 @@ fn fallback_build_by_cc(c_root: &Path) {
         .warnings(false);
 
     if std::env::var_os("CXX").is_none() {
-        for cxx in ["clang++", "g++", "c++", "clang++-20", "clang++-19", "g++-14", "g++-13"] {
+        for cxx in ["clang++", "g++", "c++", "clang++-22", "clang++-21", "clang++-20", "g++-16", "g++-15", "g++-14"] {
             if Command::new(cxx).arg("--version").status().is_ok() {
                 build.compiler(cxx);
                 println!("cargo:warning=Using C++ compiler fallback: {cxx}");

--- a/rust/libpltxt2htm-sys/build.rs
+++ b/rust/libpltxt2htm-sys/build.rs
@@ -70,8 +70,14 @@ fn fallback_build_by_cc(c_root: &Path) {
         .include("../../include")
         .warnings(false);
 
-    if Command::new("clang++-20").arg("--version").status().is_ok() {
-        build.compiler("clang++-20");
+    if std::env::var_os("CXX").is_none() {
+        for cxx in ["clang++", "g++", "c++", "clang++-20", "clang++-19", "g++-14", "g++-13"] {
+            if Command::new(cxx).arg("--version").status().is_ok() {
+                build.compiler(cxx);
+                println!("cargo:warning=Using C++ compiler fallback: {cxx}");
+                break;
+            }
+        }
     }
 
     if profile_mode() == "release" {

--- a/rust/libpltxt2htm-sys/build.rs
+++ b/rust/libpltxt2htm-sys/build.rs
@@ -9,6 +9,14 @@ fn profile_mode() -> &'static str {
     }
 }
 
+fn static_lib_name(target: &str) -> &'static str {
+    if target.contains("windows") && profile_mode() == "debug" {
+        "pltxt2htmd"
+    } else {
+        "pltxt2htm"
+    }
+}
+
 fn try_run_xmake(c_root: &Path, out_dir: &Path) -> Result<(), String> {
     let install_dir = out_dir.join("pltxt2htm-install");
 
@@ -90,9 +98,9 @@ fn main() {
         }
     }
 
-    println!("cargo:rustc-link-lib=static=pltxt2htm");
-
     let target = std::env::var("TARGET").unwrap_or_default();
+    println!("cargo:rustc-link-lib=static={}", static_lib_name(&target));
+
     if target.contains("msvc") {
         return;
     }

--- a/rust/libpltxt2htm-sys/src/libpltxt2htm_sys.rs
+++ b/rust/libpltxt2htm-sys/src/libpltxt2htm_sys.rs
@@ -1,6 +1,5 @@
 use libc::{c_char, size_t};
 
-#[link(name = "pltxt2htm", kind = "static")]
 unsafe extern "C" {
     pub unsafe fn pltxt2htm_common_parser(pltext: *const c_char) -> *const c_char;
     pub unsafe fn pltxt2htm_advanced_parser(pltext: *const c_char) -> *const c_char;


### PR DESCRIPTION
### Motivation
- Remove the manual step of building a static C library in `c/` and copying it into `rust/` so the Rust bindings are easier to use. 
- Ensure `libpltxt2htm-sys` builds the C bridge automatically during `cargo build` while preferring the project’s existing `xmake` workflow.

### Description
- Add `rust/libpltxt2htm-sys/build.rs` which tries to build/install the C static library via `xmake` and prints a link-search path for the produced library. 
- Add a `cc`-based fallback in `build.rs` that compiles `c/src/pltxt2htm.cc` directly when `xmake` is unavailable, and link the C++ runtime on non-MSVC targets. 
- Update `rust/libpltxt2htm-sys/Cargo.toml` to set `build = "build.rs"`, `links = "pltxt2htm"`, and add `cc` under `[build-dependencies]`. 
- Update `rust/README.md` to document the automatic build behavior and note that a C++23 toolchain is required because the bridge is compiled during the Rust build.

### Testing
- Ran `cd rust && cargo check -p libpltxt2htm-sys` to exercise the build script, and the script attempted `xmake` then fell back to `cc`; this validated the build-path selection logic but the overall build failed. 
- Failure reason: the environment compiler/standard library used here lacks required C++23 features (errors such as missing `std::forward_like`), so compilation of the C bridge did not succeed in this test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e87300e620832a93eb808f1577ad49)