### PR TITLE
support html table tags

### DIFF
--- a/include/pltxt2htm/ast/ast.hh
+++ b/include/pltxt2htm/ast/ast.hh
@@ -60,6 +60,18 @@ class PlTxtNode {
         ::pltxt2htm::Pre<ndebug> pre_node;
         ::pltxt2htm::Blockquote<ndebug> blockquote_node;
 
+        // html table node
+        ::pltxt2htm::Col col_node;
+        ::pltxt2htm::Table<ndebug> table_node;
+        ::pltxt2htm::Caption<ndebug> caption_node;
+        ::pltxt2htm::Colgroup<ndebug> colgroup_node;
+        ::pltxt2htm::Thead<ndebug> thead_node;
+        ::pltxt2htm::Tbody<ndebug> tbody_node;
+        ::pltxt2htm::Tfoot<ndebug> tfoot_node;
+        ::pltxt2htm::Tr<ndebug> tr_node;
+        ::pltxt2htm::Th<ndebug> th_node;
+        ::pltxt2htm::Td<ndebug> td_node;
+
         // markdown node
         ::pltxt2htm::MdAtxH1<ndebug> md_atx_h1_node;
         ::pltxt2htm::MdAtxH2<ndebug> md_atx_h2_node;
@@ -353,6 +365,56 @@ public:
     constexpr PlTxtNode(::pltxt2htm::Blockquote<ndebug>&& node) noexcept
         : blockquote_node(::std::move(node)),
           node_kind{::pltxt2htm::NodeKind::html_blockquote} {
+    }
+
+    constexpr PlTxtNode(::pltxt2htm::Col&& node) noexcept
+        : col_node(::std::move(node)),
+          node_kind{::pltxt2htm::NodeKind::html_col} {
+    }
+
+    constexpr PlTxtNode(::pltxt2htm::Table<ndebug>&& node) noexcept
+        : table_node(::std::move(node)),
+          node_kind{::pltxt2htm::NodeKind::html_table} {
+    }
+
+    constexpr PlTxtNode(::pltxt2htm::Caption<ndebug>&& node) noexcept
+        : caption_node(::std::move(node)),
+          node_kind{::pltxt2htm::NodeKind::html_caption} {
+    }
+
+    constexpr PlTxtNode(::pltxt2htm::Colgroup<ndebug>&& node) noexcept
+        : colgroup_node(::std::move(node)),
+          node_kind{::pltxt2htm::NodeKind::html_colgroup} {
+    }
+
+    constexpr PlTxtNode(::pltxt2htm::Thead<ndebug>&& node) noexcept
+        : thead_node(::std::move(node)),
+          node_kind{::pltxt2htm::NodeKind::html_thead} {
+    }
+
+    constexpr PlTxtNode(::pltxt2htm::Tbody<ndebug>&& node) noexcept
+        : tbody_node(::std::move(node)),
+          node_kind{::pltxt2htm::NodeKind::html_tbody} {
+    }
+
+    constexpr PlTxtNode(::pltxt2htm::Tfoot<ndebug>&& node) noexcept
+        : tfoot_node(::std::move(node)),
+          node_kind{::pltxt2htm::NodeKind::html_tfoot} {
+    }
+
+    constexpr PlTxtNode(::pltxt2htm::Tr<ndebug>&& node) noexcept
+        : tr_node(::std::move(node)),
+          node_kind{::pltxt2htm::NodeKind::html_tr} {
+    }
+
+    constexpr PlTxtNode(::pltxt2htm::Th<ndebug>&& node) noexcept
+        : th_node(::std::move(node)),
+          node_kind{::pltxt2htm::NodeKind::html_th} {
+    }
+
+    constexpr PlTxtNode(::pltxt2htm::Td<ndebug>&& node) noexcept
+        : td_node(::std::move(node)),
+          node_kind{::pltxt2htm::NodeKind::html_td} {
     }
 
     constexpr PlTxtNode(::pltxt2htm::MdAtxH1<ndebug>&& node) noexcept
@@ -861,6 +923,57 @@ public:
             new (::std::addressof(blockquote_node))::pltxt2htm::Blockquote(::std::move(other.blockquote_node));
             break;
         }
