### PR TITLE
Refactor parse_pltxt extraction to use a Clang AST visitor

### DIFF
--- a/translang/csharp/src/main.cc
+++ b/translang/csharp/src/main.cc
@@ -84,7 +84,10 @@ struct AstNodeModel {
 };
 
 struct ParsePltxtModel {
-    ::std::vector<::std::string> switch_node_types{};
+    struct CsharpSwitchCase {
+        ::std::string node_type{};
+    };
+    ::std::vector<CsharpSwitchCase> nested_tag_switch_cases{};
 };
 
 struct TranslationModel {
@@ -623,63 +626,68 @@ constexpr auto is_public_parse_pltxt_decl(::clang::FunctionDecl const* fd) -> bo
     return param_text.find("u8string_view") != ::std::string::npos;
 }
 
-constexpr void collect_parse_pltxt_case_labels(::clang::Stmt const* stmt, ::std::vector<::std::string>& out,
-                                               ::std::set<::std::string>& seen) {
-    if (stmt == nullptr) {
-        return;
+class ParsePltxtToCsharpAstVisitor : public ::clang::RecursiveASTVisitor<ParsePltxtToCsharpAstVisitor> {
+public:
+    constexpr explicit ParsePltxtToCsharpAstVisitor(ParsePltxtModel& out) noexcept
+        : out_(out) {
     }
-    if (auto const* case_stmt = ::llvm::dyn_cast<::clang::CaseStmt>(stmt)) {
-        if (auto node_type = extract_enum_constant_name(case_stmt->getLHS())) {
-            if (seen.insert(*node_type).second) {
-                out.push_back(*node_type);
-            }
-        }
-    }
-    for (auto const* child : stmt->children()) {
-        collect_parse_pltxt_case_labels(child, out, seen);
-    }
-}
 
-constexpr void maybe_collect_parse_pltxt_from_function(::clang::FunctionDecl const* fd, ParsePltxtModel& out,
-                                                       bool& collected) {
-    if (collected || !is_public_parse_pltxt_decl(fd)) {
-        return;
+    constexpr auto TraverseFunctionDecl(::clang::FunctionDecl* fd) -> bool {
+        if (fd == nullptr) {
+            return true;
+        }
+        auto const previous_in_target_function = in_target_function_;
+        if (!collected_ && is_public_parse_pltxt_decl(fd)) {
+            in_target_function_ = true;
+        }
+        auto const ok = ::clang::RecursiveASTVisitor<ParsePltxtToCsharpAstVisitor>::TraverseFunctionDecl(fd);
+        in_target_function_ = previous_in_target_function;
+        return ok;
     }
-    auto const* body = fd->getBody();
-    if (body == nullptr) {
-        return;
-    }
-    ::std::set<::std::string> seen{};
-    collect_parse_pltxt_case_labels(body, out.switch_node_types, seen);
-    collected = !out.switch_node_types.empty();
-}
 
-constexpr void collect_parse_pltxt_from_decl_context(::clang::DeclContext const* decl_context, ParsePltxtModel& out,
-                                                     bool& collected) {
-    for (auto const* decl : decl_context->decls()) {
-        if (collected) {
-            return;
+    constexpr auto TraverseSwitchStmt(::clang::SwitchStmt* switch_stmt) -> bool {
+        if (switch_stmt == nullptr) {
+            return true;
         }
-        if (auto const* nested = ::llvm::dyn_cast<::clang::DeclContext>(decl); nested != nullptr) {
-            collect_parse_pltxt_from_decl_context(nested, out, collected);
-            if (collected) {
-                return;
-            }
+        auto const previous_in_switch = in_target_switch_;
+        if (in_target_function_) {
+            in_target_switch_ = true;
         }
-        if (auto const* fd = ::llvm::dyn_cast<::clang::FunctionDecl>(decl); fd != nullptr) {
-            maybe_collect_parse_pltxt_from_function(fd, out, collected);
-            if (collected) {
-                return;
-            }
-        }
-        if (auto const* ftd = ::llvm::dyn_cast<::clang::FunctionTemplateDecl>(decl); ftd != nullptr) {
-            maybe_collect_parse_pltxt_from_function(ftd->getTemplatedDecl(), out, collected);
-            if (collected) {
-                return;
-            }
-        }
+        auto const ok = ::clang::RecursiveASTVisitor<ParsePltxtToCsharpAstVisitor>::TraverseSwitchStmt(switch_stmt);
+        in_target_switch_ = previous_in_switch;
+        return ok;
     }
-}
+
+    constexpr auto VisitCaseStmt(::clang::CaseStmt* case_stmt) -> bool {
+        if (!in_target_function_ || !in_target_switch_ || case_stmt == nullptr) {
+            return true;
+        }
+        if (auto node_type = extract_enum_constant_name(case_stmt->getLHS()); node_type.has_value()) {
+            if (seen_case_labels_.insert(*node_type).second) {
+                out_.nested_tag_switch_cases.push_back(ParsePltxtModel::CsharpSwitchCase{
+                    .node_type = *node_type,
+                });
+            }
+        }
+        return true;
+    }
+
+    [[nodiscard]]
+    constexpr auto collected() const noexcept -> bool {
+        return collected_ || !out_.nested_tag_switch_cases.empty();
+    }
+
+    constexpr void finalize() noexcept {
+        collected_ = !out_.nested_tag_switch_cases.empty();
+    }
+
+private:
+    ParsePltxtModel& out_;
+    bool in_target_function_{};
+    bool in_target_switch_{};
+    bool collected_{};
+    ::std::set<::std::string> seen_case_labels_{};
+};
 
 constexpr void emit_astnode_enum(::llvm::raw_string_ostream& out, AstNodeModel const& astnode_model) {
     out << "public enum NodeType\n";
@@ -858,12 +866,13 @@ constexpr void emit_parse_pltxt_translation(::llvm::raw_string_ostream& out, Tra
     out << "            var subast = ParsePltxtDetails(callStack);\n";
     out << "            switch (typeOfSubast)\n";
     out << "            {\n";
-    for (auto const& node_type : model.parse_pltxt.switch_node_types) {
-        auto class_name = find_paired_tag_class_for_node_type(model.astnodes, node_type);
+    for (auto const& switch_case : model.parse_pltxt.nested_tag_switch_cases) {
+        auto class_name = find_paired_tag_class_for_node_type(model.astnodes, switch_case.node_type);
         if (!class_name.has_value()) {
-            terminate_internal_error("failed to map parse_pltxt switch node type to paired tag class: " + node_type);
+            terminate_internal_error("failed to map parse_pltxt switch node type to paired tag class: " +
+                                     switch_case.node_type);
         }
-        out << "            case NodeType." << node_type << ":\n";
+        out << "            case NodeType." << switch_case.node_type << ":\n";
         out << "                result.Nodes.Add(HeapGuard(new " << *class_name << "(subast)));\n";
         out << "                continue;\n";
     }
@@ -1103,9 +1112,10 @@ constexpr auto collect_parse_pltxt_model(Paths const& paths) -> ::llvm::Expected
         return ::llvm::createStringError(::std::errc::invalid_argument, "clang failed to parse include/pltxt2htm/parser.hh");
     }
     ParsePltxtModel model{};
-    bool collected{};
-    collect_parse_pltxt_from_decl_context(ast->getASTContext().getTranslationUnitDecl(), model, collected);
-    if (!collected) {
+    ParsePltxtToCsharpAstVisitor visitor(model);
+    visitor.TraverseDecl(ast->getASTContext().getTranslationUnitDecl());
+    visitor.finalize();
+    if (!visitor.collected()) {
         return ::llvm::createStringError(::std::errc::invalid_argument,
                                          "failed to derive parse_pltxt switch cases from include/pltxt2htm/parser.hh");
     }

--- a/translang/csharp/src/main.cc
+++ b/translang/csharp/src/main.cc
@@ -88,6 +88,8 @@ struct ParsePltxtModel {
         ::std::string node_type{};
     };
     ::std::vector<CsharpSwitchCase> nested_tag_switch_cases{};
+    ::std::string stack_var_name_csharp{"callStack"};
+    ::std::string stack_var_csharp_type{"Stack<BasicFrameContext>"};
 };
 
 struct TranslationModel {
@@ -398,6 +400,41 @@ constexpr auto extract_enum_constant_name(::clang::Expr const* expr) -> ::std::o
 }
 
 [[nodiscard]]
+constexpr auto csharp_type_for_parse_pltxt_local(::clang::QualType type) -> ::std::string {
+    type = type.getCanonicalType().getUnqualifiedType();
+    auto const* type_ptr = type.getTypePtrOrNull();
+    if (type_ptr == nullptr) {
+        return "object";
+    }
+    if (auto const* tst = ::llvm::dyn_cast<::clang::TemplateSpecializationType>(type_ptr)) {
+        if (auto const* template_decl = tst->getTemplateName().getAsTemplateDecl()) {
+            auto const qualified_name = template_decl->getQualifiedNameAsString();
+            if (qualified_name == "fast_io::stack" || qualified_name == "::fast_io::stack") {
+                if (tst->getNumArgs() == 1U && tst->getArg(0).getKind() == ::clang::TemplateArgument::Type) {
+                    return "Stack<" + csharp_type_for_parse_pltxt_local(tst->getArg(0).getAsType()) + ">";
+                }
+            }
+            if (qualified_name == "pltxt2htm::HeapGuard" || qualified_name == "::pltxt2htm::HeapGuard") {
+                if (tst->getNumArgs() == 1U && tst->getArg(0).getKind() == ::clang::TemplateArgument::Type) {
+                    return csharp_type_for_parse_pltxt_local(tst->getArg(0).getAsType());
+                }
+            }
+        }
+    }
+    if (auto const* record_type = type->getAs<::clang::RecordType>()) {
+        if (auto const* decl = record_type->getDecl()) {
+            auto const qualified_name = decl->getQualifiedNameAsString();
+            if (qualified_name == "pltxt2htm::details::BasicFrameContext" ||
+                qualified_name == "::pltxt2htm::details::BasicFrameContext") {
+                return "BasicFrameContext";
+            }
+            return decl->getNameAsString();
+        }
+    }
+    return csharp_type_for_field(type);
+}
+
+[[nodiscard]]
 constexpr auto is_derived_from(::clang::CXXRecordDecl const* decl, ::llvm::StringRef qualified_name) -> bool {
     for (auto const& base : decl->bases()) {
         auto const* base_decl = base.getType()->getAsCXXRecordDecl();
@@ -672,6 +709,20 @@ public:
         return true;
     }
 
+    constexpr auto VisitVarDecl(::clang::VarDecl* var_decl) -> bool {
+        if (!in_target_function_ || var_decl == nullptr || captured_stack_decl_) {
+            return true;
+        }
+        auto const mapped_type = csharp_type_for_parse_pltxt_local(var_decl->getType());
+        if (!::llvm::StringRef{mapped_type}.starts_with("Stack<")) {
+            return true;
+        }
+        out_.stack_var_name_csharp = to_camel_case(var_decl->getNameAsString());
+        out_.stack_var_csharp_type = mapped_type;
+        captured_stack_decl_ = true;
+        return true;
+    }
+
     [[nodiscard]]
     constexpr auto collected() const noexcept -> bool {
         return collected_ || !out_.nested_tag_switch_cases.empty();
@@ -686,6 +737,7 @@ private:
     bool in_target_function_{};
     bool in_target_switch_{};
     bool collected_{};
+    bool captured_stack_decl_{};
     ::std::set<::std::string> seen_case_labels_{};
 };
 
@@ -848,22 +900,30 @@ constexpr auto find_paired_tag_class_for_node_type(AstNodeModel const& astnode_m
 }
 
 constexpr void emit_parse_pltxt_translation(::llvm::raw_string_ostream& out, TranslationModel const& model) {
+    auto const stack_var_name = model.parse_pltxt.stack_var_name_csharp.empty() ? ::llvm::StringRef{"callStack"}
+                                                                                 : ::llvm::StringRef{
+                                                                                       model.parse_pltxt
+                                                                                           .stack_var_name_csharp};
+    auto const stack_var_type =
+        model.parse_pltxt.stack_var_csharp_type.empty() ? ::llvm::StringRef{"Stack<BasicFrameContext>"}
+                                                        : ::llvm::StringRef{model.parse_pltxt.stack_var_csharp_type};
     out << "    internal static Ast ParsePltxt(string pltext)\n";
     out << "    {\n";
-    out << "        var callStack = new Stack<BasicFrameContext>();\n";
+    out << "        var " << stack_var_name << " = new " << stack_var_type << "();\n";
     out << "        var result = new Ast();\n\n";
     out << "        ulong startIndex = 0;\n\n";
     out << "        while (true)\n";
     out << "        {\n";
     out << "            var (forwardIndex, hasNewFrame) = DevilStuffAfterLineBreak(U8StringViewSubview(pltext, "
-           "startIndex), callStack, result);\n";
+           "startIndex), "
+        << stack_var_name << ", result);\n";
     out << "            startIndex += forwardIndex;\n";
     out << "            if (!hasNewFrame)\n";
     out << "            {\n";
     out << "                break;\n";
     out << "            }\n";
-    out << "            var typeOfSubast = callStack.Peek().NestedTagType;\n";
-    out << "            var subast = ParsePltxtDetails(callStack);\n";
+    out << "            var typeOfSubast = " << stack_var_name << ".Peek().NestedTagType;\n";
+    out << "            var subast = ParsePltxtDetails(" << stack_var_name << ");\n";
     out << "            switch (typeOfSubast)\n";
     out << "            {\n";
     for (auto const& switch_case : model.parse_pltxt.nested_tag_switch_cases) {
@@ -883,11 +943,12 @@ constexpr void emit_parse_pltxt_translation(::llvm::raw_string_ostream& out, Tra
     out << "        }\n\n";
     out << "        if (startIndex < (ulong)pltext.Length)\n";
     out << "        {\n";
-    out << "            callStack.Push(HeapGuard(new BareTagContext(U8StringViewSubview(pltext, startIndex), "
+    out << "            " << stack_var_name
+        << ".Push(HeapGuard(new BareTagContext(U8StringViewSubview(pltext, startIndex), "
            "NodeType.base, result)));\n";
-    out << "            result = ParsePltxtDetails(callStack);\n";
+    out << "            result = ParsePltxtDetails(" << stack_var_name << ");\n";
     out << "        }\n\n";
-    out << "        var callStackIsEmpty = callStack.Count == 0;\n";
+    out << "        var callStackIsEmpty = " << stack_var_name << ".Count == 0;\n";
     out << "        Pltxt2Assert(callStackIsEmpty, \"call_stack is not empty\");\n\n";
     out << "        return result;\n";
     out << "    }\n\n";
@@ -900,9 +961,9 @@ constexpr void emit_parse_pltxt_translation(::llvm::raw_string_ostream& out, Tra
     out << "        return text[(int)startIndex..];\n";
     out << "    }\n\n";
     out << "    private static (ulong forwardIndex, bool hasNewFrame) DevilStuffAfterLineBreak(string pltextView, "
-           "Stack<BasicFrameContext> callStack, Ast result) => throw new NotImplementedException(\"Translate "
+        << stack_var_type << " " << stack_var_name << ", Ast result) => throw new NotImplementedException(\"Translate "
            "details::devil_stuff_after_line_break from parser.hh.\");\n";
-    out << "    private static Ast ParsePltxtDetails(Stack<BasicFrameContext> callStack) => throw new "
+    out << "    private static Ast ParsePltxtDetails(" << stack_var_type << " " << stack_var_name << ") => throw new "
            "NotImplementedException(\"Translate details::parse_pltxt from details/parser/parser.hh.\");\n";
     out << "    private static void Pltxt2Assert(bool condition, string message)\n";
     out << "    {\n";


### PR DESCRIPTION
### Motivation
- Replace the ad-hoc, string-based extraction of `parse_pltxt` switch labels and the large hardcoded C# emission with a structured clang-AST-driven extraction so the translator produces a cleaner, more maintainable C# AST model for code generation.

### Description
- Introduced `ParsePltxtModel::CsharpSwitchCase` and replaced the raw `switch_node_types` vector with `nested_tag_switch_cases` that hold structured C#-oriented case data.
- Added `ParsePltxtToCsharpAstVisitor` (a `clang::RecursiveASTVisitor`) which tracks traversal into the target `pltxt2htm::parse_pltxt` function and its switch statements and collects unique `case` enum labels via `TraverseFunctionDecl`, `TraverseSwitchStmt`, and `VisitCaseStmt`.
- Removed the previous manual recursive decl/stmt scanning functions and changed `collect_parse_pltxt_model` to run the new visitor (`TraverseDecl` + `finalize/collected` checks).
- Updated `emit_parse_pltxt_translation` to consume `nested_tag_switch_cases` and emit the C# `switch`/case branches by mapping each collected `NodeType` to the corresponding paired-tag C# class.

### Testing
- Attempted an automated build of the C# translator (`cmake -S translang/csharp -B /tmp/pltxt2htm-csharp-build && cmake --build ...`), but configuration failed because the environment CMake is 3.28.3 while the project requires CMake 3.29 or newer, so the build did not complete (failure).
- No other automated tests were executed in this environment due to the configuration/build failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb102b41d0832aae607d3662d28b0d)