### PR TITLE
Fix invalid constructor generation for C# AST node classes

### DIFF
--- a/translang/csharp/src/main.cc
+++ b/translang/csharp/src/main.cc
@@ -649,8 +649,15 @@ constexpr void emit_astnode_class(::llvm::raw_string_ostream& out, AstNodeClassS
         out << "\n";
     }
 
+    bool emitted_parameterless_ctor = false;
     if (cls.has_default_ctor) {
-        if (cls.fields.empty()) {
+        if (cls.base_kind == AstNodeBaseKind::paired_tag && cls.fields.empty()) {
+            out << "    public " << cls.name << "() : this(new Ast())\n";
+            out << "    {\n";
+            out << "    }\n\n";
+            emitted_parameterless_ctor = true;
+        }
+        else if (cls.fields.empty()) {
             out << "    public " << cls.name << "()";
             if (cls.base_kind == AstNodeBaseKind::pltxt_node && cls.node_type.has_value()) {
                 out << " : base(NodeType." << *cls.node_type << ")";
@@ -658,17 +665,26 @@ constexpr void emit_astnode_class(::llvm::raw_string_ostream& out, AstNodeClassS
             out << "\n";
             out << "    {\n";
             out << "    }\n\n";
+            emitted_parameterless_ctor = true;
         }
-        else if (cls.fields.size() == 1 && cls.fields.front().csharp_type == "Ast") {
+        else if (cls.base_kind == AstNodeBaseKind::plain && cls.fields.size() == 1 &&
+                 cls.fields.front().csharp_type == "Ast") {
             out << "    public " << cls.name << "() : this(new Ast())\n";
             out << "    {\n";
             out << "    }\n\n";
         }
     }
 
-    out << "    public " << cls.name << "(";
+    bool needs_subast_param = cls.base_kind == AstNodeBaseKind::paired_tag;
+    bool has_field_params = !cls.fields.empty();
+    if (emitted_parameterless_ctor && !needs_subast_param && !has_field_params) {
+        out << "}\n\n";
+        return;
+    }
+
     bool need_comma = false;
-    if (cls.base_kind == AstNodeBaseKind::paired_tag) {
+    out << "    public " << cls.name << "(";
+    if (needs_subast_param) {
         out << "Ast subast";
         need_comma = true;
     }


### PR DESCRIPTION
### Motivation
- The C# output generator produced invalid or duplicate parameterless constructors for AST node classes, and paired-tag classes could get parameterless constructors that didn't initialize the `PairedTagBase` correctly.
- This produced broken generated C# (duplicate `InvalidU8Char()` and uninitialized paired-tag constructors) which must be fixed in the translator emission logic.

### Description
- Updated the constructor emission logic in `translang/csharp/src/main.cc` to track when a parameterless constructor was already emitted via an `emitted_parameterless_ctor` flag.
- Emit paired-tag default constructors as `: this(new Ast())` when appropriate so `PairedTagBase` is initialized correctly.
- Avoid emitting duplicate parameterless constructors by skipping emission of the full parameter constructor when a parameterless one was already produced for classes without params.
- Restrict the `Ast` convenience parameterless ctor (`: this(new Ast())`) to plain classes with a single `Ast` field only.

### Testing
- Ran `git diff --check` to validate formatting/whitespace issues, which completed successfully.
- Ran `git status --short` to confirm the scope of local changes and observed only the intended translation source was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaeb36f410832ab5d078a00236d526)