+
+        case ::pltxt2htm::NodeKind::html_col: {
+            new (::std::addressof(col_node))::pltxt2htm::Col(::std::move(other.col_node));
+            break;
+        }
+
+        case ::pltxt2htm::NodeKind::html_table: {
+            new (::std::addressof(table_node))::pltxt2htm::Table(::std::move(other.table_node));
+            break;
+        }
+
+        case ::pltxt2htm::NodeKind::html_caption: {
+            new (::std::addressof(caption_node))::pltxt2htm::Caption(::std::move(other.caption_node));
+            break;
+        }
+
+        case ::pltxt2htm::NodeKind::html_colgroup: {
+            new (::std::addressof(colgroup_node))::pltxt2htm::Colgroup(::std::move(other.colgroup_node));
+            break;
+        }
+
+        case ::pltxt2htm::NodeKind::html_thead: {
+            new (::std::addressof(thead_node))::pltxt2htm::Thead(::std::move(other.thead_node));
+            break;
+        }
+
+        case ::pltxt2htm::NodeKind::html_tbody: {
+            new (::std::addressof(tbody_node))::pltxt2htm::Tbody(::std::move(other.tbody_node));
+            break;
+        }
+
+        case ::pltxt2htm::NodeKind::html_tfoot: {
+            new (::std::addressof(tfoot_node))::pltxt2htm::Tfoot(::std::move(other.tfoot_node));
+            break;
+        }
+
+        case ::pltxt2htm::NodeKind::html_tr: {
+            new (::std::addressof(tr_node))::pltxt2htm::Tr(::std::move(other.tr_node));
+            break;
+        }
+
+        case ::pltxt2htm::NodeKind::html_th: {
+            new (::std::addressof(th_node))::pltxt2htm::Th(::std::move(other.th_node));
+            break;
+        }
+
+        case ::pltxt2htm::NodeKind::html_td: {
+            new (::std::addressof(td_node))::pltxt2htm::Td(::std::move(other.td_node));
+            break;
+        }
+
         case ::pltxt2htm::NodeKind::md_atx_h1: {
             new (::std::addressof(md_atx_h1_node))::pltxt2htm::MdAtxH1(::std::move(other.md_atx_h1_node));
             break;
@@ -1308,6 +1421,47 @@ public:
         case ::pltxt2htm::NodeKind::html_blockquote:
             blockquote_node.~Blockquote();
             break;
+
+        case ::pltxt2htm::NodeKind::html_col:
+            col_node.~Col();
+            break;
+
+        case ::pltxt2htm::NodeKind::html_table:
+            table_node.~Table();
+            break;
+
+        case ::pltxt2htm::NodeKind::html_caption:
+            caption_node.~Caption();
+            break;
+
+        case ::pltxt2htm::NodeKind::html_colgroup:
+            colgroup_node.~Colgroup();
+            break;
+
+        case ::pltxt2htm::NodeKind::html_thead:
+            thead_node.~Thead();
+            break;
+
+        case ::pltxt2htm::NodeKind::html_tbody:
+            tbody_node.~Tbody();
+            break;
+
+        case ::pltxt2htm::NodeKind::html_tfoot:
+            tfoot_node.~Tfoot();
+            break;
+
+        case ::pltxt2htm::NodeKind::html_tr:
+            tr_node.~Tr();
+            break;
+
+        case ::pltxt2htm::NodeKind::html_th:
+            th_node.~Th();
+            break;
+
+        case ::pltxt2htm::NodeKind::html_td:
+            td_node.~Td();
+            break;
+
         case ::pltxt2htm::NodeKind::md_atx_h1:
             md_atx_h1_node.~MdAtxH1();
             break;
@@ -1618,6 +1772,25 @@ public:
             return ::std::forward_like<decltype(self)>(self.pre_node).get_subast();
         case ::pltxt2htm::NodeKind::html_blockquote:
             return ::std::forward_like<decltype(self)>(self.blockquote_node).get_subast();
+
+        case ::pltxt2htm::NodeKind::html_table:
+            return ::std::forward_like<decltype(self)>(self.table_node).get_subast();
+        case ::pltxt2htm::NodeKind::html_caption:
+            return ::std::forward_like<decltype(self)>(self.caption_node).get_subast();
+        case ::pltxt2htm::NodeKind::html_colgroup:
+            return ::std::forward_like<decltype(self)>(self.colgroup_node).get_subast();
+        case ::pltxt2htm::NodeKind::html_thead:
+            return ::std::forward_like<decltype(self)>(self.thead_node).get_subast();
+        case ::pltxt2htm::NodeKind::html_tbody:
+            return ::std::forward_like<decltype(self)>(self.tbody_node).get_subast();
+        case ::pltxt2htm::NodeKind::html_tfoot:
+            return ::std::forward_like<decltype(self)>(self.tfoot_node).get_subast();
+        case ::pltxt2htm::NodeKind::html_tr:
+            return ::std::forward_like<decltype(self)>(self.tr_node).get_subast();
+        case ::pltxt2htm::NodeKind::html_th:
+            return ::std::forward_like<decltype(self)>(self.th_node).get_subast();
+        case ::pltxt2htm::NodeKind::html_td:
+            return ::std::forward_like<decltype(self)>(self.td_node).get_subast();
 
         case ::pltxt2htm::NodeKind::md_atx_h1:
             return ::std::forward_like<decltype(self)>(self.md_atx_h1_node).get_subast();

--- a/include/pltxt2htm/ast/impl/html_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/html_node_decl.hh
@@ -73,6 +73,11 @@ class DoubleQuotationMark {};
 class Hr {};
 
 /**
+ * @brief HTML &lt;col&gt; self-closing column node
+ */
+class Col {};
+
+/**
  * @brief HTML &lt;h1&gt; heading node
  * @details Represents a level‑1 heading containing sub‑AST content.
  */
@@ -462,6 +467,213 @@ public:
         -> ::pltxt2htm::Blockquote<ndebug>& = delete;
     constexpr auto operator=(this ::pltxt2htm::Blockquote<ndebug>& self, ::pltxt2htm::Blockquote<ndebug>&&) noexcept
         -> ::pltxt2htm::Blockquote<ndebug>&;
+
+    [[nodiscard]]
+    constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.subast);
+    }
+};
+
+/**
+ * @brief HTML &lt;table&gt; table node
+ */
+template<::pltxt2htm::Contracts ndebug>
+class Table {
+    ::pltxt2htm::Ast<ndebug> subast{};
+
+public:
+    constexpr Table() noexcept = delete;
+    constexpr explicit Table(::pltxt2htm::Ast<ndebug>&& subast_) noexcept;
+    constexpr Table(::pltxt2htm::Table<ndebug> const&) noexcept = delete;
+    constexpr Table(::pltxt2htm::Table<ndebug>&&) noexcept;
+    constexpr ~Table() noexcept;
+    constexpr auto operator=(::pltxt2htm::Table<ndebug> const&) noexcept -> ::pltxt2htm::Table<ndebug>& = delete;
+    constexpr auto operator=(this ::pltxt2htm::Table<ndebug>& self, ::pltxt2htm::Table<ndebug>&&) noexcept
+        -> ::pltxt2htm::Table<ndebug>&;
+
+    [[nodiscard]]
+    constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.subast);
+    }
+};
+
+/**
+ * @brief HTML &lt;tr&gt; table row node
+ */
+template<::pltxt2htm::Contracts ndebug>
+class Tr {
+    ::pltxt2htm::Ast<ndebug> subast{};
+
+public:
+    constexpr Tr() noexcept = delete;
+    constexpr explicit Tr(::pltxt2htm::Ast<ndebug>&& subast_) noexcept;
+    constexpr Tr(::pltxt2htm::Tr<ndebug> const&) noexcept = delete;
+    constexpr Tr(::pltxt2htm::Tr<ndebug>&&) noexcept;
+    constexpr ~Tr() noexcept;
+    constexpr auto operator=(::pltxt2htm::Tr<ndebug> const&) noexcept -> ::pltxt2htm::Tr<ndebug>& = delete;
+    constexpr auto operator=(this ::pltxt2htm::Tr<ndebug>& self, ::pltxt2htm::Tr<ndebug>&&) noexcept
+        -> ::pltxt2htm::Tr<ndebug>&;
+
+    [[nodiscard]]
+    constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.subast);
+    }
+};
+
+/**
+ * @brief HTML &lt;td&gt; table data cell node
+ */
+template<::pltxt2htm::Contracts ndebug>
+class Td {
+    ::pltxt2htm::Ast<ndebug> subast{};
+
+public:
+    constexpr Td() noexcept = delete;
+    constexpr explicit Td(::pltxt2htm::Ast<ndebug>&& subast_) noexcept;
+    constexpr Td(::pltxt2htm::Td<ndebug> const&) noexcept = delete;
+    constexpr Td(::pltxt2htm::Td<ndebug>&&) noexcept;
+    constexpr ~Td() noexcept;
+    constexpr auto operator=(::pltxt2htm::Td<ndebug> const&) noexcept -> ::pltxt2htm::Td<ndebug>& = delete;
+    constexpr auto operator=(this ::pltxt2htm::Td<ndebug>& self, ::pltxt2htm::Td<ndebug>&&) noexcept
+        -> ::pltxt2htm::Td<ndebug>&;
+
+    [[nodiscard]]
+    constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.subast);
+    }
+};
+
+/**
+ * @brief HTML &lt;th&gt; table header cell node
+ */
+template<::pltxt2htm::Contracts ndebug>
+class Th {
+    ::pltxt2htm::Ast<ndebug> subast{};
+
+public:
+    constexpr Th() noexcept = delete;
+    constexpr explicit Th(::pltxt2htm::Ast<ndebug>&& subast_) noexcept;
+    constexpr Th(::pltxt2htm::Th<ndebug> const&) noexcept = delete;
+    constexpr Th(::pltxt2htm::Th<ndebug>&&) noexcept;
+    constexpr ~Th() noexcept;
+    constexpr auto operator=(::pltxt2htm::Th<ndebug> const&) noexcept -> ::pltxt2htm::Th<ndebug>& = delete;
+    constexpr auto operator=(this ::pltxt2htm::Th<ndebug>& self, ::pltxt2htm::Th<ndebug>&&) noexcept
+        -> ::pltxt2htm::Th<ndebug>&;
+
+    [[nodiscard]]
+    constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.subast);
+    }
+};
+
+/**
+ * @brief HTML &lt;thead&gt; table head section node
+ */
+template<::pltxt2htm::Contracts ndebug>
+class Thead {
+    ::pltxt2htm::Ast<ndebug> subast{};
+
+public:
+    constexpr Thead() noexcept = delete;
+    constexpr explicit Thead(::pltxt2htm::Ast<ndebug>&& subast_) noexcept;
+    constexpr Thead(::pltxt2htm::Thead<ndebug> const&) noexcept = delete;
+    constexpr Thead(::pltxt2htm::Thead<ndebug>&&) noexcept;
+    constexpr ~Thead() noexcept;
+    constexpr auto operator=(::pltxt2htm::Thead<ndebug> const&) noexcept -> ::pltxt2htm::Thead<ndebug>& = delete;
+    constexpr auto operator=(this ::pltxt2htm::Thead<ndebug>& self, ::pltxt2htm::Thead<ndebug>&&) noexcept
+        -> ::pltxt2htm::Thead<ndebug>&;
+
+    [[nodiscard]]
+    constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.subast);
+    }
+};
+
+/**
+ * @brief HTML &lt;tbody&gt; table body section node
+ */
+template<::pltxt2htm::Contracts ndebug>
+class Tbody {
+    ::pltxt2htm::Ast<ndebug> subast{};
+
+public:
+    constexpr Tbody() noexcept = delete;
+    constexpr explicit Tbody(::pltxt2htm::Ast<ndebug>&& subast_) noexcept;
+    constexpr Tbody(::pltxt2htm::Tbody<ndebug> const&) noexcept = delete;
+    constexpr Tbody(::pltxt2htm::Tbody<ndebug>&&) noexcept;
+    constexpr ~Tbody() noexcept;
+    constexpr auto operator=(::pltxt2htm::Tbody<ndebug> const&) noexcept -> ::pltxt2htm::Tbody<ndebug>& = delete;
+    constexpr auto operator=(this ::pltxt2htm::Tbody<ndebug>& self, ::pltxt2htm::Tbody<ndebug>&&) noexcept
+        -> ::pltxt2htm::Tbody<ndebug>&;
+
+    [[nodiscard]]
+    constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.subast);
+    }
+};
+
+/**
+ * @brief HTML &lt;tfoot&gt; table foot section node
+ */
+template<::pltxt2htm::Contracts ndebug>
+class Tfoot {
+    ::pltxt2htm::Ast<ndebug> subast{};
+
+public:
+    constexpr Tfoot() noexcept = delete;
+    constexpr explicit Tfoot(::pltxt2htm::Ast<ndebug>&& subast_) noexcept;
+    constexpr Tfoot(::pltxt2htm::Tfoot<ndebug> const&) noexcept = delete;
+    constexpr Tfoot(::pltxt2htm::Tfoot<ndebug>&&) noexcept;
+    constexpr ~Tfoot() noexcept;
+    constexpr auto operator=(::pltxt2htm::Tfoot<ndebug> const&) noexcept -> ::pltxt2htm::Tfoot<ndebug>& = delete;
+    constexpr auto operator=(this ::pltxt2htm::Tfoot<ndebug>& self, ::pltxt2htm::Tfoot<ndebug>&&) noexcept
+        -> ::pltxt2htm::Tfoot<ndebug>&;
+
+    [[nodiscard]]
+    constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.subast);
+    }
+};
+
+/**
+ * @brief HTML &lt;caption&gt; table caption node
+ */
+template<::pltxt2htm::Contracts ndebug>
+class Caption {
+    ::pltxt2htm::Ast<ndebug> subast{};
+
+public:
+    constexpr Caption() noexcept = delete;
+    constexpr explicit Caption(::pltxt2htm::Ast<ndebug>&& subast_) noexcept;
+    constexpr Caption(::pltxt2htm::Caption<ndebug> const&) noexcept = delete;
+    constexpr Caption(::pltxt2htm::Caption<ndebug>&&) noexcept;
+    constexpr ~Caption() noexcept;
+    constexpr auto operator=(::pltxt2htm::Caption<ndebug> const&) noexcept -> ::pltxt2htm::Caption<ndebug>& = delete;
+    constexpr auto operator=(this ::pltxt2htm::Caption<ndebug>& self, ::pltxt2htm::Caption<ndebug>&&) noexcept
+        -> ::pltxt2htm::Caption<ndebug>&;
+
+    [[nodiscard]]
+    constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.subast);
+    }
+};
+
+/**
+ * @brief HTML &lt;colgroup&gt; table column group node
+ */
+template<::pltxt2htm::Contracts ndebug>
+class Colgroup {
+    ::pltxt2htm::Ast<ndebug> subast{};
+
+public:
+    constexpr Colgroup() noexcept = delete;
+    constexpr explicit Colgroup(::pltxt2htm::Ast<ndebug>&& subast_) noexcept;
+    constexpr Colgroup(::pltxt2htm::Colgroup<ndebug> const&) noexcept = delete;
+    constexpr Colgroup(::pltxt2htm::Colgroup<ndebug>&&) noexcept;
+    constexpr ~Colgroup() noexcept;
+    constexpr auto operator=(::pltxt2htm::Colgroup<ndebug> const&) noexcept -> ::pltxt2htm::Colgroup<ndebug>& = delete;
+    constexpr auto operator=(this ::pltxt2htm::Colgroup<ndebug>& self, ::pltxt2htm::Colgroup<ndebug>&&) noexcept
+        -> ::pltxt2htm::Colgroup<ndebug>&;
 
     [[nodiscard]]
     constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {

--- a/include/pltxt2htm/ast/impl/html_node_def.inc
+++ b/include/pltxt2htm/ast/impl/html_node_def.inc
@@ -239,4 +239,130 @@ constexpr auto ::pltxt2htm::Blockquote<ndebug>::operator=(this ::pltxt2htm::Bloc
                                                           ::pltxt2htm::Blockquote<ndebug>&&) noexcept
     -> ::pltxt2htm::Blockquote<ndebug>& = default;
 
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Table<ndebug>::Table(::pltxt2htm::Ast<ndebug>&& subast_) noexcept
+    : subast(::std::move(subast_)) {
+}
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Table<ndebug>::Table(::pltxt2htm::Table<ndebug>&&) noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Table<ndebug>::~Table() noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr auto ::pltxt2htm::Table<ndebug>::operator=(this ::pltxt2htm::Table<ndebug>& self,
+                                                     ::pltxt2htm::Table<ndebug>&&) noexcept
+    -> ::pltxt2htm::Table<ndebug>& = default;
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Tr<ndebug>::Tr(::pltxt2htm::Ast<ndebug>&& subast_) noexcept
+    : subast(::std::move(subast_)) {
+}
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Tr<ndebug>::Tr(::pltxt2htm::Tr<ndebug>&&) noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Tr<ndebug>::~Tr() noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr auto ::pltxt2htm::Tr<ndebug>::operator=(this ::pltxt2htm::Tr<ndebug>& self,
+                                                  ::pltxt2htm::Tr<ndebug>&&) noexcept
+    -> ::pltxt2htm::Tr<ndebug>& = default;
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Td<ndebug>::Td(::pltxt2htm::Ast<ndebug>&& subast_) noexcept
+    : subast(::std::move(subast_)) {
+}
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Td<ndebug>::Td(::pltxt2htm::Td<ndebug>&&) noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Td<ndebug>::~Td() noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr auto ::pltxt2htm::Td<ndebug>::operator=(this ::pltxt2htm::Td<ndebug>& self,
+                                                  ::pltxt2htm::Td<ndebug>&&) noexcept
+    -> ::pltxt2htm::Td<ndebug>& = default;
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Th<ndebug>::Th(::pltxt2htm::Ast<ndebug>&& subast_) noexcept
+    : subast(::std::move(subast_)) {
+}
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Th<ndebug>::Th(::pltxt2htm::Th<ndebug>&&) noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Th<ndebug>::~Th() noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr auto ::pltxt2htm::Th<ndebug>::operator=(this ::pltxt2htm::Th<ndebug>& self,
+                                                  ::pltxt2htm::Th<ndebug>&&) noexcept
+    -> ::pltxt2htm::Th<ndebug>& = default;
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Thead<ndebug>::Thead(::pltxt2htm::Ast<ndebug>&& subast_) noexcept
+    : subast(::std::move(subast_)) {
+}
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Thead<ndebug>::Thead(::pltxt2htm::Thead<ndebug>&&) noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Thead<ndebug>::~Thead() noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr auto ::pltxt2htm::Thead<ndebug>::operator=(this ::pltxt2htm::Thead<ndebug>& self,
+                                                     ::pltxt2htm::Thead<ndebug>&&) noexcept
+    -> ::pltxt2htm::Thead<ndebug>& = default;
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Tbody<ndebug>::Tbody(::pltxt2htm::Ast<ndebug>&& subast_) noexcept
+    : subast(::std::move(subast_)) {
+}
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Tbody<ndebug>::Tbody(::pltxt2htm::Tbody<ndebug>&&) noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Tbody<ndebug>::~Tbody() noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr auto ::pltxt2htm::Tbody<ndebug>::operator=(this ::pltxt2htm::Tbody<ndebug>& self,
+                                                     ::pltxt2htm::Tbody<ndebug>&&) noexcept
+    -> ::pltxt2htm::Tbody<ndebug>& = default;
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Tfoot<ndebug>::Tfoot(::pltxt2htm::Ast<ndebug>&& subast_) noexcept
+    : subast(::std::move(subast_)) {
+}
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Tfoot<ndebug>::Tfoot(::pltxt2htm::Tfoot<ndebug>&&) noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Tfoot<ndebug>::~Tfoot() noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr auto ::pltxt2htm::Tfoot<ndebug>::operator=(this ::pltxt2htm::Tfoot<ndebug>& self,
+                                                     ::pltxt2htm::Tfoot<ndebug>&&) noexcept
+    -> ::pltxt2htm::Tfoot<ndebug>& = default;
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Caption<ndebug>::Caption(::pltxt2htm::Ast<ndebug>&& subast_) noexcept
+    : subast(::std::move(subast_)) {
+}
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Caption<ndebug>::Caption(::pltxt2htm::Caption<ndebug>&&) noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Caption<ndebug>::~Caption() noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr auto ::pltxt2htm::Caption<ndebug>::operator=(this ::pltxt2htm::Caption<ndebug>& self,
+                                                       ::pltxt2htm::Caption<ndebug>&&) noexcept
+    -> ::pltxt2htm::Caption<ndebug>& = default;
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Colgroup<ndebug>::Colgroup(::pltxt2htm::Ast<ndebug>&& subast_) noexcept
+    : subast(::std::move(subast_)) {
+}
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Colgroup<ndebug>::Colgroup(::pltxt2htm::Colgroup<ndebug>&&) noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::Colgroup<ndebug>::~Colgroup() noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr auto ::pltxt2htm::Colgroup<ndebug>::operator=(this ::pltxt2htm::Colgroup<ndebug>& self,
+                                                        ::pltxt2htm::Colgroup<ndebug>&&) noexcept
+    -> ::pltxt2htm::Colgroup<ndebug>& = default;
+
 } // namespace pltxt2htm

--- a/include/pltxt2htm/ast/node_type.hh
+++ b/include/pltxt2htm/ast/node_type.hh
@@ -84,6 +84,18 @@ enum class NodeKind : ::std::size_t {
     html_pre, ///< Preformatted text: &lt;pre&gt;...&lt;/pre&gt;
     html_blockquote, ///< Block quote: &lt;blockquote&gt;...&lt;/blockquote&gt;
 
+    // HTML table elements
+    html_table, ///< HTML table: &lt;table&gt;...&lt;/table&gt;
+    html_tr, ///< HTML table row: &lt;tr&gt;...&lt;/tr&gt;
+    html_td, ///< HTML table cell: &lt;td&gt;...&lt;/td&gt;
+    html_th, ///< HTML table header cell: &lt;th&gt;...&lt;/th&gt;
+    html_thead, ///< HTML table head: &lt;thead&gt;...&lt;/thead&gt;
+    html_tbody, ///< HTML table body: &lt;tbody&gt;...&lt;/tbody&gt;
+    html_tfoot, ///< HTML table foot: &lt;tfoot&gt;...&lt;/tfoot&gt;
+    html_caption, ///< HTML table caption: &lt;caption&gt;...&lt;/caption&gt;
+    html_colgroup, ///< HTML table column group: &lt;colgroup&gt;...&lt;/colgroup&gt;
+    html_col, ///< HTML table column: &lt;col&gt; (self-closing)
+
     // Markdown ATX-style headers (# ## ### #### ##### ######)
     md_atx_h1, ///< Markdown level 1 heading: # Heading
     md_atx_h2, ///< Markdown level 2 heading: ## Heading

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -574,72 +574,72 @@ entry:
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_table: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                node.get_subast(), ::pltxt2htm::NodeKind::html_table, 0));
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_table, 0));
             ++current_index;
             constexpr ::fast_io::u8string_view start_tag = u8"<table>";
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_tr: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                node.get_subast(), ::pltxt2htm::NodeKind::html_tr, 0));
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_tr, 0));
             ++current_index;
             constexpr ::fast_io::u8string_view start_tag = u8"<tr>";
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_td: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                node.get_subast(), ::pltxt2htm::NodeKind::html_td, 0));
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_td, 0));
             ++current_index;
             constexpr ::fast_io::u8string_view start_tag = u8"<td>";
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_th: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                node.get_subast(), ::pltxt2htm::NodeKind::html_th, 0));
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_th, 0));
             ++current_index;
             constexpr ::fast_io::u8string_view start_tag = u8"<th>";
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_thead: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                node.get_subast(), ::pltxt2htm::NodeKind::html_thead, 0));
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_thead, 0));
             ++current_index;
             constexpr ::fast_io::u8string_view start_tag = u8"<thead>";
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_tbody: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                node.get_subast(), ::pltxt2htm::NodeKind::html_tbody, 0));
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_tbody, 0));
             ++current_index;
             constexpr ::fast_io::u8string_view start_tag = u8"<tbody>";
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_tfoot: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                node.get_subast(), ::pltxt2htm::NodeKind::html_tfoot, 0));
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_tfoot, 0));
             ++current_index;
             constexpr ::fast_io::u8string_view start_tag = u8"<tfoot>";
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_caption: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                node.get_subast(), ::pltxt2htm::NodeKind::html_caption, 0));
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_caption, 0));
             ++current_index;
             constexpr ::fast_io::u8string_view start_tag = u8"<caption>";
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_colgroup: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                node.get_subast(), ::pltxt2htm::NodeKind::html_colgroup, 0));
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_colgroup, 0));
             ++current_index;
             constexpr ::fast_io::u8string_view start_tag = u8"<colgroup>";
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -573,6 +573,83 @@ entry:
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
             goto entry;
         }
