### PR TITLE
fix: use correct emscripten -s flag syntax in wasm/CMakeLists.txt

### DIFF
--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -38,11 +38,11 @@ endif()
 
 target_link_options(pltxt2htm PRIVATE
     -fuse-ld=lld
-    "-s EXPORTED_FUNCTIONS=['_common_parser','_fixedadv_parser','_free','_ver_major','_ver_minor','_ver_patch']"
-    "-s EXPORTED_RUNTIME_METHODS=['cwrap','UTF8ToString']"
-    "-s MODULARIZE=1"
-    "-s EXPORT_ES6=1"
-    "-s EXPORT_NAME=\"pltxt2htm\""
+    "-sEXPORTED_FUNCTIONS=['_common_parser','_fixedadv_parser','_free','_ver_major','_ver_minor','_ver_patch']"
+    "-sEXPORTED_RUNTIME_METHODS=['cwrap','UTF8ToString']"
+    -sMODULARIZE=1
+    -sEXPORT_ES6=1
+    -sEXPORT_NAME=pltxt2htm
 )
 
 # Install step: copy all pltxt2htm.* outputs to install dir

--- a/wasm/docker/wasm32-unknown-emscripten/Dockerfile
+++ b/wasm/docker/wasm32-unknown-emscripten/Dockerfile
@@ -12,4 +12,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends ninja-build && 
 RUN emcmake cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=${mode}
 RUN cmake --build build -v
 RUN cmake --install build --prefix wasm32-unknown-emscripten-pltxt2htm-wasm-${mode}
+RUN node --input-type=module -e "\
+import assert from 'node:assert';\
+import m from './wasm32-unknown-emscripten-pltxt2htm-wasm-${mode}/pltxt2htm.js';\
+const mod = await m();\
+const cp = mod.cwrap('common_parser', 'number', ['string']);\
+const r = mod.UTF8ToString(cp('<b>test'));\
+assert.equal(r, '<strong>test</strong>');\
+"
 RUN zip -r wasm32-unknown-emscripten-pltxt2htm-wasm-${mode}.zip wasm32-unknown-emscripten-pltxt2htm-wasm-${mode}/


### PR DESCRIPTION
Emscripten requires -sFLAG=VALUE (no space). The space between -s and the flag caused all linker settings (MODULARIZE, EXPORT_ES6, EXPORT_NAME, EXPORTED_FUNCTIONS, EXPORTED_RUNTIME_METHODS) to be silently ignored.