+        case ::pltxt2htm::NodeKind::html_table: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                node.get_subast(), ::pltxt2htm::NodeKind::html_table, 0));
+            ++current_index;
+            constexpr ::fast_io::u8string_view start_tag = u8"<table>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_tr: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                node.get_subast(), ::pltxt2htm::NodeKind::html_tr, 0));
+            ++current_index;
+            constexpr ::fast_io::u8string_view start_tag = u8"<tr>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_td: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                node.get_subast(), ::pltxt2htm::NodeKind::html_td, 0));
+            ++current_index;
+            constexpr ::fast_io::u8string_view start_tag = u8"<td>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_th: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                node.get_subast(), ::pltxt2htm::NodeKind::html_th, 0));
+            ++current_index;
+            constexpr ::fast_io::u8string_view start_tag = u8"<th>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_thead: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                node.get_subast(), ::pltxt2htm::NodeKind::html_thead, 0));
+            ++current_index;
+            constexpr ::fast_io::u8string_view start_tag = u8"<thead>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_tbody: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                node.get_subast(), ::pltxt2htm::NodeKind::html_tbody, 0));
+            ++current_index;
+            constexpr ::fast_io::u8string_view start_tag = u8"<tbody>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_tfoot: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                node.get_subast(), ::pltxt2htm::NodeKind::html_tfoot, 0));
+            ++current_index;
+            constexpr ::fast_io::u8string_view start_tag = u8"<tfoot>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_caption: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                node.get_subast(), ::pltxt2htm::NodeKind::html_caption, 0));
+            ++current_index;
+            constexpr ::fast_io::u8string_view start_tag = u8"<caption>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_colgroup: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                node.get_subast(), ::pltxt2htm::NodeKind::html_colgroup, 0));
+            ++current_index;
+            constexpr ::fast_io::u8string_view start_tag = u8"<colgroup>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_col: {
+            constexpr ::fast_io::u8string_view start_tag = u8"<col>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            continue;
+        }
         case ::pltxt2htm::NodeKind::md_triple_emphasis_underscore:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_triple_emphasis_asterisk: {
@@ -893,6 +970,51 @@ entry:
             goto entry;
         }
         case ::pltxt2htm::NodeKind::md_block_quotes: {
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_table: {
+            constexpr ::fast_io::u8string_view close_tag = u8"</table>";
+            result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_tr: {
+            constexpr ::fast_io::u8string_view close_tag = u8"</tr>";
+            result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_td: {
+            constexpr ::fast_io::u8string_view close_tag = u8"</td>";
+            result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_th: {
+            constexpr ::fast_io::u8string_view close_tag = u8"</th>";
+            result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_thead: {
+            constexpr ::fast_io::u8string_view close_tag = u8"</thead>";
+            result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_tbody: {
+            constexpr ::fast_io::u8string_view close_tag = u8"</tbody>";
+            result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_tfoot: {
+            constexpr ::fast_io::u8string_view close_tag = u8"</tfoot>";
+            result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_caption: {
+            constexpr ::fast_io::u8string_view close_tag = u8"</caption>";
+            result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_colgroup: {
+            constexpr ::fast_io::u8string_view close_tag = u8"</colgroup>";
+            result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_blockquote: {

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -679,72 +679,72 @@ entry:
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_table: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                node.get_subast(), ::pltxt2htm::NodeKind::html_table, 0));
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_table, 0));
             ++current_index;
             constexpr ::fast_io::u8string_view start_tag = u8"<table>";
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_tr: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                node.get_subast(), ::pltxt2htm::NodeKind::html_tr, 0));
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_tr, 0));
             ++current_index;
             constexpr ::fast_io::u8string_view start_tag = u8"<tr>";
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_td: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                node.get_subast(), ::pltxt2htm::NodeKind::html_td, 0));
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_td, 0));
             ++current_index;
             constexpr ::fast_io::u8string_view start_tag = u8"<td>";
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_th: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                node.get_subast(), ::pltxt2htm::NodeKind::html_th, 0));
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_th, 0));
             ++current_index;
             constexpr ::fast_io::u8string_view start_tag = u8"<th>";
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_thead: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                node.get_subast(), ::pltxt2htm::NodeKind::html_thead, 0));
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_thead, 0));
             ++current_index;
             constexpr ::fast_io::u8string_view start_tag = u8"<thead>";
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_tbody: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                node.get_subast(), ::pltxt2htm::NodeKind::html_tbody, 0));
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_tbody, 0));
             ++current_index;
             constexpr ::fast_io::u8string_view start_tag = u8"<tbody>";
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_tfoot: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                node.get_subast(), ::pltxt2htm::NodeKind::html_tfoot, 0));
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_tfoot, 0));
             ++current_index;
             constexpr ::fast_io::u8string_view start_tag = u8"<tfoot>";
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_caption: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                node.get_subast(), ::pltxt2htm::NodeKind::html_caption, 0));
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_caption, 0));
             ++current_index;
             constexpr ::fast_io::u8string_view start_tag = u8"<caption>";
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_colgroup: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                node.get_subast(), ::pltxt2htm::NodeKind::html_colgroup, 0));
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_colgroup, 0));
             ++current_index;
             constexpr ::fast_io::u8string_view start_tag = u8"<colgroup>";
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -678,6 +678,83 @@ entry:
             result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
             goto entry;
         }
+        case ::pltxt2htm::NodeKind::html_table: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                node.get_subast(), ::pltxt2htm::NodeKind::html_table, 0));
+            ++current_index;
+            constexpr ::fast_io::u8string_view start_tag = u8"<table>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_tr: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                node.get_subast(), ::pltxt2htm::NodeKind::html_tr, 0));
+            ++current_index;
+            constexpr ::fast_io::u8string_view start_tag = u8"<tr>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_td: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                node.get_subast(), ::pltxt2htm::NodeKind::html_td, 0));
+            ++current_index;
+            constexpr ::fast_io::u8string_view start_tag = u8"<td>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_th: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                node.get_subast(), ::pltxt2htm::NodeKind::html_th, 0));
+            ++current_index;
+            constexpr ::fast_io::u8string_view start_tag = u8"<th>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_thead: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                node.get_subast(), ::pltxt2htm::NodeKind::html_thead, 0));
+            ++current_index;
+            constexpr ::fast_io::u8string_view start_tag = u8"<thead>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_tbody: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                node.get_subast(), ::pltxt2htm::NodeKind::html_tbody, 0));
+            ++current_index;
+            constexpr ::fast_io::u8string_view start_tag = u8"<tbody>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_tfoot: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                node.get_subast(), ::pltxt2htm::NodeKind::html_tfoot, 0));
+            ++current_index;
+            constexpr ::fast_io::u8string_view start_tag = u8"<tfoot>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_caption: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                node.get_subast(), ::pltxt2htm::NodeKind::html_caption, 0));
+            ++current_index;
+            constexpr ::fast_io::u8string_view start_tag = u8"<caption>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_colgroup: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                node.get_subast(), ::pltxt2htm::NodeKind::html_colgroup, 0));
+            ++current_index;
+            constexpr ::fast_io::u8string_view start_tag = u8"<colgroup>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_col: {
+            constexpr ::fast_io::u8string_view start_tag = u8"<col>";
+            result.append(::fast_io::u8string_view(start_tag.begin(), start_tag.size()));
+            continue;
+        }
         case ::pltxt2htm::NodeKind::md_triple_emphasis_underscore:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_triple_emphasis_asterisk: {
@@ -1031,6 +1108,51 @@ entry:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_blockquote: {
             constexpr ::fast_io::u8string_view close_tag = u8"</blockquote>";
+            result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_table: {
+            constexpr ::fast_io::u8string_view close_tag = u8"</table>";
+            result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_tr: {
+            constexpr ::fast_io::u8string_view close_tag = u8"</tr>";
+            result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_td: {
+            constexpr ::fast_io::u8string_view close_tag = u8"</td>";
+            result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_th: {
+            constexpr ::fast_io::u8string_view close_tag = u8"</th>";
+            result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_thead: {
+            constexpr ::fast_io::u8string_view close_tag = u8"</thead>";
+            result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_tbody: {
+            constexpr ::fast_io::u8string_view close_tag = u8"</tbody>";
+            result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_tfoot: {
+            constexpr ::fast_io::u8string_view close_tag = u8"</tfoot>";
+            result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_caption: {
+            constexpr ::fast_io::u8string_view close_tag = u8"</caption>";
+            result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_colgroup: {
+            constexpr ::fast_io::u8string_view close_tag = u8"</colgroup>";
             result.append(::fast_io::u8string_view{close_tag.data(), close_tag.size()});
             goto entry;
         }

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -343,6 +343,26 @@ entry:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_blockquote:
             [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_table:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_tr:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_td:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_th:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_thead:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_tbody:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_tfoot:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_caption:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_colgroup:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_col:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_block_quotes:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_code_fence_backtick:

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -276,7 +276,9 @@ entry:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_hr:
             [[fallthrough]];
-        case ::pltxt2htm::NodeKind::html_note: {
+        case ::pltxt2htm::NodeKind::html_note:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_col: {
             continue;
         }
         case ::pltxt2htm::NodeKind::pl_external:
@@ -360,8 +362,6 @@ entry:
         case ::pltxt2htm::NodeKind::html_caption:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_colgroup:
-            [[fallthrough]];
-        case ::pltxt2htm::NodeKind::html_col:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_block_quotes:
             [[fallthrough]];

--- a/include/pltxt2htm/details/parser/frame_concext.hh
+++ b/include/pltxt2htm/details/parser/frame_concext.hh
@@ -208,6 +208,26 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_blockquote:
             [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_table:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_tr:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_td:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_th:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_thead:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_tbody:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_tfoot:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_caption:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_colgroup:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_col:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_atx_h1:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_atx_h2:
@@ -437,6 +457,26 @@ public:
         case ::pltxt2htm::NodeKind::html_pre:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_blockquote:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_table:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_tr:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_td:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_th:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_thead:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_tbody:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_tfoot:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_caption:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_colgroup:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_col:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_atx_h1:
             [[fallthrough]];
@@ -749,6 +789,26 @@ public:
         case ::pltxt2htm::NodeKind::html_pre:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_blockquote:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_table:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_tr:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_td:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_th:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_thead:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_tbody:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_tfoot:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_caption:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_colgroup:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_col:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_atx_h1:
             [[fallthrough]];

--- a/include/pltxt2htm/details/parser/md_list.hh
+++ b/include/pltxt2htm/details/parser/md_list.hh
@@ -744,8 +744,7 @@ constexpr auto optionally_to_md_list_ast(::fast_io::u8string_view pltext) noexce
         if (space_hierarchy > top_frame.space_hierarchy + 1) {
             call_stack.push(::pltxt2htm::details::MdListFrameContext<ndebug>{
                 item_kind, space_hierarchy,
-                ::pltxt2htm::details::u8string_view_subview<ndebug>(
-                    top_frame.pltext, current_index)});
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(top_frame.pltext, current_index)});
             auto&& child_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
             child_frame.md_list_ast.emplace_back(::pltxt2htm::details::MdListTextNode(::std::move(text)));
             continue;
@@ -769,7 +768,8 @@ constexpr auto optionally_to_md_list_ast(::fast_io::u8string_view pltext) noexce
         auto&& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
         switch (frame.get_item_kind()) {
         case ::pltxt2htm::details::MdUlListItemKind::ordered_item: {
-            parent_frame.md_list_ast.emplace_back(::pltxt2htm::details::MdListOlNode<ndebug>(::std::move(frame.md_list_ast)));
+            parent_frame.md_list_ast.emplace_back(
+                ::pltxt2htm::details::MdListOlNode<ndebug>(::std::move(frame.md_list_ast)));
             break;
         }
         case ::pltxt2htm::details::MdUlListItemKind::hyphen:
@@ -777,7 +777,8 @@ constexpr auto optionally_to_md_list_ast(::fast_io::u8string_view pltext) noexce
         case ::pltxt2htm::details::MdUlListItemKind::plus:
             [[fallthrough]];
         case ::pltxt2htm::details::MdUlListItemKind::asterisk: {
-            parent_frame.md_list_ast.emplace_back(::pltxt2htm::details::MdListUlNode<ndebug>(::std::move(frame.md_list_ast)));
+            parent_frame.md_list_ast.emplace_back(
+                ::pltxt2htm::details::MdListUlNode<ndebug>(::std::move(frame.md_list_ast)));
             break;
         }
 #if 0

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -627,8 +627,9 @@ entry:
                         ::pltxt2htm::NodeKind::html_code));
                     goto entry;
                 }
-                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"aption">(
-                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_caption_tag<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                        ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
                     opt_tag_len.has_value()) {
                     // parsing html <caption> tag
                     current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
@@ -637,8 +638,9 @@ entry:
                         ::pltxt2htm::NodeKind::html_caption));
                     goto entry;
                 }
-                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"olgroup">(
-                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_colgroup_tag<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                        ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
                     opt_tag_len.has_value()) {
                     // parsing html <colgroup> tag
                     current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
@@ -647,8 +649,9 @@ entry:
                         ::pltxt2htm::NodeKind::html_colgroup));
                     goto entry;
                 }
-                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_self_closing_tag<ndebug, u8"ol">(
-                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_col_tag<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                        ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
                     opt_tag_len.has_value()) {
                     // parsing html <col> self-closing tag
                     current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
@@ -944,8 +947,9 @@ entry:
                         ::pltxt2htm::NodeKind::html_table));
                     goto entry;
                 }
-                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"head">(
-                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_thead_tag<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                        ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
                     opt_tag_len.has_value()) {
                     current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                     call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
@@ -953,8 +957,9 @@ entry:
                         ::pltxt2htm::NodeKind::html_thead));
                     goto entry;
                 }
-                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"body">(
-                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_tbody_tag<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                        ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
                     opt_tag_len.has_value()) {
                     current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                     call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
@@ -962,8 +967,9 @@ entry:
                         ::pltxt2htm::NodeKind::html_tbody));
                     goto entry;
                 }
-                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"foot">(
-                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_tfoot_tag<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                        ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
                     opt_tag_len.has_value()) {
                     current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                     call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
@@ -971,8 +977,9 @@ entry:
                         ::pltxt2htm::NodeKind::html_tfoot));
                     goto entry;
                 }
-                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"r">(
-                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_tr_tag<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                        ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
                     opt_tag_len.has_value()) {
                     current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                     call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
@@ -980,8 +987,9 @@ entry:
                         ::pltxt2htm::NodeKind::html_tr));
                     goto entry;
                 }
-                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"h">(
-                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_th_tag<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                        ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
                     opt_tag_len.has_value()) {
                     current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                     call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
@@ -989,8 +997,9 @@ entry:
                         ::pltxt2htm::NodeKind::html_th));
                     goto entry;
                 }
-                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"d">(
-                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_td_tag<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                        ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
                     opt_tag_len.has_value()) {
                     current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                     call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -164,8 +164,7 @@ entry:
             // When the parent is another md_ul/md_ol (child nested inside a
             // parent list): no re-scan needed -- the parent iterates its own AST.
             auto&& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-            if (::pltxt2htm::details::is_md_list_ul_or_ol_type(
-                    parent_frame.get_nested_tag_type()) == false) {
+            if (::pltxt2htm::details::is_md_list_ul_or_ol_type(parent_frame.get_nested_tag_type()) == false) {
                 ::std::size_t& parent_index = parent_frame.current_index;
                 auto parent_text = parent_frame.get_pltext();
                 auto&& [fwd, restart] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
@@ -222,8 +221,7 @@ entry:
             // Same logic as the MdUl case above -- re-scan only when the parent is a
             // plain-text frame, not another md_ul/md_ol.
             auto&& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-            if (::pltxt2htm::details::is_md_list_ul_or_ol_type(
-                    parent_frame.get_nested_tag_type()) == false) {
+            if (::pltxt2htm::details::is_md_list_ul_or_ol_type(parent_frame.get_nested_tag_type()) == false) {
                 ::std::size_t& parent_index = parent_frame.current_index;
                 auto parent_text = parent_frame.get_pltext();
                 auto&& [fwd, restart] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
@@ -269,9 +267,7 @@ entry:
     auto&& result = top_frame.subast;
     ::std::size_t const pltext_size{pltext.size()};
 
-    if (top_frame.get_nested_tag_type() ==
-            ::pltxt2htm::NodeKind::md_block_quotes &&
-        current_index == 0) {
+    if (top_frame.get_nested_tag_type() == ::pltxt2htm::NodeKind::md_block_quotes && current_index == 0) {
         // https://spec.commonmark.org/0.31.2/#example-228
         // to support parsing md-atx-heading e.t.c inside md-block-quotes
         auto&& [forward_index, require_restart] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
@@ -1085,13 +1081,12 @@ entry:
                     if (opt_tag_len.has_value()) {
                         // parsing end tag </color> successed
                         ::std::size_t const staged_index{current_index};
-                        ::pltxt2htm::PlColor staged_node(
-                            ::std::move(result),
-                            ::std::move(frame.get_equal_sign_tag_id()));
+                        ::pltxt2htm::PlColor staged_node(::std::move(result),
+                                                         ::std::move(frame.get_equal_sign_tag_id()));
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlColor<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlColor<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1116,7 +1111,7 @@ entry:
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlA<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlA<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1132,13 +1127,12 @@ entry:
                         opt_tag_len.has_value()) {
                         // Whether or not extern_index is out of range, extern for loop will handle it correctly.
                         ::std::size_t const staged_index{current_index};
-                        ::pltxt2htm::PlExperiment staged_node(
-                            ::std::move(result),
-                            ::std::move(frame.get_equal_sign_tag_id()));
+                        ::pltxt2htm::PlExperiment staged_node(::std::move(result),
+                                                              ::std::move(frame.get_equal_sign_tag_id()));
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                                ::pltxt2htm::PlExperiment<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlExperiment<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1154,13 +1148,12 @@ entry:
                         opt_tag_len.has_value()) {
                         // Whether or not extern_index is out of range, extern for loop will handle it correctly.
                         ::std::size_t const staged_index{current_index};
-                        ::pltxt2htm::PlDiscussion staged_node(
-                            ::std::move(result),
-                            ::std::move(frame.get_equal_sign_tag_id()));
+                        ::pltxt2htm::PlDiscussion staged_node(::std::move(result),
+                                                              ::std::move(frame.get_equal_sign_tag_id()));
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                                ::pltxt2htm::PlDiscussion<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlDiscussion<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1176,13 +1169,12 @@ entry:
                         opt_tag_len.has_value()) {
                         // Whether or not extern_index is out of range, extern for loop will handle it correctly.
                         ::std::size_t const staged_index{current_index};
-                        ::pltxt2htm::PlExternal staged_node(
-                            ::std::move(result),
-                            ::std::move(frame.get_external_tag_url()));
+                        ::pltxt2htm::PlExternal staged_node(::std::move(result),
+                                                            ::std::move(frame.get_external_tag_url()));
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                                ::pltxt2htm::PlExternal<ndebug>{::std::move(staged_node)}));
+                        parent_frame.subast.push_back(
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlExternal<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1197,13 +1189,12 @@ entry:
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                         opt_tag_len.has_value()) {
                         ::std::size_t const staged_index{current_index};
-                        ::pltxt2htm::PlUser staged_node(
-                            ::std::move(result),
-                            ::std::move(frame.get_equal_sign_tag_id()));
+                        ::pltxt2htm::PlUser staged_node(::std::move(result),
+                                                        ::std::move(frame.get_equal_sign_tag_id()));
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlUser<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlUser<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1218,13 +1209,11 @@ entry:
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                         opt_tag_len.has_value()) {
                         ::std::size_t const staged_index{current_index};
-                        ::pltxt2htm::PlSize staged_node(
-                            ::std::move(result),
-                            frame.get_pl_size_tag_id());
+                        ::pltxt2htm::PlSize staged_node(::std::move(result), frame.get_pl_size_tag_id());
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlSize<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlSize<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1243,7 +1232,7 @@ entry:
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlB<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlB<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1262,7 +1251,7 @@ entry:
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlI<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlI<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1281,7 +1270,7 @@ entry:
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::P<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::P<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1300,7 +1289,7 @@ entry:
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::H1<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::H1<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1319,7 +1308,7 @@ entry:
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::H2<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::H2<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1338,7 +1327,7 @@ entry:
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::H3<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::H3<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1357,7 +1346,7 @@ entry:
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::H4<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::H4<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1376,7 +1365,7 @@ entry:
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::H5<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::H5<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1395,7 +1384,7 @@ entry:
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::H6<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::H6<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1414,7 +1403,7 @@ entry:
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Del<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Del<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1437,7 +1426,7 @@ entry:
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Em<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Em<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1456,7 +1445,7 @@ entry:
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Strong<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Strong<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1475,7 +1464,7 @@ entry:
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Ul<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Ul<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1494,7 +1483,7 @@ entry:
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Ol<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Ol<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1513,7 +1502,7 @@ entry:
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Li<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Li<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1532,7 +1521,7 @@ entry:
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Code<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Code<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1551,7 +1540,7 @@ entry:
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                         parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Pre<ndebug>{::std::move(staged_node)}));
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Pre<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1569,8 +1558,8 @@ entry:
                         ::pltxt2htm::Table staged_node(::std::move(result));
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                                ::pltxt2htm::Table<ndebug>{::std::move(staged_node)}));
+                        parent_frame.subast.push_back(
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Table<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1588,8 +1577,8 @@ entry:
                         ::pltxt2htm::Tr staged_node(::std::move(result));
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                                ::pltxt2htm::Tr<ndebug>{::std::move(staged_node)}));
+                        parent_frame.subast.push_back(
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Tr<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1607,8 +1596,8 @@ entry:
                         ::pltxt2htm::Td staged_node(::std::move(result));
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                                ::pltxt2htm::Td<ndebug>{::std::move(staged_node)}));
+                        parent_frame.subast.push_back(
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Td<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1626,8 +1615,8 @@ entry:
                         ::pltxt2htm::Th staged_node(::std::move(result));
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                                ::pltxt2htm::Th<ndebug>{::std::move(staged_node)}));
+                        parent_frame.subast.push_back(
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Th<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1645,8 +1634,8 @@ entry:
                         ::pltxt2htm::Thead staged_node(::std::move(result));
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                                ::pltxt2htm::Thead<ndebug>{::std::move(staged_node)}));
+                        parent_frame.subast.push_back(
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Thead<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1664,8 +1653,8 @@ entry:
                         ::pltxt2htm::Tbody staged_node(::std::move(result));
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                                ::pltxt2htm::Tbody<ndebug>{::std::move(staged_node)}));
+                        parent_frame.subast.push_back(
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Tbody<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1683,8 +1672,8 @@ entry:
                         ::pltxt2htm::Tfoot staged_node(::std::move(result));
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                                ::pltxt2htm::Tfoot<ndebug>{::std::move(staged_node)}));
+                        parent_frame.subast.push_back(
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Tfoot<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1702,8 +1691,8 @@ entry:
                         ::pltxt2htm::Caption staged_node(::std::move(result));
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                                ::pltxt2htm::Caption<ndebug>{::std::move(staged_node)}));
+                        parent_frame.subast.push_back(
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Caption<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1721,8 +1710,8 @@ entry:
                         ::pltxt2htm::Colgroup staged_node(::std::move(result));
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                                ::pltxt2htm::Colgroup<ndebug>{::std::move(staged_node)}));
+                        parent_frame.subast.push_back(
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Colgroup<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -1740,8 +1729,8 @@ entry:
                         ::pltxt2htm::Blockquote staged_node(::std::move(result));
                         call_stack.pop();
                         auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                                ::pltxt2htm::Blockquote<ndebug>{::std::move(staged_node)}));
+                        parent_frame.subast.push_back(
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Blockquote<ndebug>{::std::move(staged_node)}));
                         parent_frame.current_index +=
                             staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
                         goto entry;
@@ -2140,7 +2129,8 @@ entry:
             ::fast_io::u8string_view super_pltext{::pltxt2htm::details::stack_top<ndebug>(call_stack).get_pltext()};
             parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdAtxH1<ndebug>{::std::move(subast)}));
             auto&& [forward_index, _] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
-                ::pltxt2htm::details::u8string_view_subview<ndebug>(super_pltext, parent_index), call_stack, parent_ast);
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(super_pltext, parent_index), call_stack,
+                parent_ast);
             parent_index += forward_index;
             goto entry;
         }
@@ -2148,7 +2138,8 @@ entry:
             ::fast_io::u8string_view super_pltext{::pltxt2htm::details::stack_top<ndebug>(call_stack).get_pltext()};
             parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdAtxH2<ndebug>{::std::move(subast)}));
             auto&& [forward_index, _] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
-                ::pltxt2htm::details::u8string_view_subview<ndebug>(super_pltext, parent_index), call_stack, parent_ast);
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(super_pltext, parent_index), call_stack,
+                parent_ast);
             parent_index += forward_index;
             goto entry;
         }
@@ -2156,7 +2147,8 @@ entry:
             ::fast_io::u8string_view super_pltext{::pltxt2htm::details::stack_top<ndebug>(call_stack).get_pltext()};
             parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdAtxH3<ndebug>{::std::move(subast)}));
             auto&& [forward_index, _] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
-                ::pltxt2htm::details::u8string_view_subview<ndebug>(super_pltext, parent_index), call_stack, parent_ast);
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(super_pltext, parent_index), call_stack,
+                parent_ast);
             parent_index += forward_index;
             goto entry;
         }
@@ -2164,7 +2156,8 @@ entry:
             ::fast_io::u8string_view super_pltext{::pltxt2htm::details::stack_top<ndebug>(call_stack).get_pltext()};
             parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdAtxH4<ndebug>{::std::move(subast)}));
             auto&& [forward_index, _] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
-                ::pltxt2htm::details::u8string_view_subview<ndebug>(super_pltext, parent_index), call_stack, parent_ast);
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(super_pltext, parent_index), call_stack,
+                parent_ast);
             parent_index += forward_index;
             goto entry;
         }
@@ -2172,7 +2165,8 @@ entry:
             ::fast_io::u8string_view super_pltext{::pltxt2htm::details::stack_top<ndebug>(call_stack).get_pltext()};
             parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdAtxH5<ndebug>{::std::move(subast)}));
             auto&& [forward_index, _] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
-                ::pltxt2htm::details::u8string_view_subview<ndebug>(super_pltext, parent_index), call_stack, parent_ast);
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(super_pltext, parent_index), call_stack,
+                parent_ast);
             parent_index += forward_index;
             goto entry;
         }
@@ -2180,7 +2174,8 @@ entry:
             ::fast_io::u8string_view super_pltext{::pltxt2htm::details::stack_top<ndebug>(call_stack).get_pltext()};
             parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdAtxH6<ndebug>{::std::move(subast)}));
             auto&& [forward_index, _] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
-                ::pltxt2htm::details::u8string_view_subview<ndebug>(super_pltext, parent_index), call_stack, parent_ast);
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(super_pltext, parent_index), call_stack,
+                parent_ast);
             parent_index += forward_index;
             goto entry;
         }
@@ -2205,7 +2200,8 @@ entry:
             goto entry;
         }
         case ::pltxt2htm::NodeKind::md_latex_block: {
-            parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdLatexBlock<ndebug>{::std::move(subast)}));
+            parent_ast.push_back(
+                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdLatexBlock<ndebug>{::std::move(subast)}));
             goto entry;
         }
         case ::pltxt2htm::NodeKind::md_single_emphasis_asterisk: {

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -627,6 +627,35 @@ entry:
                         ::pltxt2htm::NodeKind::html_code));
                     goto entry;
                 }
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"aption">(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                    opt_tag_len.has_value()) {
+                    // parsing html <caption> tag
+                    current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                        ::pltxt2htm::NodeKind::html_caption));
+                    goto entry;
+                }
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"olgroup">(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                    opt_tag_len.has_value()) {
+                    // parsing html <colgroup> tag
+                    current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                        ::pltxt2htm::NodeKind::html_colgroup));
+                    goto entry;
+                }
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_self_closing_tag<ndebug, u8"ol">(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                    opt_tag_len.has_value()) {
+                    // parsing html <col> self-closing tag
+                    current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Col{}));
+                    ++current_index;
+                    continue;
+                }
                 result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
                 ++current_index;
                 continue;
@@ -896,6 +925,77 @@ entry:
                     call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                         ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
                         ::pltxt2htm::NodeKind::html_strong));
+                    goto entry;
+                }
+                result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                ++current_index;
+                continue;
+            }
+
+            case u8't':
+                [[fallthrough]];
+            case u8'T': {
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"able">(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                    opt_tag_len.has_value()) {
+                    current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                        ::pltxt2htm::NodeKind::html_table));
+                    goto entry;
+                }
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"head">(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                    opt_tag_len.has_value()) {
+                    current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                        ::pltxt2htm::NodeKind::html_thead));
+                    goto entry;
+                }
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"body">(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                    opt_tag_len.has_value()) {
+                    current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                        ::pltxt2htm::NodeKind::html_tbody));
+                    goto entry;
+                }
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"foot">(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                    opt_tag_len.has_value()) {
+                    current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                        ::pltxt2htm::NodeKind::html_tfoot));
+                    goto entry;
+                }
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"r">(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                    opt_tag_len.has_value()) {
+                    current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                        ::pltxt2htm::NodeKind::html_tr));
+                    goto entry;
+                }
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"h">(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                    opt_tag_len.has_value()) {
+                    current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                        ::pltxt2htm::NodeKind::html_th));
+                    goto entry;
+                }
+                if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"d">(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                    opt_tag_len.has_value()) {
+                    current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                        ::pltxt2htm::NodeKind::html_td));
                     goto entry;
                 }
                 result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
@@ -1451,6 +1551,177 @@ entry:
                     ++current_index;
                     continue;
                 }
+                case ::pltxt2htm::NodeKind::html_table: {
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"table">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // parsing end tag </table> successed
+                        ::std::size_t const staged_index{current_index};
+                        ::pltxt2htm::Table staged_node(::std::move(result));
+                        call_stack.pop();
+                        auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                                ::pltxt2htm::Table<ndebug>{::std::move(staged_node)}));
+                        parent_frame.current_index +=
+                            staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        goto entry;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+                case ::pltxt2htm::NodeKind::html_tr: {
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"tr">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // parsing end tag </tr> successed
+                        ::std::size_t const staged_index{current_index};
+                        ::pltxt2htm::Tr staged_node(::std::move(result));
+                        call_stack.pop();
+                        auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                                ::pltxt2htm::Tr<ndebug>{::std::move(staged_node)}));
+                        parent_frame.current_index +=
+                            staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        goto entry;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+                case ::pltxt2htm::NodeKind::html_td: {
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"td">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // parsing end tag </td> successed
+                        ::std::size_t const staged_index{current_index};
+                        ::pltxt2htm::Td staged_node(::std::move(result));
+                        call_stack.pop();
+                        auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                                ::pltxt2htm::Td<ndebug>{::std::move(staged_node)}));
+                        parent_frame.current_index +=
+                            staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        goto entry;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+                case ::pltxt2htm::NodeKind::html_th: {
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"th">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // parsing end tag </th> successed
+                        ::std::size_t const staged_index{current_index};
+                        ::pltxt2htm::Th staged_node(::std::move(result));
+                        call_stack.pop();
+                        auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                                ::pltxt2htm::Th<ndebug>{::std::move(staged_node)}));
+                        parent_frame.current_index +=
+                            staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        goto entry;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+                case ::pltxt2htm::NodeKind::html_thead: {
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"thead">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // parsing end tag </thead> successed
+                        ::std::size_t const staged_index{current_index};
+                        ::pltxt2htm::Thead staged_node(::std::move(result));
+                        call_stack.pop();
+                        auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                                ::pltxt2htm::Thead<ndebug>{::std::move(staged_node)}));
+                        parent_frame.current_index +=
+                            staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        goto entry;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+                case ::pltxt2htm::NodeKind::html_tbody: {
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"tbody">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // parsing end tag </tbody> successed
+                        ::std::size_t const staged_index{current_index};
+                        ::pltxt2htm::Tbody staged_node(::std::move(result));
+                        call_stack.pop();
+                        auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                                ::pltxt2htm::Tbody<ndebug>{::std::move(staged_node)}));
+                        parent_frame.current_index +=
+                            staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        goto entry;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+                case ::pltxt2htm::NodeKind::html_tfoot: {
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"tfoot">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // parsing end tag </tfoot> successed
+                        ::std::size_t const staged_index{current_index};
+                        ::pltxt2htm::Tfoot staged_node(::std::move(result));
+                        call_stack.pop();
+                        auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                                ::pltxt2htm::Tfoot<ndebug>{::std::move(staged_node)}));
+                        parent_frame.current_index +=
+                            staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        goto entry;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+                case ::pltxt2htm::NodeKind::html_caption: {
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"caption">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // parsing end tag </caption> successed
+                        ::std::size_t const staged_index{current_index};
+                        ::pltxt2htm::Caption staged_node(::std::move(result));
+                        call_stack.pop();
+                        auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                                ::pltxt2htm::Caption<ndebug>{::std::move(staged_node)}));
+                        parent_frame.current_index +=
+                            staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        goto entry;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+                case ::pltxt2htm::NodeKind::html_colgroup: {
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"colgroup">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // parsing end tag </colgroup> successed
+                        ::std::size_t const staged_index{current_index};
+                        ::pltxt2htm::Colgroup staged_node(::std::move(result));
+                        call_stack.pop();
+                        auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                        parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                                ::pltxt2htm::Colgroup<ndebug>{::std::move(staged_node)}));
+                        parent_frame.current_index +=
+                            staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        goto entry;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
                 case ::pltxt2htm::NodeKind::html_blockquote: {
                     if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"blockquote">(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
@@ -1517,6 +1788,8 @@ entry:
                 case ::pltxt2htm::NodeKind::html_br:
                     [[fallthrough]];
                 case ::pltxt2htm::NodeKind::html_hr:
+                    [[fallthrough]];
+                case ::pltxt2htm::NodeKind::html_col:
                     [[fallthrough]];
                 case ::pltxt2htm::NodeKind::md_li:
                     [[fallthrough]];
@@ -1804,6 +2077,51 @@ entry:
             parent_index += staged_index;
             goto entry;
         }
+        case ::pltxt2htm::NodeKind::html_table: {
+            parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Table<ndebug>{::std::move(subast)}));
+            parent_index += staged_index;
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_tr: {
+            parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Tr<ndebug>{::std::move(subast)}));
+            parent_index += staged_index;
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_td: {
+            parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Td<ndebug>{::std::move(subast)}));
+            parent_index += staged_index;
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_th: {
+            parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Th<ndebug>{::std::move(subast)}));
+            parent_index += staged_index;
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_thead: {
+            parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Thead<ndebug>{::std::move(subast)}));
+            parent_index += staged_index;
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_tbody: {
+            parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Tbody<ndebug>{::std::move(subast)}));
+            parent_index += staged_index;
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_tfoot: {
+            parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Tfoot<ndebug>{::std::move(subast)}));
+            parent_index += staged_index;
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_caption: {
+            parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Caption<ndebug>{::std::move(subast)}));
+            parent_index += staged_index;
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_colgroup: {
+            parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Colgroup<ndebug>{::std::move(subast)}));
+            parent_index += staged_index;
+            goto entry;
+        }
         case ::pltxt2htm::NodeKind::html_blockquote: {
             parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Blockquote<ndebug>{::std::move(subast)}));
             parent_index += staged_index;
@@ -1951,6 +2269,8 @@ entry:
         case ::pltxt2htm::NodeKind::html_br:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_hr:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_col:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_escape_backslash:
             [[fallthrough]];

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -459,22 +459,20 @@ constexpr auto try_parse_tfoot_tag(::fast_io::u8string_view pltext,
  * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
  * @param[in] pltext The input text to parse, starting after `<t`.
  * @param[in] nested_tag_type Current parent tag type from parsing context.
- * @return Matched tag length when valid under &lt;table&gt;,&lt;thead&gt;,&lt;tbody&gt;,or &lt;tfoot&gt;; otherwise nullopt.
+ * @return Matched tag length when valid under &lt;table&gt;,&lt;thead&gt;,&lt;tbody&gt;,or &lt;tfoot&gt;; otherwise
+ * nullopt.
  */
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
-constexpr auto try_parse_tr_tag(::fast_io::u8string_view pltext,
-                                ::pltxt2htm::NodeKind const nested_tag_type) noexcept
+constexpr auto try_parse_tr_tag(::fast_io::u8string_view pltext, ::pltxt2htm::NodeKind const nested_tag_type) noexcept
     -> ::exception::optional<::std::size_t> {
     auto opt_tag_len =
         ::pltxt2htm::details::try_parse_bare_tag<ndebug, ::pltxt2htm::details::U8LiteralString{u8"r"}>(pltext);
     if (!opt_tag_len.has_value()) {
         return ::exception::nullopt_t{};
     }
-    if (nested_tag_type != ::pltxt2htm::NodeKind::html_table &&
-        nested_tag_type != ::pltxt2htm::NodeKind::html_thead &&
-        nested_tag_type != ::pltxt2htm::NodeKind::html_tbody &&
-        nested_tag_type != ::pltxt2htm::NodeKind::html_tfoot) {
+    if (nested_tag_type != ::pltxt2htm::NodeKind::html_table && nested_tag_type != ::pltxt2htm::NodeKind::html_thead &&
+        nested_tag_type != ::pltxt2htm::NodeKind::html_tbody && nested_tag_type != ::pltxt2htm::NodeKind::html_tfoot) {
         return ::exception::nullopt_t{};
     }
     return opt_tag_len;
@@ -489,8 +487,7 @@ constexpr auto try_parse_tr_tag(::fast_io::u8string_view pltext,
  */
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
-constexpr auto try_parse_th_tag(::fast_io::u8string_view pltext,
-                                ::pltxt2htm::NodeKind const nested_tag_type) noexcept
+constexpr auto try_parse_th_tag(::fast_io::u8string_view pltext, ::pltxt2htm::NodeKind const nested_tag_type) noexcept
     -> ::exception::optional<::std::size_t> {
     auto opt_tag_len =
         ::pltxt2htm::details::try_parse_bare_tag<ndebug, ::pltxt2htm::details::U8LiteralString{u8"h"}>(pltext);
@@ -512,8 +509,7 @@ constexpr auto try_parse_th_tag(::fast_io::u8string_view pltext,
  */
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
-constexpr auto try_parse_td_tag(::fast_io::u8string_view pltext,
-                                ::pltxt2htm::NodeKind const nested_tag_type) noexcept
+constexpr auto try_parse_td_tag(::fast_io::u8string_view pltext, ::pltxt2htm::NodeKind const nested_tag_type) noexcept
     -> ::exception::optional<::std::size_t> {
     auto opt_tag_len =
         ::pltxt2htm::details::try_parse_bare_tag<ndebug, ::pltxt2htm::details::U8LiteralString{u8"d"}>(pltext);
@@ -796,8 +792,7 @@ constexpr auto try_parse_self_closing_tag(::fast_io::u8string_view pltext) noexc
  */
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
-constexpr auto try_parse_col_tag(::fast_io::u8string_view pltext,
-                                 ::pltxt2htm::NodeKind const nested_tag_type) noexcept
+constexpr auto try_parse_col_tag(::fast_io::u8string_view pltext, ::pltxt2htm::NodeKind const nested_tag_type) noexcept
     -> ::exception::optional<::std::size_t> {
     auto opt_tag_len =
         ::pltxt2htm::details::try_parse_self_closing_tag<ndebug, ::pltxt2htm::details::U8LiteralString{u8"ol"}>(pltext);

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -339,6 +339,193 @@ constexpr auto try_parse_li_tag(::fast_io::u8string_view pltext, ::pltxt2htm::No
     return opt_tag_len;
 }
 
+/**
+ * @brief Parse &lt;caption&gt; and validate parent container type.
+ * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
+ * @param[in] pltext The input text to parse, starting after `<c`.
+ * @param[in] nested_tag_type Current parent tag type from parsing context.
+ * @return Matched tag length when valid under &lt;table&gt;; otherwise nullopt.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_caption_tag(::fast_io::u8string_view pltext,
+                                     ::pltxt2htm::NodeKind const nested_tag_type) noexcept
+    -> ::exception::optional<::std::size_t> {
+    auto opt_tag_len =
+        ::pltxt2htm::details::try_parse_bare_tag<ndebug, ::pltxt2htm::details::U8LiteralString{u8"aption"}>(pltext);
+    if (!opt_tag_len.has_value()) {
+        return ::exception::nullopt_t{};
+    }
+    if (nested_tag_type != ::pltxt2htm::NodeKind::html_table) {
+        return ::exception::nullopt_t{};
+    }
+    return opt_tag_len;
+}
+
+/**
+ * @brief Parse &lt;colgroup&gt; and validate parent container type.
+ * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
+ * @param[in] pltext The input text to parse, starting after `<c`.
+ * @param[in] nested_tag_type Current parent tag type from parsing context.
+ * @return Matched tag length when valid under &lt;table&gt;; otherwise nullopt.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_colgroup_tag(::fast_io::u8string_view pltext,
+                                      ::pltxt2htm::NodeKind const nested_tag_type) noexcept
+    -> ::exception::optional<::std::size_t> {
+    auto opt_tag_len =
+        ::pltxt2htm::details::try_parse_bare_tag<ndebug, ::pltxt2htm::details::U8LiteralString{u8"olgroup"}>(pltext);
+    if (!opt_tag_len.has_value()) {
+        return ::exception::nullopt_t{};
+    }
+    if (nested_tag_type != ::pltxt2htm::NodeKind::html_table) {
+        return ::exception::nullopt_t{};
+    }
+    return opt_tag_len;
+}
+
+/**
+ * @brief Parse &lt;thead&gt; and validate parent container type.
+ * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
+ * @param[in] pltext The input text to parse, starting after `<t`.
+ * @param[in] nested_tag_type Current parent tag type from parsing context.
+ * @return Matched tag length when valid under &lt;table&gt;; otherwise nullopt.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_thead_tag(::fast_io::u8string_view pltext,
+                                   ::pltxt2htm::NodeKind const nested_tag_type) noexcept
+    -> ::exception::optional<::std::size_t> {
+    auto opt_tag_len =
+        ::pltxt2htm::details::try_parse_bare_tag<ndebug, ::pltxt2htm::details::U8LiteralString{u8"head"}>(pltext);
+    if (!opt_tag_len.has_value()) {
+        return ::exception::nullopt_t{};
+    }
+    if (nested_tag_type != ::pltxt2htm::NodeKind::html_table) {
+        return ::exception::nullopt_t{};
+    }
+    return opt_tag_len;
+}
+
+/**
+ * @brief Parse &lt;tbody&gt; and validate parent container type.
+ * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
+ * @param[in] pltext The input text to parse, starting after `<t`.
+ * @param[in] nested_tag_type Current parent tag type from parsing context.
+ * @return Matched tag length when valid under &lt;table&gt;; otherwise nullopt.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_tbody_tag(::fast_io::u8string_view pltext,
+                                   ::pltxt2htm::NodeKind const nested_tag_type) noexcept
+    -> ::exception::optional<::std::size_t> {
+    auto opt_tag_len =
+        ::pltxt2htm::details::try_parse_bare_tag<ndebug, ::pltxt2htm::details::U8LiteralString{u8"body"}>(pltext);
+    if (!opt_tag_len.has_value()) {
+        return ::exception::nullopt_t{};
+    }
+    if (nested_tag_type != ::pltxt2htm::NodeKind::html_table) {
+        return ::exception::nullopt_t{};
+    }
+    return opt_tag_len;
+}
+
+/**
+ * @brief Parse &lt;tfoot&gt; and validate parent container type.
+ * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
+ * @param[in] pltext The input text to parse, starting after `<t`.
+ * @param[in] nested_tag_type Current parent tag type from parsing context.
+ * @return Matched tag length when valid under &lt;table&gt;; otherwise nullopt.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_tfoot_tag(::fast_io::u8string_view pltext,
+                                   ::pltxt2htm::NodeKind const nested_tag_type) noexcept
+    -> ::exception::optional<::std::size_t> {
+    auto opt_tag_len =
+        ::pltxt2htm::details::try_parse_bare_tag<ndebug, ::pltxt2htm::details::U8LiteralString{u8"foot"}>(pltext);
+    if (!opt_tag_len.has_value()) {
+        return ::exception::nullopt_t{};
+    }
+    if (nested_tag_type != ::pltxt2htm::NodeKind::html_table) {
+        return ::exception::nullopt_t{};
+    }
+    return opt_tag_len;
+}
+
+/**
+ * @brief Parse &lt;tr&gt; and validate parent container type.
+ * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
+ * @param[in] pltext The input text to parse, starting after `<t`.
+ * @param[in] nested_tag_type Current parent tag type from parsing context.
+ * @return Matched tag length when valid under &lt;table&gt;,&lt;thead&gt;,&lt;tbody&gt;,or &lt;tfoot&gt;; otherwise nullopt.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_tr_tag(::fast_io::u8string_view pltext,
+                                ::pltxt2htm::NodeKind const nested_tag_type) noexcept
+    -> ::exception::optional<::std::size_t> {
+    auto opt_tag_len =
+        ::pltxt2htm::details::try_parse_bare_tag<ndebug, ::pltxt2htm::details::U8LiteralString{u8"r"}>(pltext);
+    if (!opt_tag_len.has_value()) {
+        return ::exception::nullopt_t{};
+    }
+    if (nested_tag_type != ::pltxt2htm::NodeKind::html_table &&
+        nested_tag_type != ::pltxt2htm::NodeKind::html_thead &&
+        nested_tag_type != ::pltxt2htm::NodeKind::html_tbody &&
+        nested_tag_type != ::pltxt2htm::NodeKind::html_tfoot) {
+        return ::exception::nullopt_t{};
+    }
+    return opt_tag_len;
+}
+
+/**
+ * @brief Parse &lt;th&gt; and validate parent container type.
+ * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
+ * @param[in] pltext The input text to parse, starting after `<t`.
+ * @param[in] nested_tag_type Current parent tag type from parsing context.
+ * @return Matched tag length when valid under &lt;tr&gt;; otherwise nullopt.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_th_tag(::fast_io::u8string_view pltext,
+                                ::pltxt2htm::NodeKind const nested_tag_type) noexcept
+    -> ::exception::optional<::std::size_t> {
+    auto opt_tag_len =
+        ::pltxt2htm::details::try_parse_bare_tag<ndebug, ::pltxt2htm::details::U8LiteralString{u8"h"}>(pltext);
+    if (!opt_tag_len.has_value()) {
+        return ::exception::nullopt_t{};
+    }
+    if (nested_tag_type != ::pltxt2htm::NodeKind::html_tr) {
+        return ::exception::nullopt_t{};
+    }
+    return opt_tag_len;
+}
+
+/**
+ * @brief Parse &lt;td&gt; and validate parent container type.
+ * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
+ * @param[in] pltext The input text to parse, starting after `<t`.
+ * @param[in] nested_tag_type Current parent tag type from parsing context.
+ * @return Matched tag length when valid under &lt;tr&gt;; otherwise nullopt.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_td_tag(::fast_io::u8string_view pltext,
+                                ::pltxt2htm::NodeKind const nested_tag_type) noexcept
+    -> ::exception::optional<::std::size_t> {
+    auto opt_tag_len =
+        ::pltxt2htm::details::try_parse_bare_tag<ndebug, ::pltxt2htm::details::U8LiteralString{u8"d"}>(pltext);
+    if (!opt_tag_len.has_value()) {
+        return ::exception::nullopt_t{};
+    }
+    if (nested_tag_type != ::pltxt2htm::NodeKind::html_tr) {
+        return ::exception::nullopt_t{};
+    }
+    return opt_tag_len;
+}
+
 struct TryParseEqualSignTagResult {
     ::std::size_t tag_len; ///< Length of the tag.
     ::fast_io::u8string substr; ///< Substring extracted from the tag.
@@ -598,6 +785,29 @@ constexpr auto try_parse_self_closing_tag(::fast_io::u8string_view pltext) noexc
         }
     }
     return ::exception::nullopt_t{};
+}
+
+/**
+ * @brief Parse &lt;col&gt; self-closing tag and validate parent container type.
+ * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
+ * @param[in] pltext The input text to parse, starting after `<c`.
+ * @param[in] nested_tag_type Current parent tag type from parsing context.
+ * @return Matched tag length when valid under &lt;colgroup&gt;; otherwise nullopt.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_col_tag(::fast_io::u8string_view pltext,
+                                 ::pltxt2htm::NodeKind const nested_tag_type) noexcept
+    -> ::exception::optional<::std::size_t> {
+    auto opt_tag_len =
+        ::pltxt2htm::details::try_parse_self_closing_tag<ndebug, ::pltxt2htm::details::U8LiteralString{u8"ol"}>(pltext);
+    if (!opt_tag_len.has_value()) {
+        return ::exception::nullopt_t{};
+    }
+    if (nested_tag_type != ::pltxt2htm::NodeKind::html_colgroup) {
+        return ::exception::nullopt_t{};
+    }
+    return opt_tag_len;
 }
 
 /**

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -747,6 +747,73 @@ entry:
                     ::std::addressof(subast), ::pltxt2htm::NodeKind::html_blockquote, subast.begin()));
             goto entry;
         }
+        case ::pltxt2htm::NodeKind::html_table: {
+            auto&& subast = node.get_subast();
+            call_stack.push(
+                ::pltxt2htm::details::OptimizerFrameContext<typename ::pltxt2htm::Ast<ndebug>::iterator, ndebug>(
+                    ::std::addressof(subast), ::pltxt2htm::NodeKind::html_table, subast.begin()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_caption: {
+            auto&& subast = node.get_subast();
+            call_stack.push(
+                ::pltxt2htm::details::OptimizerFrameContext<typename ::pltxt2htm::Ast<ndebug>::iterator, ndebug>(
+                    ::std::addressof(subast), ::pltxt2htm::NodeKind::html_caption, subast.begin()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_colgroup: {
+            auto&& subast = node.get_subast();
+            call_stack.push(
+                ::pltxt2htm::details::OptimizerFrameContext<typename ::pltxt2htm::Ast<ndebug>::iterator, ndebug>(
+                    ::std::addressof(subast), ::pltxt2htm::NodeKind::html_colgroup, subast.begin()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_thead: {
+            auto&& subast = node.get_subast();
+            call_stack.push(
+                ::pltxt2htm::details::OptimizerFrameContext<typename ::pltxt2htm::Ast<ndebug>::iterator, ndebug>(
+                    ::std::addressof(subast), ::pltxt2htm::NodeKind::html_thead, subast.begin()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_tbody: {
+            auto&& subast = node.get_subast();
+            call_stack.push(
+                ::pltxt2htm::details::OptimizerFrameContext<typename ::pltxt2htm::Ast<ndebug>::iterator, ndebug>(
+                    ::std::addressof(subast), ::pltxt2htm::NodeKind::html_tbody, subast.begin()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_tfoot: {
+            auto&& subast = node.get_subast();
+            call_stack.push(
+                ::pltxt2htm::details::OptimizerFrameContext<typename ::pltxt2htm::Ast<ndebug>::iterator, ndebug>(
+                    ::std::addressof(subast), ::pltxt2htm::NodeKind::html_tfoot, subast.begin()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_tr: {
+            auto&& subast = node.get_subast();
+            call_stack.push(
+                ::pltxt2htm::details::OptimizerFrameContext<typename ::pltxt2htm::Ast<ndebug>::iterator, ndebug>(
+                    ::std::addressof(subast), ::pltxt2htm::NodeKind::html_tr, subast.begin()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_th: {
+            auto&& subast = node.get_subast();
+            call_stack.push(
+                ::pltxt2htm::details::OptimizerFrameContext<typename ::pltxt2htm::Ast<ndebug>::iterator, ndebug>(
+                    ::std::addressof(subast), ::pltxt2htm::NodeKind::html_th, subast.begin()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_td: {
+            auto&& subast = node.get_subast();
+            call_stack.push(
+                ::pltxt2htm::details::OptimizerFrameContext<typename ::pltxt2htm::Ast<ndebug>::iterator, ndebug>(
+                    ::std::addressof(subast), ::pltxt2htm::NodeKind::html_td, subast.begin()));
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::html_col: {
+            ++current_iter;
+            continue;
+        }
         case ::pltxt2htm::NodeKind::md_image:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_link: {

--- a/tests/test_html_table.cc
+++ b/tests/test_html_table.cc
@@ -1,0 +1,87 @@
+#include "precompile.hh"
+
+int main() {
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td>cell1</td><td>cell2</td></tr></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><tr><td>cell1</td><td>cell2</td></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><thead><tr><th>h1</th><th>h2</th></tr></thead></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><thead><tr><th>h1</th><th>h2</th></tr></thead></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html =
+            ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>");
+        auto answer =
+            ::fast_io::u8string_view{u8"<table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<TABLE><TR><TD>CELL</TD></TR></TABLE>");
+        auto answer = ::fast_io::u8string_view{u8"<table><tr><td>CELL</td></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><caption>caption</caption><tr><th>header</th></tr></table>");
+        auto answer =
+            ::fast_io::u8string_view{u8"<table><caption>caption</caption><tr><th>header</th></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><colgroup><col></colgroup><tr><td>text</td></tr></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><colgroup><col></colgroup><tr><td>text</td></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td><color=red>red</color></td></tr></table>");
+        auto answer =
+            ::fast_io::u8string_view{u8"<table><tr><td><span style=\"color:red;\">red</span></td></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><tbody><tr><td>body</td></tr></tbody></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><tbody><tr><td>body</td></tr></tbody></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><tfoot><tr><td>foot</td></tr></tfoot></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><tfoot><tr><td>foot</td></tr></tfoot></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table>");
+        auto answer = ::fast_io::u8string_view{u8"<table></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"t<table></table>t");
+        auto answer = ::fast_io::u8string_view{u8"t<table></table>t"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<col>");
+        auto answer = ::fast_io::u8string_view{u8"<col>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<table><tr><td>cell</td></tr></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><tr><td>cell</td></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    return 0;
+}

--- a/tests/test_html_table.cc
+++ b/tests/test_html_table.cc
@@ -72,14 +72,157 @@ int main() {
     }
 
     {
+        // <col> outside <table>/<colgroup> is treated as literal text
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<col>");
-        auto answer = ::fast_io::u8string_view{u8"<col>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;col&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<table><tr><td>cell</td></tr></table>");
         auto answer = ::fast_io::u8string_view{u8"<table><tr><td>cell</td></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    // ── Rejection of table-internal tags outside their valid context ──
+
+    {
+        // <tr> at top level → literal text
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<tr>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;tr&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <td> at top level → literal text
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<td>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;td&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <th> at top level → literal text
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<th>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;th&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <thead> at top level → literal text
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<thead>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;thead&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <tbody> at top level → literal text
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<tbody>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;tbody&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <tfoot> at top level → literal text
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<tfoot>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;tfoot&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <caption> at top level → literal text
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<caption>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;caption&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <colgroup> at top level → literal text
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<colgroup>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;colgroup&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // uppercase <TR> at top level → literal text
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<TR>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;TR&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <thead> inside <table> is valid
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><thead><tr><th>x</th></tr></thead></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><thead><tr><th>x</th></tr></thead></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <tbody> inside <table> is valid
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><tbody><tr><td>x</td></tr></tbody></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><tbody><tr><td>x</td></tr></tbody></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <tfoot> inside <table> is valid
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><tfoot><tr><td>x</td></tr></tfoot></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><tfoot><tr><td>x</td></tr></tfoot></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <caption> inside <table> is valid
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><caption>title</caption></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><caption>title</caption></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <colgroup> inside <table> is valid
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><colgroup><col></colgroup></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><colgroup><col></colgroup></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <col> inside <colgroup> inside <table> is valid (multiple cols)
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><colgroup><col><col></colgroup></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><colgroup><col><col></colgroup></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <tr> directly in <table> is valid
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td>x</td></tr></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><tr><td>x</td></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <tr> in <thead> is valid
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><thead><tr><th>x</th></tr></thead></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><thead><tr><th>x</th></tr></thead></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <tr> in <tbody> is valid
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><tbody><tr><td>x</td></tr></tbody></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><tbody><tr><td>x</td></tr></tbody></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <td> and <th> in <tr> is valid
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><th>h</th><td>b</td></tr></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><tr><th>h</th><td>b</td></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <tr> inside <caption> → <tr> is rejected (wrong context)
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><caption><tr>x</tr></caption></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><caption>&lt;tr&gt;x&lt;/tr&gt;</caption></table>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 


### PR DESCRIPTION
Implement Table, Tr, Td, Th, Thead, Tbody, Tfoot, Caption, Colgroup, Col
node types with parent-context enforcement — table-internal tags are
rejected (emitted as literal text) when appearing outside their valid
HTML nesting context, following the `<li>` tag validation pattern.