### PR TITLE
feature: support markdown checkbox/task list syntax (`- [ ]` / `- [x]`)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,7 @@
 **/venv/
 **/.venv/
 dist/
-**/build/
+**/build*/
 *.egg-info/
 **/__pycache__/
 **/*.pyc
@@ -81,3 +81,6 @@ csharp/bin/
 
 # pixi
 **/.pixi
+
+# OpenCode
+.opencode

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ csharp/bin/
 
 # pixi
 **/.pixi
+
+# OpenCode
+.opencode

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ markdown extension based on [commonmark](https://spec.commonmark.org/0.31.2/)
 * Rough support for markdown [block quotes](https://spec.commonmark.org/0.31.2/#block-quotes) but common usage is well tested.
 * Rough support for markdown [links](https://spec.commonmark.org/0.31.2/#links) but common usage is well tested.
 * Rough support for markdown [lists](https://spec.commonmark.org/0.31.2/#lists) but common usage is well tested.
-* `Checkbox` and `mermaid` are not planned yet.
 
 Show all supported features in [tests](./tests/)
 

--- a/include/pltxt2htm/ast/ast.hh
+++ b/include/pltxt2htm/ast/ast.hh
@@ -2125,6 +2125,30 @@ public:
             }
         }
     }
+
+    [[nodiscard]]
+    constexpr auto is_checkbox(this auto&& self) noexcept -> bool {
+        switch (self.node_kind) {
+        case ::pltxt2htm::NodeKind::md_li: {
+            return self.md_li_node.is_checkbox();
+        }
+        default: {
+            return false;
+        }
+        }
+    }
+
+    [[nodiscard]]
+    constexpr auto is_checked(this auto&& self) noexcept -> bool {
+        switch (self.node_kind) {
+        case ::pltxt2htm::NodeKind::md_li: {
+            return self.md_li_node.is_checked();
+        }
+        default: {
+            return false;
+        }
+        }
+    };
 };
 
 } // namespace pltxt2htm

--- a/include/pltxt2htm/ast/ast.hh
+++ b/include/pltxt2htm/ast/ast.hh
@@ -2145,27 +2145,10 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto is_checkbox(this auto&& self) noexcept -> bool {
-        switch (self.node_kind) {
-        case ::pltxt2htm::NodeKind::md_li_checkbox: {
-            return true;
-        }
-        default: {
-            return false;
-        }
-        }
-    }
-
-    [[nodiscard]]
     constexpr auto is_checked(this auto&& self) noexcept -> bool {
-        switch (self.node_kind) {
-        case ::pltxt2htm::NodeKind::md_li_checkbox: {
-            return self.md_li_checkbox_node.is_checked();
-        }
-        default: {
-            return false;
-        }
-        }
+        bool const is_checkbox_type{self.node_kind == ::pltxt2htm::NodeKind::md_li_checkbox};
+        pltxt2htm_assert(is_checkbox_type, u8"node kind mismatch");
+        return self.md_li_checkbox_node.is_checked();
     };
 };
 

--- a/include/pltxt2htm/ast/ast.hh
+++ b/include/pltxt2htm/ast/ast.hh
@@ -130,6 +130,7 @@ class PlTxtNode {
         ::pltxt2htm::MdUl<ndebug> md_ul_node;
         ::pltxt2htm::MdOl<ndebug> md_ol_node;
         ::pltxt2htm::MdLi<ndebug> md_li_node;
+        ::pltxt2htm::MdLiCheckbox<ndebug> md_li_checkbox_node;
         ::pltxt2htm::MdTable<ndebug> md_table_node;
         ::pltxt2htm::MdThead<ndebug> md_thead_node;
         ::pltxt2htm::MdTbody<ndebug> md_tbody_node;
@@ -708,6 +709,11 @@ public:
           node_kind{::pltxt2htm::NodeKind::md_li} {
     }
 
+    constexpr PlTxtNode(::pltxt2htm::MdLiCheckbox<ndebug>&& node) noexcept
+        : md_li_checkbox_node(::std::move(node)),
+          node_kind{::pltxt2htm::NodeKind::md_li_checkbox} {
+    }
+
     constexpr PlTxtNode(::pltxt2htm::MdTable<ndebug>&& node) noexcept
         : md_table_node(::std::move(node)),
           node_kind{::pltxt2htm::NodeKind::md_table} {
@@ -1280,6 +1286,11 @@ public:
             new (::std::addressof(md_li_node))::pltxt2htm::MdLi(::std::move(other.md_li_node));
             break;
         }
+        case ::pltxt2htm::NodeKind::md_li_checkbox: {
+            new (::std::addressof(md_li_checkbox_node))::pltxt2htm::MdLiCheckbox(
+                ::std::move(other.md_li_checkbox_node));
+            break;
+        }
         case ::pltxt2htm::NodeKind::md_table: {
             new (::std::addressof(md_table_node))::pltxt2htm::MdTable(::std::move(other.md_table_node));
             break;
@@ -1765,6 +1776,10 @@ public:
             md_li_node.~MdLi();
             break;
         }
+        case ::pltxt2htm::NodeKind::md_li_checkbox: {
+            md_li_checkbox_node.~MdLiCheckbox();
+            break;
+        }
         case ::pltxt2htm::NodeKind::md_table: {
             md_table_node.~MdTable();
             break;
@@ -2068,6 +2083,9 @@ public:
         case ::pltxt2htm::NodeKind::md_li: {
             return ::std::forward_like<decltype(self)>(self.md_li_node).get_subast();
         }
+        case ::pltxt2htm::NodeKind::md_li_checkbox: {
+            return ::std::forward_like<decltype(self)>(self.md_li_checkbox_node).get_subast();
+        }
         case ::pltxt2htm::NodeKind::md_table: {
             return ::std::forward_like<decltype(self)>(self.md_table_node).get_subast();
         }
@@ -2129,8 +2147,8 @@ public:
     [[nodiscard]]
     constexpr auto is_checkbox(this auto&& self) noexcept -> bool {
         switch (self.node_kind) {
-        case ::pltxt2htm::NodeKind::md_li: {
-            return self.md_li_node.is_checkbox();
+        case ::pltxt2htm::NodeKind::md_li_checkbox: {
+            return true;
         }
         default: {
             return false;
@@ -2141,8 +2159,8 @@ public:
     [[nodiscard]]
     constexpr auto is_checked(this auto&& self) noexcept -> bool {
         switch (self.node_kind) {
-        case ::pltxt2htm::NodeKind::md_li: {
-            return self.md_li_node.is_checked();
+        case ::pltxt2htm::NodeKind::md_li_checkbox: {
+            return self.md_li_checkbox_node.is_checked();
         }
         default: {
             return false;

--- a/include/pltxt2htm/ast/impl/markdown_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/markdown_node_decl.hh
@@ -695,13 +695,10 @@ public:
 template<::pltxt2htm::Contracts ndebug>
 class MdLi {
     ::pltxt2htm::Ast<ndebug> subast{};
-    bool checkbox_{};
-    bool checked_{};
 
 public:
     constexpr MdLi() noexcept = delete;
     constexpr explicit MdLi(::pltxt2htm::Ast<ndebug>&& subast_) noexcept;
-    constexpr explicit MdLi(::pltxt2htm::Ast<ndebug>&& subast_, bool checkbox, bool checked) noexcept;
     constexpr MdLi(::pltxt2htm::MdLi<ndebug> const&) noexcept = delete;
     constexpr MdLi(::pltxt2htm::MdLi<ndebug>&&) noexcept;
     constexpr ~MdLi() noexcept;
@@ -713,10 +710,30 @@ public:
     constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
         return ::std::forward_like<decltype(self)>(self.subast);
     }
+};
+
+/**
+ * @brief Markdown checkbox list item (- [ ] / - [x])
+ */
+template<::pltxt2htm::Contracts ndebug>
+class MdLiCheckbox {
+    ::pltxt2htm::Ast<ndebug> subast{};
+    bool checked_{};
+
+public:
+    constexpr MdLiCheckbox() noexcept = delete;
+    constexpr explicit MdLiCheckbox(::pltxt2htm::Ast<ndebug>&& subast_, bool checked) noexcept;
+    constexpr MdLiCheckbox(::pltxt2htm::MdLiCheckbox<ndebug> const&) noexcept = delete;
+    constexpr MdLiCheckbox(::pltxt2htm::MdLiCheckbox<ndebug>&&) noexcept;
+    constexpr ~MdLiCheckbox() noexcept;
+    constexpr auto operator=(::pltxt2htm::MdLiCheckbox<ndebug> const&) noexcept
+        -> ::pltxt2htm::MdLiCheckbox<ndebug>& = delete;
+    constexpr auto operator=(this ::pltxt2htm::MdLiCheckbox<ndebug>& self, ::pltxt2htm::MdLiCheckbox<ndebug>&&) noexcept
+        -> ::pltxt2htm::MdLiCheckbox<ndebug>&;
 
     [[nodiscard]]
-    constexpr auto is_checkbox(this auto&& self) noexcept -> bool {
-        return self.checkbox_;
+    constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.subast);
     }
 
     [[nodiscard]]

--- a/include/pltxt2htm/ast/impl/markdown_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/markdown_node_decl.hh
@@ -695,10 +695,13 @@ public:
 template<::pltxt2htm::Contracts ndebug>
 class MdLi {
     ::pltxt2htm::Ast<ndebug> subast{};
+    bool checkbox_{};
+    bool checked_{};
 
 public:
     constexpr MdLi() noexcept = delete;
     constexpr explicit MdLi(::pltxt2htm::Ast<ndebug>&& subast_) noexcept;
+    constexpr explicit MdLi(::pltxt2htm::Ast<ndebug>&& subast_, bool checkbox, bool checked) noexcept;
     constexpr MdLi(::pltxt2htm::MdLi<ndebug> const&) noexcept = delete;
     constexpr MdLi(::pltxt2htm::MdLi<ndebug>&&) noexcept;
     constexpr ~MdLi() noexcept;
@@ -709,6 +712,16 @@ public:
     [[nodiscard]]
     constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
         return ::std::forward_like<decltype(self)>(self.subast);
+    }
+
+    [[nodiscard]]
+    constexpr auto is_checkbox(this auto&& self) noexcept -> bool {
+        return self.checkbox_;
+    }
+
+    [[nodiscard]]
+    constexpr auto is_checked(this auto&& self) noexcept -> bool {
+        return self.checked_;
     }
 };
 

--- a/include/pltxt2htm/ast/impl/markdown_node_def.inc
+++ b/include/pltxt2htm/ast/impl/markdown_node_def.inc
@@ -358,6 +358,13 @@ constexpr ::pltxt2htm::MdLi<ndebug>::MdLi(::pltxt2htm::Ast<ndebug>&& subast_) no
 }
 
 template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::MdLi<ndebug>::MdLi(::pltxt2htm::Ast<ndebug>&& subast_, bool checkbox, bool checked) noexcept
+    : subast(::std::move(subast_)),
+      checkbox_(checkbox),
+      checked_(checked) {
+}
+
+template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::MdLi<ndebug>::MdLi(::pltxt2htm::MdLi<ndebug>&&) noexcept = default;
 template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::MdLi<ndebug>::~MdLi() noexcept = default;

--- a/include/pltxt2htm/ast/impl/markdown_node_def.inc
+++ b/include/pltxt2htm/ast/impl/markdown_node_def.inc
@@ -358,13 +358,6 @@ constexpr ::pltxt2htm::MdLi<ndebug>::MdLi(::pltxt2htm::Ast<ndebug>&& subast_) no
 }
 
 template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::MdLi<ndebug>::MdLi(::pltxt2htm::Ast<ndebug>&& subast_, bool checkbox, bool checked) noexcept
-    : subast(::std::move(subast_)),
-      checkbox_(checkbox),
-      checked_(checked) {
-}
-
-template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::MdLi<ndebug>::MdLi(::pltxt2htm::MdLi<ndebug>&&) noexcept = default;
 template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::MdLi<ndebug>::~MdLi() noexcept = default;
@@ -372,6 +365,21 @@ template<::pltxt2htm::Contracts ndebug>
 constexpr auto ::pltxt2htm::MdLi<ndebug>::operator=(this ::pltxt2htm::MdLi<ndebug>& self,
                                                     ::pltxt2htm::MdLi<ndebug>&&) noexcept
     -> ::pltxt2htm::MdLi<ndebug>& = default;
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::MdLiCheckbox<ndebug>::MdLiCheckbox(::pltxt2htm::Ast<ndebug>&& subast_, bool checked) noexcept
+    : subast(::std::move(subast_)),
+      checked_(checked) {
+}
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::MdLiCheckbox<ndebug>::MdLiCheckbox(::pltxt2htm::MdLiCheckbox<ndebug>&&) noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::MdLiCheckbox<ndebug>::~MdLiCheckbox() noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr auto ::pltxt2htm::MdLiCheckbox<ndebug>::operator=(this ::pltxt2htm::MdLiCheckbox<ndebug>& self,
+                                                            ::pltxt2htm::MdLiCheckbox<ndebug>&&) noexcept
+    -> ::pltxt2htm::MdLiCheckbox<ndebug>& = default;
 
 template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::MdLatexInline<ndebug>::MdLatexInline(::pltxt2htm::Ast<ndebug>&& subast_) noexcept

--- a/include/pltxt2htm/ast/node_type.hh
+++ b/include/pltxt2htm/ast/node_type.hh
@@ -170,6 +170,7 @@ enum class NodeKind : ::std::size_t {
     md_ul, ///< Unordered list marker
     md_ol, ///< Ordered list marker
     md_li, ///< List item
+    md_li_checkbox, ///< Checkbox list item (- [ ] / - [x])
 
     // Markdown table nodes (markdown pipe-table syntax)
     md_table, ///< Markdown table: | ... |

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -471,6 +471,8 @@ entry:
                 u8"Invalid tag type");
             [[fallthrough]];
         }
+        case ::pltxt2htm::NodeKind::md_li_checkbox:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_li: {
             call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
                                                                               ::pltxt2htm::NodeKind::html_li, 0));
@@ -490,7 +492,7 @@ entry:
             }
             else if (nested_tag_type == ::pltxt2htm::NodeKind::html_ul ||
                      nested_tag_type == ::pltxt2htm::NodeKind::md_ul) {
-                if (node.get_node_kind() == ::pltxt2htm::NodeKind::md_li && node.is_checkbox()) {
+                if (node.is_checkbox()) {
                     if (node.is_checked()) {
                         result.append(u8"[x] ");
                     }
@@ -958,6 +960,8 @@ entry:
             --list_nesting_depth;
             goto entry;
         }
+        case ::pltxt2htm::NodeKind::md_li_checkbox:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_li:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_li: {

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -492,7 +492,7 @@ entry:
             }
             else if (nested_tag_type == ::pltxt2htm::NodeKind::html_ul ||
                      nested_tag_type == ::pltxt2htm::NodeKind::md_ul) {
-                if (node.is_checkbox()) {
+                if (node.get_node_kind() == ::pltxt2htm::NodeKind::md_li_checkbox) {
                     if (node.is_checked()) {
                         result.append(u8"[x] ");
                     }

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -490,7 +490,15 @@ entry:
             }
             else if (nested_tag_type == ::pltxt2htm::NodeKind::html_ul ||
                      nested_tag_type == ::pltxt2htm::NodeKind::md_ul) {
-                if (indent_level % 3 == 1) {
+                if (node.get_node_kind() == ::pltxt2htm::NodeKind::md_li && node.is_checkbox()) {
+                    if (node.is_checked()) {
+                        result.append(u8"[x] ");
+                    }
+                    else {
+                        result.append(u8"[ ] ");
+                    }
+                }
+                else if (indent_level % 3 == 1) {
                     result.append(u8"\u2022 ");
                 }
                 else if (indent_level % 3 == 2) {

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -612,13 +612,8 @@ entry:
             }
             goto entry;
         }
-        case ::pltxt2htm::NodeKind::md_li: {
-            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
-                                                                              ::pltxt2htm::NodeKind::html_li, 0));
-            ++current_index;
-            result.append(u8"<li>");
-            goto entry;
-        }
+        case ::pltxt2htm::NodeKind::md_li:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_li: {
             call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
                                                                               ::pltxt2htm::NodeKind::html_li, 0));

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -599,19 +599,24 @@ entry:
             result.append(u8"<ol>");
             goto entry;
         }
+        case ::pltxt2htm::NodeKind::md_li_checkbox: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_li, 0));
+            ++current_index;
+            result.append(u8"<li>");
+            if (node.is_checked()) {
+                result.append(u8"<input type=\"checkbox\" disabled checked>");
+            }
+            else {
+                result.append(u8"<input type=\"checkbox\" disabled>");
+            }
+            goto entry;
+        }
         case ::pltxt2htm::NodeKind::md_li: {
             call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
                                                                               ::pltxt2htm::NodeKind::html_li, 0));
             ++current_index;
             result.append(u8"<li>");
-            if (node.is_checkbox()) {
-                if (node.is_checked()) {
-                    result.append(u8"<input type=\"checkbox\" disabled checked>");
-                }
-                else {
-                    result.append(u8"<input type=\"checkbox\" disabled>");
-                }
-            }
             goto entry;
         }
         case ::pltxt2htm::NodeKind::html_li: {

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -599,8 +599,21 @@ entry:
             result.append(u8"<ol>");
             goto entry;
         }
-        case ::pltxt2htm::NodeKind::md_li:
-            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::md_li: {
+            call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
+                                                                              ::pltxt2htm::NodeKind::html_li, 0));
+            ++current_index;
+            result.append(u8"<li>");
+            if (node.is_checkbox()) {
+                if (node.is_checked()) {
+                    result.append(u8"<input type=\"checkbox\" disabled checked>");
+                }
+                else {
+                    result.append(u8"<input type=\"checkbox\" disabled>");
+                }
+            }
+            goto entry;
+        }
         case ::pltxt2htm::NodeKind::html_li: {
             call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.get_subast(),
                                                                               ::pltxt2htm::NodeKind::html_li, 0));

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -316,6 +316,8 @@ entry:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_ol:
             [[fallthrough]];
+        case ::pltxt2htm::NodeKind::md_li_checkbox:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_li:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_code:

--- a/include/pltxt2htm/details/parser/frame_concext.hh
+++ b/include/pltxt2htm/details/parser/frame_concext.hh
@@ -806,7 +806,9 @@ public:
     constexpr ParserFrameContext(::pltxt2htm::details::ParserFrameContext<ndebug>&& other) noexcept
         : context_data{::std::move(other.context_data)},
           current_index{other.current_index},
-          subast(::std::move(other.subast)) {
+          subast(::std::move(other.subast)),
+          checkbox{other.checkbox},
+          checked{other.checked} {
     }
 
     constexpr auto operator=(::pltxt2htm::details::ParserFrameContext<ndebug> const&) noexcept

--- a/include/pltxt2htm/details/parser/frame_concext.hh
+++ b/include/pltxt2htm/details/parser/frame_concext.hh
@@ -81,6 +81,12 @@ public:
     ::pltxt2htm::MdTableAlign align;
 };
 
+class ParserFrameContextWithMdLiCheckboxInfo {
+public:
+    ::fast_io::u8string_view pltext;
+    bool checked;
+};
+
 enum class MdTableParsePhase : ::std::size_t {
     header = 0,
     body,
@@ -119,6 +125,7 @@ public:
         ::pltxt2htm::details::ParserFrameContextWithMdLinkInfo<ndebug> md_link;
         ::pltxt2htm::details::ParserFrameContextWithMdListInfo<ndebug> md_list;
         ::pltxt2htm::details::ParserFrameContextWithMdCellInfo md_cell;
+        ::pltxt2htm::details::ParserFrameContextWithMdLiCheckboxInfo md_li_checkbox;
         ::pltxt2htm::details::ParserFrameContextWithMdTableInfo<ndebug> md_table;
     };
 
@@ -172,6 +179,12 @@ public:
           kind{node_type} {
     }
 
+    constexpr ContextVariant(::pltxt2htm::details::ParserFrameContextWithMdLiCheckboxInfo&& md_li_checkbox_context,
+                             ::pltxt2htm::NodeKind node_type) noexcept
+        : md_li_checkbox{::std::move(md_li_checkbox_context)},
+          kind{node_type} {
+    }
+
     constexpr ContextVariant(::pltxt2htm::details::ParserFrameContextWithMdTableInfo<ndebug>&& md_table_context,
                              ::pltxt2htm::NodeKind node_type) noexcept
         : md_table{::std::move(md_table_context)},
@@ -212,6 +225,10 @@ public:
         case ::pltxt2htm::NodeKind::md_ul:
         case ::pltxt2htm::NodeKind::md_ol: {
             ::std::construct_at(::std::addressof(this->md_list), ::std::move(other.md_list));
+            return;
+        }
+        case ::pltxt2htm::NodeKind::md_li_checkbox: {
+            ::std::construct_at(::std::addressof(this->md_li_checkbox), ::std::move(other.md_li_checkbox));
             return;
         }
         case ::pltxt2htm::NodeKind::text:
@@ -317,8 +334,6 @@ public:
         case ::pltxt2htm::NodeKind::md_del:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_image:
-            [[fallthrough]];
-        case ::pltxt2htm::NodeKind::md_li_checkbox:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_li:
             [[fallthrough]];
@@ -586,8 +601,6 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_image:
             [[fallthrough]];
-        case ::pltxt2htm::NodeKind::md_li_checkbox:
-            [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_li:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_latex_inline:
@@ -698,6 +711,10 @@ public:
             ::std::destroy_at(::std::addressof(this->md_table));
             return;
         }
+        case ::pltxt2htm::NodeKind::md_li_checkbox: {
+            ::std::destroy_at(::std::addressof(this->md_li_checkbox));
+            return;
+        }
         case ::pltxt2htm::NodeKind::md_thead:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_tbody:
@@ -719,7 +736,6 @@ class ParserFrameContext {
 public:
     ::std::size_t current_index{};
     ::pltxt2htm::Ast<ndebug> subast{};
-    bool checked{};
 
     constexpr explicit ParserFrameContext(::fast_io::u8string_view pltext_,
                                           ::pltxt2htm::NodeKind const nested_tag_type_) noexcept
@@ -781,6 +797,13 @@ public:
               ::pltxt2htm::NodeKind::md_link}} {
     }
 
+    constexpr explicit ParserFrameContext(::fast_io::u8string_view pltext_, bool checked_,
+                                          ::pltxt2htm::NodeKind node_type) noexcept
+        : context_data{::pltxt2htm::details::ContextVariant<ndebug>{
+              ::pltxt2htm::details::ParserFrameContextWithMdLiCheckboxInfo{pltext_, checked_}, node_type}} {
+        pltxt2htm_assert(node_type == ::pltxt2htm::NodeKind::md_li_checkbox, u8"mismatch node type");
+    }
+
     constexpr explicit ParserFrameContext(::pltxt2htm::NodeKind node_type,
                                           ::pltxt2htm::details::MdListAst<ndebug>&& md_list_ast_) noexcept
         : context_data{::pltxt2htm::details::ContextVariant<ndebug>{
@@ -809,8 +832,7 @@ public:
     constexpr ParserFrameContext(::pltxt2htm::details::ParserFrameContext<ndebug>&& other) noexcept
         : context_data{::std::move(other.context_data)},
           current_index{other.current_index},
-          subast(::std::move(other.subast)),
-          checked{other.checked} {
+          subast(::std::move(other.subast)) {
     }
 
     constexpr auto operator=(::pltxt2htm::details::ParserFrameContext<ndebug> const&) noexcept
@@ -959,14 +981,15 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_image:
             [[fallthrough]];
-        case ::pltxt2htm::NodeKind::md_li_checkbox:
-            [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_li:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_latex_inline:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_latex_block: {
             return context_data_ref.pltext.pltext;
+        }
+        case ::pltxt2htm::NodeKind::md_li_checkbox: {
+            return context_data_ref.md_li_checkbox.pltext;
         }
         case ::pltxt2htm::NodeKind::pl_color:
             [[fallthrough]];
@@ -1183,6 +1206,14 @@ public:
                              context_data_ref.kind == ::pltxt2htm::NodeKind::md_td,
                          u8"context kind mismatch");
         return context_data_ref.md_cell.align;
+    }
+
+    [[nodiscard]]
+    constexpr auto get_checked(this auto&& self) noexcept -> bool {
+        auto&& context_data_ref = self.context_data;
+        pltxt2htm_assert(context_data_ref.kind == ::pltxt2htm::NodeKind::md_li_checkbox,
+                         u8"context kind mismatch");
+        return context_data_ref.md_li_checkbox.checked;
     }
 };
 

--- a/include/pltxt2htm/details/parser/frame_concext.hh
+++ b/include/pltxt2htm/details/parser/frame_concext.hh
@@ -715,6 +715,8 @@ class ParserFrameContext {
 public:
     ::std::size_t current_index{};
     ::pltxt2htm::Ast<ndebug> subast{};
+    bool checkbox{};
+    bool checked{};
 
     constexpr explicit ParserFrameContext(::fast_io::u8string_view pltext_,
                                           ::pltxt2htm::NodeKind const nested_tag_type_) noexcept

--- a/include/pltxt2htm/details/parser/frame_concext.hh
+++ b/include/pltxt2htm/details/parser/frame_concext.hh
@@ -318,6 +318,8 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_image:
             [[fallthrough]];
+        case ::pltxt2htm::NodeKind::md_li_checkbox:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_li:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_latex_inline:
@@ -584,6 +586,8 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_image:
             [[fallthrough]];
+        case ::pltxt2htm::NodeKind::md_li_checkbox:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_li:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_latex_inline:
@@ -715,7 +719,6 @@ class ParserFrameContext {
 public:
     ::std::size_t current_index{};
     ::pltxt2htm::Ast<ndebug> subast{};
-    bool checkbox{};
     bool checked{};
 
     constexpr explicit ParserFrameContext(::fast_io::u8string_view pltext_,
@@ -807,7 +810,6 @@ public:
         : context_data{::std::move(other.context_data)},
           current_index{other.current_index},
           subast(::std::move(other.subast)),
-          checkbox{other.checkbox},
           checked{other.checked} {
     }
 
@@ -956,6 +958,8 @@ public:
         case ::pltxt2htm::NodeKind::md_del:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_image:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::md_li_checkbox:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_li:
             [[fallthrough]];

--- a/include/pltxt2htm/details/parser/frame_concext.hh
+++ b/include/pltxt2htm/details/parser/frame_concext.hh
@@ -1210,10 +1210,8 @@ public:
 
     [[nodiscard]]
     constexpr auto get_checked(this auto&& self) noexcept -> bool {
-        auto&& context_data_ref = self.context_data;
-        pltxt2htm_assert(context_data_ref.kind == ::pltxt2htm::NodeKind::md_li_checkbox,
-                         u8"context kind mismatch");
-        return context_data_ref.md_li_checkbox.checked;
+        pltxt2htm_assert(self.context_data.kind == ::pltxt2htm::NodeKind::md_li_checkbox, u8"context kind mismatch");
+        return self.context_data.md_li_checkbox.checked;
     }
 };
 

--- a/include/pltxt2htm/details/parser/md_list.hh
+++ b/include/pltxt2htm/details/parser/md_list.hh
@@ -698,9 +698,8 @@ constexpr auto try_parse_item(
     // detect markdown checkbox syntax: [ ] or [x]/[X] at start of text
     bool checkbox{};
     bool checked{};
-    if (text.size() >= 4 && text[0] == u8'[' &&
-        (text[1] == u8' ' || text[1] == u8'x' || text[1] == u8'X') && text[2] == u8']' &&
-        (text[3] == u8' ' || text[3] == u8'\t')) {
+    if (text.size() >= 4 && text[0] == u8'[' && (text[1] == u8' ' || text[1] == u8'x' || text[1] == u8'X') &&
+        text[2] == u8']' && (text[3] == u8' ' || text[3] == u8'\t')) {
         checkbox = true;
         checked = (text[1] == u8'x' || text[1] == u8'X');
         auto remaining = ::fast_io::u8string{::fast_io::u8string_view{text.data() + 4, text.size() - 4}};

--- a/include/pltxt2htm/details/parser/md_list.hh
+++ b/include/pltxt2htm/details/parser/md_list.hh
@@ -392,11 +392,6 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto is_checkbox(this auto&& self) noexcept -> bool {
-        return self.type_ == ::pltxt2htm::details::MdListNodeType::md_li_checkbox;
-    }
-
-    [[nodiscard]]
     constexpr auto is_checked(this auto&& self) noexcept -> bool {
         switch (self.type_) /* -Werror=switch */ {
         case ::pltxt2htm::details::MdListNodeType::md_li_checkbox: {

--- a/include/pltxt2htm/details/parser/md_list.hh
+++ b/include/pltxt2htm/details/parser/md_list.hh
@@ -55,10 +55,18 @@ using MdListAst = ::fast_io::vector<::pltxt2htm::details::MdListBaseNode<ndebug>
  */
 class MdListTextNode {
     ::fast_io::u8string text;
+    bool checkbox_{};
+    bool checked_{};
 
 public:
     constexpr MdListTextNode(::fast_io::u8string&& text_) noexcept
         : text(::std::move(text_)) {
+    }
+
+    constexpr MdListTextNode(::fast_io::u8string&& text_, bool cb, bool ckd) noexcept
+        : text(::std::move(text_)),
+          checkbox_(cb),
+          checked_(ckd) {
     }
 
     constexpr MdListTextNode(::pltxt2htm::details::MdListTextNode const&) noexcept = default;
@@ -81,7 +89,17 @@ public:
 #endif
     constexpr auto operator==(this ::pltxt2htm::details::MdListTextNode const& self,
                               ::pltxt2htm::details::MdListTextNode const& other) noexcept -> bool {
-        return self.text == other.text;
+        return self.text == other.text && self.checkbox_ == other.checkbox_ && self.checked_ == other.checked_;
+    }
+
+    [[nodiscard]]
+    constexpr auto is_checkbox(this auto&& self) noexcept -> bool {
+        return self.checkbox_;
+    }
+
+    [[nodiscard]]
+    constexpr auto is_checked(this auto&& self) noexcept -> bool {
+        return self.checked_;
     }
 
     [[nodiscard]]
@@ -289,6 +307,36 @@ public:
             [[unlikely]] {
                 ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
             }
+        }
+        ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+    }
+
+    [[nodiscard]]
+    constexpr auto is_checkbox(this auto&& self) noexcept -> bool {
+        switch (self.type_) /* -Werror=switch */ {
+        case ::pltxt2htm::details::MdListNodeType::text: {
+            return self.text_node.is_checkbox();
+        }
+        case ::pltxt2htm::details::MdListNodeType::md_ul:
+            [[fallthrough]];
+        case ::pltxt2htm::details::MdListNodeType::md_ol: {
+            return false;
+        }
+        }
+        ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+    }
+
+    [[nodiscard]]
+    constexpr auto is_checked(this auto&& self) noexcept -> bool {
+        switch (self.type_) /* -Werror=switch */ {
+        case ::pltxt2htm::details::MdListNodeType::text: {
+            return self.text_node.is_checked();
+        }
+        case ::pltxt2htm::details::MdListNodeType::md_ul:
+            [[fallthrough]];
+        case ::pltxt2htm::details::MdListNodeType::md_ol: {
+            return false;
+        }
         }
         ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
     }
@@ -565,6 +613,8 @@ struct TryParseItemResult {
     ::std::size_t forward_index;
     ::fast_io::u8string text;
     ::pltxt2htm::details::MdUlListItemKind item_kind;
+    bool checkbox{};
+    bool checked{};
 };
 
 template<::pltxt2htm::Contracts ndebug>
@@ -645,11 +695,24 @@ constexpr auto try_parse_item(
         }
         text.push_back(chr);
     }
+    // detect markdown checkbox syntax: [ ] or [x]/[X] at start of text
+    bool checkbox{};
+    bool checked{};
+    if (text.size() >= 4 && text[0] == u8'[' &&
+        (text[1] == u8' ' || text[1] == u8'x' || text[1] == u8'X') && text[2] == u8']' &&
+        (text[3] == u8' ' || text[3] == u8'\t')) {
+        checkbox = true;
+        checked = (text[1] == u8'x' || text[1] == u8'X');
+        auto remaining = ::fast_io::u8string{::fast_io::u8string_view{text.data() + 4, text.size() - 4}};
+        text = ::std::move(remaining);
+    }
     return ::pltxt2htm::details::TryParseItemResult{
         .space_hierarchy = space_hierarchy,
         .forward_index = current_index,
         .text = ::std::move(text),
         .item_kind = item_kind,
+        .checkbox = checkbox,
+        .checked = checked,
     };
 }
 
@@ -672,11 +735,12 @@ constexpr auto optionally_to_md_list_ast(::fast_io::u8string_view pltext) noexce
     // manually managing stack to avoid stack-overflow
     {
         if (auto opt_item = ::pltxt2htm::details::try_parse_item<ndebug>(pltext); opt_item.has_value()) {
-            auto&& [space_hierarchy, forward_index, text, item_kind] =
+            auto&& [space_hierarchy, forward_index, text, item_kind, checkbox, checked] =
                 opt_item.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
             ::pltxt2htm::details::MdListFrameContext<ndebug> current_frame{item_kind, space_hierarchy, pltext,
                                                                            forward_index};
-            current_frame.md_list_ast.emplace_back(::pltxt2htm::details::MdListTextNode(::std::move(text)));
+            current_frame.md_list_ast.emplace_back(
+                ::pltxt2htm::details::MdListTextNode(::std::move(text), checkbox, checked));
             if (forward_index >= current_frame.pltext.size()) {
                 return ::pltxt2htm::details::ToMdListAstResult<ndebug>{
                     .ast = ::std::move(current_frame.md_list_ast),
@@ -738,7 +802,7 @@ constexpr auto optionally_to_md_list_ast(::fast_io::u8string_view pltext) noexce
             parent_frame.current_index += frame.current_index;
             continue;
         }
-        auto&& [space_hierarchy, forward_index, text, item_kind] =
+        auto&& [space_hierarchy, forward_index, text, item_kind, checkbox, checked] =
             opt_list_item.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
         current_index += forward_index;
         if (space_hierarchy > top_frame.space_hierarchy + 1) {
@@ -746,10 +810,11 @@ constexpr auto optionally_to_md_list_ast(::fast_io::u8string_view pltext) noexce
                 item_kind, space_hierarchy,
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(top_frame.pltext, current_index)});
             auto&& child_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-            child_frame.md_list_ast.emplace_back(::pltxt2htm::details::MdListTextNode(::std::move(text)));
+            child_frame.md_list_ast.emplace_back(
+                ::pltxt2htm::details::MdListTextNode(::std::move(text), checkbox, checked));
             continue;
         }
-        result.emplace_back(::pltxt2htm::details::MdListTextNode(::std::move(text)));
+        result.emplace_back(::pltxt2htm::details::MdListTextNode(::std::move(text), checkbox, checked));
         top_frame.space_hierarchy = space_hierarchy;
 
         if (current_index < pltext_size) {

--- a/include/pltxt2htm/details/parser/md_list.hh
+++ b/include/pltxt2htm/details/parser/md_list.hh
@@ -16,6 +16,7 @@
 #include "../utils.hh"
 #include "../../contracts.hh"
 #include "../../ast/ast.hh"
+#include "../push_macro.hh"
 
 namespace pltxt2htm::details {
 
@@ -133,7 +134,7 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto is_checked(this auto&& self) noexcept -> bool {
+    constexpr auto is_checked(this auto const& self) noexcept -> bool {
         return self.checked_;
     }
 
@@ -392,20 +393,9 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto is_checked(this auto&& self) noexcept -> bool {
-        switch (self.type_) /* -Werror=switch */ {
-        case ::pltxt2htm::details::MdListNodeType::md_li_checkbox: {
-            return self.li_checkbox_node.is_checked();
-        }
-        case ::pltxt2htm::details::MdListNodeType::md_li:
-            [[fallthrough]];
-        case ::pltxt2htm::details::MdListNodeType::md_ul:
-            [[fallthrough]];
-        case ::pltxt2htm::details::MdListNodeType::md_ol: {
-            return false;
-        }
-        }
-        ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+    constexpr auto is_checked(this auto const& self) noexcept -> bool {
+        pltxt2htm_assert(self.type_ == ::pltxt2htm::details::MdListNodeType::md_li_checkbox, u8"node type mismatch");
+        return self.li_checkbox_node.is_checked();
     }
 
     [[nodiscard]]
@@ -756,6 +746,22 @@ constexpr auto try_parse_item(
             break;
         }
     }
+    // detect markdown checkbox syntax: [ ] or [x]/[X] at start of text
+    bool checkbox{};
+    bool checked{};
+    if (pltext.size() >= current_index + 4 &&
+        ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, current_index) == u8'[' &&
+        (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, current_index + 1) == u8' ' ||
+         ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, current_index + 1) == u8'x' ||
+         ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, current_index + 1) == u8'X') &&
+        ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, current_index + 2) == u8']' &&
+        (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, current_index + 3) == u8' ' ||
+         ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, current_index + 3) == u8'\t')) {
+        checkbox = true;
+        checked = (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, current_index + 1) == u8'x' ||
+                   ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, current_index + 1) == u8'X');
+        current_index += 4;
+    }
     // parsing text after - or + or *
     ::fast_io::u8string text{};
     for (; current_index < pltext.size(); ++current_index) {
@@ -765,16 +771,6 @@ constexpr auto try_parse_item(
             break;
         }
         text.push_back(chr);
-    }
-    // detect markdown checkbox syntax: [ ] or [x]/[X] at start of text
-    bool checkbox{};
-    bool checked{};
-    if (text.size() >= 4 && text[0] == u8'[' && (text[1] == u8' ' || text[1] == u8'x' || text[1] == u8'X') &&
-        text[2] == u8']' && (text[3] == u8' ' || text[3] == u8'\t')) {
-        checkbox = true;
-        checked = (text[1] == u8'x' || text[1] == u8'X');
-        auto remaining = ::fast_io::u8string{::fast_io::u8string_view{text.data() + 4, text.size() - 4}};
-        text = ::std::move(remaining);
     }
     return ::pltxt2htm::details::TryParseItemResult{
         .space_hierarchy = space_hierarchy,
@@ -944,3 +940,5 @@ constexpr auto optionally_to_md_list_ast(::fast_io::u8string_view pltext) noexce
 }
 
 } // namespace pltxt2htm::details
+
+#include "../pop_macro.hh"

--- a/include/pltxt2htm/details/parser/md_list.hh
+++ b/include/pltxt2htm/details/parser/md_list.hh
@@ -23,7 +23,8 @@ namespace pltxt2htm::details {
  * @brief Internal markdown-list AST node discriminator.
  */
 enum class MdListNodeType : ::std::uint_least32_t {
-    text = 0,
+    md_li = 0,
+    md_li_checkbox,
     md_ul,
     md_ol,
 };
@@ -53,48 +54,82 @@ using MdListAst = ::fast_io::vector<::pltxt2htm::details::MdListBaseNode<ndebug>
 /**
  * @brief Leaf markdown-list node that stores a single list-item text payload.
  */
-class MdListTextNode {
+class MdListLiNode {
     ::fast_io::u8string text;
-    bool checkbox_{};
-    bool checked_{};
 
 public:
-    constexpr MdListTextNode(::fast_io::u8string&& text_) noexcept
+    constexpr MdListLiNode(::fast_io::u8string&& text_) noexcept
         : text(::std::move(text_)) {
     }
 
-    constexpr MdListTextNode(::fast_io::u8string&& text_, bool cb, bool ckd) noexcept
-        : text(::std::move(text_)),
-          checkbox_(cb),
-          checked_(ckd) {
-    }
+    constexpr MdListLiNode(::pltxt2htm::details::MdListLiNode const&) noexcept = default;
 
-    constexpr MdListTextNode(::pltxt2htm::details::MdListTextNode const&) noexcept = default;
+    constexpr MdListLiNode(::pltxt2htm::details::MdListLiNode&&) noexcept = default;
 
-    constexpr MdListTextNode(::pltxt2htm::details::MdListTextNode&&) noexcept = default;
+    constexpr ~MdListLiNode() noexcept = default;
 
-    constexpr ~MdListTextNode() noexcept = default;
+    constexpr auto operator=(this ::pltxt2htm::details::MdListLiNode& self,
+                             ::pltxt2htm::details::MdListLiNode const& other) noexcept
+        -> ::pltxt2htm::details::MdListLiNode& = default;
 
-    constexpr auto operator=(this ::pltxt2htm::details::MdListTextNode& self,
-                             ::pltxt2htm::details::MdListTextNode const& other) noexcept
-        -> ::pltxt2htm::details::MdListTextNode& = default;
-
-    constexpr auto operator=(this ::pltxt2htm::details::MdListTextNode& self,
-                             ::pltxt2htm::details::MdListTextNode&&) noexcept
-        -> ::pltxt2htm::details::MdListTextNode& = default;
+    constexpr auto operator=(this ::pltxt2htm::details::MdListLiNode& self,
+                             ::pltxt2htm::details::MdListLiNode&&) noexcept
+        -> ::pltxt2htm::details::MdListLiNode& = default;
 
     [[nodiscard]]
 #if __has_cpp_attribute(__gnu__::__pure__)
     [[__gnu__::__pure__]]
 #endif
-    constexpr auto operator==(this ::pltxt2htm::details::MdListTextNode const& self,
-                              ::pltxt2htm::details::MdListTextNode const& other) noexcept -> bool {
-        return self.text == other.text && self.checkbox_ == other.checkbox_ && self.checked_ == other.checked_;
+    constexpr auto operator==(this ::pltxt2htm::details::MdListLiNode const& self,
+                              ::pltxt2htm::details::MdListLiNode const& other) noexcept -> bool {
+        return self.text == other.text;
     }
 
     [[nodiscard]]
-    constexpr auto is_checkbox(this auto&& self) noexcept -> bool {
-        return self.checkbox_;
+    constexpr auto get_text(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.text);
+    }
+
+    [[nodiscard]]
+    constexpr auto get_text_view(this ::pltxt2htm::details::MdListLiNode const& self) noexcept {
+        return ::fast_io::u8string_view{self.text.data(), self.text.size()};
+    }
+};
+
+/**
+ * @brief Leaf markdown-list node for checkbox items (- [ ] / - [x]).
+ */
+class MdListLiCheckboxNode {
+    ::fast_io::u8string text;
+    bool checked_{};
+
+public:
+    constexpr MdListLiCheckboxNode(::fast_io::u8string&& text_, bool checked) noexcept
+        : text(::std::move(text_)),
+          checked_(checked) {
+    }
+
+    constexpr MdListLiCheckboxNode(::pltxt2htm::details::MdListLiCheckboxNode const&) noexcept = default;
+
+    constexpr MdListLiCheckboxNode(::pltxt2htm::details::MdListLiCheckboxNode&&) noexcept = default;
+
+    constexpr ~MdListLiCheckboxNode() noexcept = default;
+
+    constexpr auto operator=(this ::pltxt2htm::details::MdListLiCheckboxNode& self,
+                             ::pltxt2htm::details::MdListLiCheckboxNode const& other) noexcept
+        -> ::pltxt2htm::details::MdListLiCheckboxNode& = default;
+
+    constexpr auto operator=(this ::pltxt2htm::details::MdListLiCheckboxNode& self,
+                             ::pltxt2htm::details::MdListLiCheckboxNode&&) noexcept
+        -> ::pltxt2htm::details::MdListLiCheckboxNode& = default;
+
+    [[nodiscard]]
+#if __has_cpp_attribute(__gnu__::__pure__)
+    [[__gnu__::__pure__]]
+#endif
+    constexpr auto operator==(this ::pltxt2htm::details::MdListLiCheckboxNode const& self,
+                              ::pltxt2htm::details::MdListLiCheckboxNode const& other) noexcept -> bool {
+        return self.text == other.text && self.checked_ == other.checked_;
     }
 
     [[nodiscard]]
@@ -108,7 +143,7 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto get_text_view(this ::pltxt2htm::details::MdListTextNode const& self) noexcept {
+    constexpr auto get_text_view(this ::pltxt2htm::details::MdListLiCheckboxNode const& self) noexcept {
         return ::fast_io::u8string_view{self.text.data(), self.text.size()};
     }
 };
@@ -191,7 +226,8 @@ public:
 template<::pltxt2htm::Contracts ndebug>
 class MdListBaseNode {
     union {
-        ::pltxt2htm::details::MdListTextNode text_node;
+        ::pltxt2htm::details::MdListLiNode li_node;
+        ::pltxt2htm::details::MdListLiCheckboxNode li_checkbox_node;
         ::pltxt2htm::details::MdListUlNode<ndebug> ul_node;
         ::pltxt2htm::details::MdListOlNode<ndebug> ol_node;
     };
@@ -201,9 +237,14 @@ class MdListBaseNode {
 public:
     constexpr MdListBaseNode() noexcept = delete;
 
-    constexpr MdListBaseNode(::pltxt2htm::details::MdListTextNode&& node) noexcept
-        : text_node(::std::move(node)),
-          type_{::pltxt2htm::details::MdListNodeType::text} {
+    constexpr MdListBaseNode(::pltxt2htm::details::MdListLiNode&& node) noexcept
+        : li_node(::std::move(node)),
+          type_{::pltxt2htm::details::MdListNodeType::md_li} {
+    }
+
+    constexpr MdListBaseNode(::pltxt2htm::details::MdListLiCheckboxNode&& node) noexcept
+        : li_checkbox_node(::std::move(node)),
+          type_{::pltxt2htm::details::MdListNodeType::md_li_checkbox} {
     }
 
     constexpr MdListBaseNode(::pltxt2htm::details::MdListUlNode<ndebug>&& node) noexcept
@@ -221,8 +262,13 @@ public:
     constexpr MdListBaseNode(::pltxt2htm::details::MdListBaseNode<ndebug>&& other) noexcept
         : type_(other.type_) {
         switch (type_) /* -Werror=switch */ {
-        case ::pltxt2htm::details::MdListNodeType::text: {
-            new (::std::addressof(text_node))::pltxt2htm::details::MdListTextNode(::std::move(other.text_node));
+        case ::pltxt2htm::details::MdListNodeType::md_li: {
+            new (::std::addressof(li_node))::pltxt2htm::details::MdListLiNode(::std::move(other.li_node));
+            break;
+        }
+        case ::pltxt2htm::details::MdListNodeType::md_li_checkbox: {
+            new (::std::addressof(li_checkbox_node))::pltxt2htm::details::MdListLiCheckboxNode(
+                ::std::move(other.li_checkbox_node));
             break;
         }
         case ::pltxt2htm::details::MdListNodeType::md_ul: {
@@ -244,8 +290,12 @@ public:
 
     constexpr ~MdListBaseNode() noexcept {
         switch (type_) /* -Werror=switch */ {
-        case ::pltxt2htm::details::MdListNodeType::text: {
-            text_node.~MdListTextNode();
+        case ::pltxt2htm::details::MdListNodeType::md_li: {
+            li_node.~MdListLiNode();
+            break;
+        }
+        case ::pltxt2htm::details::MdListNodeType::md_li_checkbox: {
+            li_checkbox_node.~MdListLiCheckboxNode();
             break;
         }
         case ::pltxt2htm::details::MdListNodeType::md_ul: {
@@ -286,12 +336,40 @@ public:
 
     [[nodiscard]]
     constexpr auto get_text(this auto&& self) noexcept -> decltype(auto) {
-        return ::std::forward_like<decltype(self)>(self.text_node).get_text();
+        switch (self.type_) /* -Werror=switch */ {
+        case ::pltxt2htm::details::MdListNodeType::md_li: {
+            return ::std::forward_like<decltype(self)>(self.li_node).get_text();
+        }
+        case ::pltxt2htm::details::MdListNodeType::md_li_checkbox: {
+            return ::std::forward_like<decltype(self)>(self.li_checkbox_node).get_text();
+        }
+        case ::pltxt2htm::details::MdListNodeType::md_ul:
+            [[fallthrough]];
+        case ::pltxt2htm::details::MdListNodeType::md_ol:
+            [[unlikely]] {
+                ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+            }
+        }
+        ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
     }
 
     [[nodiscard]]
     constexpr auto get_text_view(this auto&& self) noexcept -> ::fast_io::u8string_view {
-        return self.text_node.get_text_view();
+        switch (self.type_) /* -Werror=switch */ {
+        case ::pltxt2htm::details::MdListNodeType::md_li: {
+            return self.li_node.get_text_view();
+        }
+        case ::pltxt2htm::details::MdListNodeType::md_li_checkbox: {
+            return self.li_checkbox_node.get_text_view();
+        }
+        case ::pltxt2htm::details::MdListNodeType::md_ul:
+            [[fallthrough]];
+        case ::pltxt2htm::details::MdListNodeType::md_ol:
+            [[unlikely]] {
+                ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+            }
+        }
+        ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
     }
 
     [[nodiscard]]
@@ -303,7 +381,9 @@ public:
         case ::pltxt2htm::details::MdListNodeType::md_ol: {
             return ::std::forward_like<decltype(self)>(self.ol_node).get_sublist();
         }
-        case ::pltxt2htm::details::MdListNodeType::text:
+        case ::pltxt2htm::details::MdListNodeType::md_li:
+            [[fallthrough]];
+        case ::pltxt2htm::details::MdListNodeType::md_li_checkbox:
             [[unlikely]] {
                 ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
             }
@@ -313,25 +393,17 @@ public:
 
     [[nodiscard]]
     constexpr auto is_checkbox(this auto&& self) noexcept -> bool {
-        switch (self.type_) /* -Werror=switch */ {
-        case ::pltxt2htm::details::MdListNodeType::text: {
-            return self.text_node.is_checkbox();
-        }
-        case ::pltxt2htm::details::MdListNodeType::md_ul:
-            [[fallthrough]];
-        case ::pltxt2htm::details::MdListNodeType::md_ol: {
-            return false;
-        }
-        }
-        ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+        return self.type_ == ::pltxt2htm::details::MdListNodeType::md_li_checkbox;
     }
 
     [[nodiscard]]
     constexpr auto is_checked(this auto&& self) noexcept -> bool {
         switch (self.type_) /* -Werror=switch */ {
-        case ::pltxt2htm::details::MdListNodeType::text: {
-            return self.text_node.is_checked();
+        case ::pltxt2htm::details::MdListNodeType::md_li_checkbox: {
+            return self.li_checkbox_node.is_checked();
         }
+        case ::pltxt2htm::details::MdListNodeType::md_li:
+            [[fallthrough]];
         case ::pltxt2htm::details::MdListNodeType::md_ul:
             [[fallthrough]];
         case ::pltxt2htm::details::MdListNodeType::md_ol: {
@@ -349,8 +421,11 @@ public:
         }
 
         switch (self.type_) {
-        case ::pltxt2htm::details::MdListNodeType::text: {
-            return self.text_node == other.text_node;
+        case ::pltxt2htm::details::MdListNodeType::md_li: {
+            return self.li_node == other.li_node;
+        }
+        case ::pltxt2htm::details::MdListNodeType::md_li_checkbox: {
+            return self.li_checkbox_node == other.li_checkbox_node;
         }
         case ::pltxt2htm::details::MdListNodeType::md_ul: {
             return self.ul_node == other.ul_node;
@@ -435,7 +510,8 @@ constexpr bool is_md_list_ol_node_<::pltxt2htm::details::MdListOlNode<ndebug>> =
  * @brief Concept matching the concrete node types stored in MdListBaseNode.
  */
 template<typename T>
-concept is_md_list_node_type = ::std::is_same_v<::std::remove_cvref_t<T>, ::pltxt2htm::details::MdListTextNode> ||
+concept is_md_list_node_type = ::std::is_same_v<::std::remove_cvref_t<T>, ::pltxt2htm::details::MdListLiNode> ||
+                               ::std::is_same_v<::std::remove_cvref_t<T>, ::pltxt2htm::details::MdListLiCheckboxNode> ||
                                ::pltxt2htm::details::is_md_list_ul_node_<::std::remove_cvref_t<T>> ||
                                ::pltxt2htm::details::is_md_list_ol_node_<::std::remove_cvref_t<T>>;
 
@@ -738,8 +814,13 @@ constexpr auto optionally_to_md_list_ast(::fast_io::u8string_view pltext) noexce
                 opt_item.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
             ::pltxt2htm::details::MdListFrameContext<ndebug> current_frame{item_kind, space_hierarchy, pltext,
                                                                            forward_index};
-            current_frame.md_list_ast.emplace_back(
-                ::pltxt2htm::details::MdListTextNode(::std::move(text), checkbox, checked));
+            if (checkbox) {
+                current_frame.md_list_ast.emplace_back(
+                    ::pltxt2htm::details::MdListLiCheckboxNode(::std::move(text), checked));
+            }
+            else {
+                current_frame.md_list_ast.emplace_back(::pltxt2htm::details::MdListLiNode(::std::move(text)));
+            }
             if (forward_index >= current_frame.pltext.size()) {
                 return ::pltxt2htm::details::ToMdListAstResult<ndebug>{
                     .ast = ::std::move(current_frame.md_list_ast),
@@ -809,11 +890,21 @@ constexpr auto optionally_to_md_list_ast(::fast_io::u8string_view pltext) noexce
                 item_kind, space_hierarchy,
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(top_frame.pltext, current_index)});
             auto&& child_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-            child_frame.md_list_ast.emplace_back(
-                ::pltxt2htm::details::MdListTextNode(::std::move(text), checkbox, checked));
+            if (checkbox) {
+                child_frame.md_list_ast.emplace_back(
+                    ::pltxt2htm::details::MdListLiCheckboxNode(::std::move(text), checked));
+            }
+            else {
+                child_frame.md_list_ast.emplace_back(::pltxt2htm::details::MdListLiNode(::std::move(text)));
+            }
             continue;
         }
-        result.emplace_back(::pltxt2htm::details::MdListTextNode(::std::move(text), checkbox, checked));
+        if (checkbox) {
+            result.emplace_back(::pltxt2htm::details::MdListLiCheckboxNode(::std::move(text), checked));
+        }
+        else {
+            result.emplace_back(::pltxt2htm::details::MdListLiNode(::std::move(text)));
+        }
         top_frame.space_hierarchy = space_hierarchy;
 
         if (current_index < pltext_size) {

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -190,12 +190,15 @@ entry:
         }
         switch (frame_iter->get_type()) {
         case ::pltxt2htm::details::MdListNodeType::text: {
-            call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(frame_iter->get_text_view(),
-                                                                             ::pltxt2htm::NodeKind::md_li));
             {
-                auto& new_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                new_frame.checkbox = frame_iter->is_checkbox();
-                new_frame.checked = frame_iter->is_checked();
+                auto const node_kind =
+                    frame_iter->is_checkbox() ? ::pltxt2htm::NodeKind::md_li_checkbox : ::pltxt2htm::NodeKind::md_li;
+                call_stack.push(
+                    ::pltxt2htm::details::ParserFrameContext<ndebug>(frame_iter->get_text_view(), node_kind));
+                if (frame_iter->is_checkbox()) {
+                    auto& new_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                    new_frame.checked = frame_iter->is_checked();
+                }
             }
             break;
         }
@@ -252,12 +255,15 @@ entry:
         }
         switch (frame_iter->get_type()) {
         case ::pltxt2htm::details::MdListNodeType::text: {
-            call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(frame_iter->get_text_view(),
-                                                                             ::pltxt2htm::NodeKind::md_li));
             {
-                auto& new_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                new_frame.checkbox = frame_iter->is_checkbox();
-                new_frame.checked = frame_iter->is_checked();
+                auto const node_kind =
+                    frame_iter->is_checkbox() ? ::pltxt2htm::NodeKind::md_li_checkbox : ::pltxt2htm::NodeKind::md_li;
+                call_stack.push(
+                    ::pltxt2htm::details::ParserFrameContext<ndebug>(frame_iter->get_text_view(), node_kind));
+                if (frame_iter->is_checkbox()) {
+                    auto& new_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                    new_frame.checked = frame_iter->is_checked();
+                }
             }
             break;
         }
@@ -1909,6 +1915,8 @@ entry:
                     [[fallthrough]];
                 case ::pltxt2htm::NodeKind::md_li:
                     [[fallthrough]];
+                case ::pltxt2htm::NodeKind::md_li_checkbox:
+                    [[fallthrough]];
                 case ::pltxt2htm::NodeKind::md_escape_backslash:
                     [[fallthrough]];
                 case ::pltxt2htm::NodeKind::md_escape_exclamation:
@@ -2191,10 +2199,14 @@ entry:
             goto entry;
         }
         case ::pltxt2htm::NodeKind::md_li: {
-            auto checkbox = frame.checkbox;
+            parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdLi<ndebug>{::std::move(subast)}));
+            parent_index += staged_index;
+            goto entry;
+        }
+        case ::pltxt2htm::NodeKind::md_li_checkbox: {
             auto checked = frame.checked;
             parent_ast.push_back(
-                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdLi<ndebug>{::std::move(subast), checkbox, checked}));
+                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdLiCheckbox<ndebug>{::std::move(subast), checked}));
             parent_index += staged_index;
             goto entry;
         }

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -193,7 +193,7 @@ entry:
             [[fallthrough]];
         case ::pltxt2htm::details::MdListNodeType::md_li_checkbox: {
             {
-                if (frame_iter->is_checkbox()) {
+                if (frame_iter->get_type() == ::pltxt2htm::details::MdListNodeType::md_li_checkbox) {
                     call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                         frame_iter->get_text_view(), frame_iter->is_checked(), ::pltxt2htm::NodeKind::md_li_checkbox));
                 }
@@ -260,7 +260,7 @@ entry:
             [[fallthrough]];
         case ::pltxt2htm::details::MdListNodeType::md_li_checkbox: {
             {
-                if (frame_iter->is_checkbox()) {
+                if (frame_iter->get_type() == ::pltxt2htm::details::MdListNodeType::md_li_checkbox) {
                     call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                         frame_iter->get_text_view(), frame_iter->is_checked(), ::pltxt2htm::NodeKind::md_li_checkbox));
                 }

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -189,7 +189,9 @@ entry:
             goto entry;
         }
         switch (frame_iter->get_type()) {
-        case ::pltxt2htm::details::MdListNodeType::text: {
+        case ::pltxt2htm::details::MdListNodeType::md_li:
+            [[fallthrough]];
+        case ::pltxt2htm::details::MdListNodeType::md_li_checkbox: {
             {
                 auto const node_kind =
                     frame_iter->is_checkbox() ? ::pltxt2htm::NodeKind::md_li_checkbox : ::pltxt2htm::NodeKind::md_li;
@@ -254,7 +256,9 @@ entry:
             goto entry;
         }
         switch (frame_iter->get_type()) {
-        case ::pltxt2htm::details::MdListNodeType::text: {
+        case ::pltxt2htm::details::MdListNodeType::md_li:
+            [[fallthrough]];
+        case ::pltxt2htm::details::MdListNodeType::md_li_checkbox: {
             {
                 auto const node_kind =
                     frame_iter->is_checkbox() ? ::pltxt2htm::NodeKind::md_li_checkbox : ::pltxt2htm::NodeKind::md_li;

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -195,12 +195,11 @@ entry:
             {
                 if (frame_iter->is_checkbox()) {
                     call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                        frame_iter->get_text_view(), frame_iter->is_checked(),
-                        ::pltxt2htm::NodeKind::md_li_checkbox));
+                        frame_iter->get_text_view(), frame_iter->is_checked(), ::pltxt2htm::NodeKind::md_li_checkbox));
                 }
                 else {
-                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                        frame_iter->get_text_view(), ::pltxt2htm::NodeKind::md_li));
+                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(frame_iter->get_text_view(),
+                                                                                     ::pltxt2htm::NodeKind::md_li));
                 }
             }
             break;
@@ -263,12 +262,11 @@ entry:
             {
                 if (frame_iter->is_checkbox()) {
                     call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                        frame_iter->get_text_view(), frame_iter->is_checked(),
-                        ::pltxt2htm::NodeKind::md_li_checkbox));
+                        frame_iter->get_text_view(), frame_iter->is_checked(), ::pltxt2htm::NodeKind::md_li_checkbox));
                 }
                 else {
-                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                        frame_iter->get_text_view(), ::pltxt2htm::NodeKind::md_li));
+                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(frame_iter->get_text_view(),
+                                                                                     ::pltxt2htm::NodeKind::md_li));
                 }
             }
             break;

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -193,13 +193,14 @@ entry:
             [[fallthrough]];
         case ::pltxt2htm::details::MdListNodeType::md_li_checkbox: {
             {
-                auto const node_kind =
-                    frame_iter->is_checkbox() ? ::pltxt2htm::NodeKind::md_li_checkbox : ::pltxt2htm::NodeKind::md_li;
-                call_stack.push(
-                    ::pltxt2htm::details::ParserFrameContext<ndebug>(frame_iter->get_text_view(), node_kind));
                 if (frame_iter->is_checkbox()) {
-                    auto& new_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                    new_frame.checked = frame_iter->is_checked();
+                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                        frame_iter->get_text_view(), frame_iter->is_checked(),
+                        ::pltxt2htm::NodeKind::md_li_checkbox));
+                }
+                else {
+                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                        frame_iter->get_text_view(), ::pltxt2htm::NodeKind::md_li));
                 }
             }
             break;
@@ -260,13 +261,14 @@ entry:
             [[fallthrough]];
         case ::pltxt2htm::details::MdListNodeType::md_li_checkbox: {
             {
-                auto const node_kind =
-                    frame_iter->is_checkbox() ? ::pltxt2htm::NodeKind::md_li_checkbox : ::pltxt2htm::NodeKind::md_li;
-                call_stack.push(
-                    ::pltxt2htm::details::ParserFrameContext<ndebug>(frame_iter->get_text_view(), node_kind));
                 if (frame_iter->is_checkbox()) {
-                    auto& new_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                    new_frame.checked = frame_iter->is_checked();
+                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                        frame_iter->get_text_view(), frame_iter->is_checked(),
+                        ::pltxt2htm::NodeKind::md_li_checkbox));
+                }
+                else {
+                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                        frame_iter->get_text_view(), ::pltxt2htm::NodeKind::md_li));
                 }
             }
             break;
@@ -2208,7 +2210,7 @@ entry:
             goto entry;
         }
         case ::pltxt2htm::NodeKind::md_li_checkbox: {
-            auto checked = frame.checked;
+            auto checked = frame.get_checked();
             parent_ast.push_back(
                 ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdLiCheckbox<ndebug>{::std::move(subast), checked}));
             parent_index += staged_index;

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -192,6 +192,11 @@ entry:
         case ::pltxt2htm::details::MdListNodeType::text: {
             call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(frame_iter->get_text_view(),
                                                                              ::pltxt2htm::NodeKind::md_li));
+            {
+                auto& new_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                new_frame.checkbox = frame_iter->is_checkbox();
+                new_frame.checked = frame_iter->is_checked();
+            }
             break;
         }
         case ::pltxt2htm::details::MdListNodeType::md_ul: {
@@ -249,6 +254,11 @@ entry:
         case ::pltxt2htm::details::MdListNodeType::text: {
             call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(frame_iter->get_text_view(),
                                                                              ::pltxt2htm::NodeKind::md_li));
+            {
+                auto& new_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                new_frame.checkbox = frame_iter->is_checkbox();
+                new_frame.checked = frame_iter->is_checked();
+            }
             break;
         }
         case ::pltxt2htm::details::MdListNodeType::md_ul: {
@@ -2181,7 +2191,10 @@ entry:
             goto entry;
         }
         case ::pltxt2htm::NodeKind::md_li: {
-            parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdLi<ndebug>{::std::move(subast)}));
+            auto checkbox = frame.checkbox;
+            auto checked = frame.checked;
+            parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                ::pltxt2htm::MdLi<ndebug>{::std::move(subast), checkbox, checked}));
             parent_index += staged_index;
             goto entry;
         }

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -2193,8 +2193,8 @@ entry:
         case ::pltxt2htm::NodeKind::md_li: {
             auto checkbox = frame.checkbox;
             auto checked = frame.checked;
-            parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                ::pltxt2htm::MdLi<ndebug>{::std::move(subast), checkbox, checked}));
+            parent_ast.push_back(
+                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdLi<ndebug>{::std::move(subast), checkbox, checked}));
             parent_index += staged_index;
             goto entry;
         }

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1439,7 +1439,7 @@ constexpr auto try_parse_md_block_quotes(::fast_io::u8string_view pltext) noexce
         subpltext.pop_back();
     }
     return ::pltxt2htm::details::TryParseMdBlockQuotesResult{.forward_index = current_index,
-                                                                     .subpltext = ::std::move(subpltext)};
+                                                             .subpltext = ::std::move(subpltext)};
 }
 
 template<::pltxt2htm::Contracts ndebug>

--- a/include/pltxt2htm/details/utils.hh
+++ b/include/pltxt2htm/details/utils.hh
@@ -134,7 +134,8 @@ template<::pltxt2htm::Contracts ndebug>
 #if __has_cpp_attribute(__gnu__::__pure__)
 [[__gnu__::__pure__]]
 #endif
-constexpr auto vector_index(::pltxt2htm::details::is_fast_io_vector auto&& vec, ::std::size_t i) noexcept -> decltype(auto) {
+constexpr auto vector_index(::pltxt2htm::details::is_fast_io_vector auto&& vec, ::std::size_t i) noexcept
+    -> decltype(auto) {
     bool const is_not_out_of_bound{i < vec.size()};
     pltxt2htm_assert(is_not_out_of_bound, u8"Index of vector out of bound");
 

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -707,6 +707,8 @@ entry:
                     ::std::addressof(subast), ::pltxt2htm::NodeKind::html_ol, subast.begin()));
             goto entry;
         }
+        case ::pltxt2htm::NodeKind::md_li_checkbox:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_li:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_li: {

--- a/tests/test_md_checkbox.cc
+++ b/tests/test_md_checkbox.cc
@@ -1,77 +1,55 @@
-#include <pltxt2htm/details/parser/md_list.hh>
-#include <pltxt2htm/details/parser/frame_concext.hh>
-#include <pltxt2htm/parser.hh>
-#include <pltxt2htm/ast/ast.hh>
-#include <cstdio>
+#include "precompile.hh"
 
 int main() {
-    // Test 1: optionally_to_md_list_ast
+    // ---- unchecked checkbox ----
     {
-        using detail = ::pltxt2htm::details;
-        auto opt = detail::optionally_to_md_list_ast<::pltxt2htm::Contracts::quick_enforce>(u8"- [ ] task");
-        if (!opt.has_value()) {
-            std::printf("FAIL: optionally_to_md_list_ast returned nullopt\n");
-            return 1;
-        }
-        auto& md_ast = opt.template value<false>().ast;
-        if (md_ast.empty()) {
-            std::printf("FAIL: ast is empty\n");
-            return 1;
-        }
-        auto iter = md_ast.begin();
-        if (iter->get_type() != detail::MdListNodeType::text) {
-            std::printf("FAIL: not a text node\n");
-            return 1;
-        }
-        if (!iter->is_checkbox()) {
-            std::printf("FAIL: is_checkbox() is false in MdListAst\n");
-            return 1;
-        }
-        std::printf("PASS: optionally_to_md_list_ast checkbox=%d checked=%d\n",
-                    (int)iter->is_checkbox(), (int)iter->is_checked());
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"- [ ] task");
+        auto answer = ::fast_io::u8string_view(u8"<ul><li><input type=\"checkbox\" disabled>task</li></ul>");
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity = ::pltxt2htm_test::pltxt2plunity_introduction(u8"- [ ] task");
+        auto plunity_answer = ::fast_io::u8string_view(u8"[ ] task\n");
+        pltxt2htm_test_assert_equal(plunity, plunity_answer);
     }
-
-    // Test 2: parse_pltxt top-level
+    // ---- checked checkbox ----
     {
-        auto ast = ::pltxt2htm::parse_pltxt<::pltxt2htm::Contracts::quick_enforce>(u8"- [ ] task");
-        std::printf("Top-level AST has %zu nodes\n", ast.size());
-        for (auto& node : ast) {
-            std::printf("  node kind = %d\n", (int)node.get_node_kind());
-            if (node.get_node_kind() == ::pltxt2htm::NodeKind::md_li) {
-                std::printf("  md_li: checkbox=%d checked=%d\n",
-                            (int)node.is_checkbox(), (int)node.is_checked());
-            }
-            else if (node.get_node_kind() == ::pltxt2htm::NodeKind::md_ul) {
-                auto& subast = node.get_subast();
-                std::printf("  md_ul has %zu children\n", subast.size());
-                for (auto& child : subast) {
-                    std::printf("    child kind = %d\n", (int)child.get_node_kind());
-                    if (child.get_node_kind() == ::pltxt2htm::NodeKind::md_li) {
-                        std::printf("    md_li: checkbox=%d checked=%d\n",
-                                    (int)child.is_checkbox(), (int)child.is_checked());
-                    }
-                }
-            }
-        }
-        // Actually verify
-        bool found = false;
-        for (auto& node : ast) {
-            if (node.get_node_kind() == ::pltxt2htm::NodeKind::md_li && node.is_checkbox()) {
-                found = true;
-            }
-            else if (node.get_node_kind() == ::pltxt2htm::NodeKind::md_ul) {
-                for (auto& child : node.get_subast()) {
-                    if (child.get_node_kind() == ::pltxt2htm::NodeKind::md_li && child.is_checkbox()) {
-                        found = true;
-                    }
-                }
-            }
-        }
-        if (!found) {
-            std::printf("FAIL: no checkbox md_li found in parse_pltxt result\n");
-            return 1;
-        }
-        std::printf("PASS: parse_pltxt result has checkbox\n");
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"- [x] done");
+        auto answer = ::fast_io::u8string_view(u8"<ul><li><input type=\"checkbox\" disabled checked>done</li></ul>");
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity = ::pltxt2htm_test::pltxt2plunity_introduction(u8"- [x] done");
+        auto plunity_answer = ::fast_io::u8string_view(u8"[x] done\n");
+        pltxt2htm_test_assert_equal(plunity, plunity_answer);
+    }
+    // ---- uppercase X ----
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"- [X] done");
+        auto answer = ::fast_io::u8string_view(u8"<ul><li><input type=\"checkbox\" disabled checked>done</li></ul>");
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // ---- nested checkboxes ----
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"- [ ] parent\n  - [x] child");
+        auto answer = ::fast_io::u8string_view(
+            u8"<ul><li><input type=\"checkbox\" disabled>parent</li><ul><li><input type=\"checkbox\" disabled checked>child</li></ul></ul>");
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // ---- checkbox in mixed list ----
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"- [ ] task\n- normal");
+        auto answer = ::fast_io::u8string_view(
+            u8"<ul><li><input type=\"checkbox\" disabled>task</li><li>normal</li></ul>");
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // ---- [ ] without following space is not a checkbox ----
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"- [] not a checkbox");
+        auto answer = ::fast_io::u8string_view(u8"<ul><li>[]&nbsp;not&nbsp;a&nbsp;checkbox</li></ul>");
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // ---- [x] without following space is not a checkbox ----
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"- [x]not a checkbox");
+        auto answer = ::fast_io::u8string_view(u8"<ul><li>[x]not&nbsp;a&nbsp;checkbox</li></ul>");
+        pltxt2htm_test_assert_equal(html, answer);
     }
     return 0;
 }

--- a/tests/test_md_checkbox.cc
+++ b/tests/test_md_checkbox.cc
@@ -1,0 +1,77 @@
+#include <pltxt2htm/details/parser/md_list.hh>
+#include <pltxt2htm/details/parser/frame_concext.hh>
+#include <pltxt2htm/parser.hh>
+#include <pltxt2htm/ast/ast.hh>
+#include <cstdio>
+
+int main() {
+    // Test 1: optionally_to_md_list_ast
+    {
+        using detail = ::pltxt2htm::details;
+        auto opt = detail::optionally_to_md_list_ast<::pltxt2htm::Contracts::quick_enforce>(u8"- [ ] task");
+        if (!opt.has_value()) {
+            std::printf("FAIL: optionally_to_md_list_ast returned nullopt\n");
+            return 1;
+        }
+        auto& md_ast = opt.template value<false>().ast;
+        if (md_ast.empty()) {
+            std::printf("FAIL: ast is empty\n");
+            return 1;
+        }
+        auto iter = md_ast.begin();
+        if (iter->get_type() != detail::MdListNodeType::text) {
+            std::printf("FAIL: not a text node\n");
+            return 1;
+        }
+        if (!iter->is_checkbox()) {
+            std::printf("FAIL: is_checkbox() is false in MdListAst\n");
+            return 1;
+        }
+        std::printf("PASS: optionally_to_md_list_ast checkbox=%d checked=%d\n",
+                    (int)iter->is_checkbox(), (int)iter->is_checked());
+    }
+
+    // Test 2: parse_pltxt top-level
+    {
+        auto ast = ::pltxt2htm::parse_pltxt<::pltxt2htm::Contracts::quick_enforce>(u8"- [ ] task");
+        std::printf("Top-level AST has %zu nodes\n", ast.size());
+        for (auto& node : ast) {
+            std::printf("  node kind = %d\n", (int)node.get_node_kind());
+            if (node.get_node_kind() == ::pltxt2htm::NodeKind::md_li) {
+                std::printf("  md_li: checkbox=%d checked=%d\n",
+                            (int)node.is_checkbox(), (int)node.is_checked());
+            }
+            else if (node.get_node_kind() == ::pltxt2htm::NodeKind::md_ul) {
+                auto& subast = node.get_subast();
+                std::printf("  md_ul has %zu children\n", subast.size());
+                for (auto& child : subast) {
+                    std::printf("    child kind = %d\n", (int)child.get_node_kind());
+                    if (child.get_node_kind() == ::pltxt2htm::NodeKind::md_li) {
+                        std::printf("    md_li: checkbox=%d checked=%d\n",
+                                    (int)child.is_checkbox(), (int)child.is_checked());
+                    }
+                }
+            }
+        }
+        // Actually verify
+        bool found = false;
+        for (auto& node : ast) {
+            if (node.get_node_kind() == ::pltxt2htm::NodeKind::md_li && node.is_checkbox()) {
+                found = true;
+            }
+            else if (node.get_node_kind() == ::pltxt2htm::NodeKind::md_ul) {
+                for (auto& child : node.get_subast()) {
+                    if (child.get_node_kind() == ::pltxt2htm::NodeKind::md_li && child.is_checkbox()) {
+                        found = true;
+                    }
+                }
+            }
+        }
+        if (!found) {
+            std::printf("FAIL: no checkbox md_li found in parse_pltxt result\n");
+            return 1;
+        }
+        std::printf("PASS: parse_pltxt result has checkbox\n");
+    }
+    return 0;
+}

--- a/tests/test_md_code_fence.cc
+++ b/tests/test_md_code_fence.cc
@@ -174,12 +174,8 @@ print("Hello World")
         // 5 backticks: first 3 are code span delimiter, remaining 2 are content
         // 0xE0 is an incomplete UTF-8 leading byte → gets replaced with U+FFFD
         // space inside <code> becomes &nbsp;
-        auto html = ::pltxt2htm_test::pltxt2fixedadv_htmld(
-            u8"`````\xe0 )\uBB6D"
-        );
-        auto answer = ::fast_io::u8string_view{
-            u8"<code>``\uFFFD&nbsp;)\uBB6D</code>"
-        };
+        auto html = ::pltxt2htm_test::pltxt2fixedadv_htmld(u8"`````\xe0 )\uBB6D");
+        auto answer = ::fast_io::u8string_view{u8"<code>``\uFFFD&nbsp;)\uBB6D</code>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_md_list_intermediate_ast.cc
+++ b/tests/test_md_list_intermediate_ast.cc
@@ -4,7 +4,7 @@ inline namespace pltxt2htm_test {
 
 template<::std::size_t N>
 constexpr auto text_item(char8_t const (&text)[N]) noexcept {
-    return ::pltxt2htm::details::MdListTextNode{::fast_io::u8string{text}};
+    return ::pltxt2htm::details::MdListLiNode{::fast_io::u8string{text}};
 }
 
 template<::pltxt2htm::Contracts ndebug = ::pltxt2htm::Contracts::quick_enforce,
@@ -35,8 +35,8 @@ constexpr auto ol_item(Nodes&&... nodes) noexcept {
 
 int main() {
     {
-        ::pltxt2htm::details::MdListTextNode node1{::fast_io::u8string{u8"test"}};
-        ::pltxt2htm::details::MdListTextNode node2{::fast_io::u8string{u8"test"}};
+        ::pltxt2htm::details::MdListLiNode node1{::fast_io::u8string{u8"test"}};
+        ::pltxt2htm::details::MdListLiNode node2{::fast_io::u8string{u8"test"}};
         ::exception::assert_true<false>(node1 == node2);
     }
     {
@@ -47,7 +47,7 @@ int main() {
         ::exception::assert_true<false>(node1 == node2);
     }
     {
-        ::pltxt2htm::details::MdListTextNode text_node{::fast_io::u8string{u8"test"}};
+        ::pltxt2htm::details::MdListLiNode text_node{::fast_io::u8string{u8"test"}};
         ::pltxt2htm::details::MdListUlNode<::pltxt2htm::Contracts::quick_enforce> ul_node{
             ::pltxt2htm::details::MdListAst<::pltxt2htm::Contracts::quick_enforce>{}};
         ::exception::assert_false<false>(

--- a/tests/test_xss.cc
+++ b/tests/test_xss.cc
@@ -427,6 +427,63 @@ int main() {
         assert_no_raw_xss_tags(to_view(html));
     }
     {
+        // Checkbox emits a legitimate <input> tag, so we verify script/iframe/object/svg
+        // are escaped rather than using assert_no_raw_xss_tags (which flags <input>).
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"- [ ] <script>alert(1)</script>");
+        auto v = to_view(html);
+        ::pltxt2htm_test::assert_true(contains_u8(v, u8"&lt;script&gt;alert(1)&lt;/script&gt;"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"script"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"iframe"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"object"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"svg"));
+        // Also verify standard checkbox <input> is present
+        ::pltxt2htm_test::assert_true(contains_u8(v, u8"<input type=\"checkbox\" disabled>"));
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"- [x] <script>alert(1)</script>");
+        auto v = to_view(html);
+        ::pltxt2htm_test::assert_true(contains_u8(v, u8"&lt;script&gt;alert(1)&lt;/script&gt;"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"script"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"iframe"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"object"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"svg"));
+        // Checked variant
+        ::pltxt2htm_test::assert_true(contains_u8(v, u8"<input type=\"checkbox\" disabled checked>"));
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"- [X] <script>alert(1)</script>");
+        auto v = to_view(html);
+        ::pltxt2htm_test::assert_true(contains_u8(v, u8"&lt;script&gt;alert(1)&lt;/script&gt;"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"script"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"iframe"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"object"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"svg"));
+        // Uppercase X also checked
+        ::pltxt2htm_test::assert_true(contains_u8(v, u8"<input type=\"checkbox\" disabled checked>"));
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"- [x] <script>alert(1)</script>");
+        auto v = to_view(html);
+        ::pltxt2htm_test::assert_true(contains_u8(v, u8"&lt;script&gt;alert(1)&lt;/script&gt;"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"script"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"iframe"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"object"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"svg"));
+        // Checked variant
+        ::pltxt2htm_test::assert_true(contains_u8(v, u8"<input type=\"checkbox\" disabled checked>"));
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"- [X] <script>alert(1)</script>");
+        auto v = to_view(html);
+        ::pltxt2htm_test::assert_true(contains_u8(v, u8"&lt;script&gt;alert(1)&lt;/script&gt;"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"script"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"iframe"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"object"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(v, u8"svg"));
+        // Uppercase X also checked
+        ::pltxt2htm_test::assert_true(contains_u8(v, u8"<input type=\"checkbox\" disabled checked>"));
+    }
+    {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"> <script>alert(1)</script>");
         assert_no_raw_xss_tags(to_view(html));
     }


### PR DESCRIPTION
- Parse `- [ ]`, `- [x]`, `- [X]` (with trailing space/tab) as checkboxes
  in `try_parse_item`, strip the `[ ]`/`[x]` prefix from text payload
- Add `NodeKind::md_li_checkbox` and `MdLiCheckbox<ndebug>` to the public
  AST, replacing bool fields on `MdLi` with a dedicated node type so the
  invalid state (checkbox=false, checked=true) is unrepresentable
- Add `MdListNodeType::md_li_checkbox`, `MdListLiCheckboxNode` (text +
  checked), rename `MdListTextNode` → `MdListLiNode` (pure text, no bools)
  in the intermediate list AST; update all 8+ dispatch sites and 3 creation
  branches in `optionally_to_md_list_ast`
- Add `checked` field to `ParserFrameContext`, propagate in move ctor
- Render web backend: `<li><input type="checkbox" disabled[/ checked]>`
- Render plunity backend: `[x] ` / `[ ] ` prefix inside `<li>`
- Plweb-title and optimizer: `md_li_checkbox` → `md_li` fallthrough
- Remove "Checkbox and mermaid are not planned yet" from README
- Add 7 test cases in `test_md_checkbox.cc` (unchecked, checked, uppercase X,
  nested, mixed list, non-checkbox `[]`/`[x]` without trailing space)
- Add XSS tests verifying `<script>` injection is escaped even with
  the legitimate `<input>` tag emitted by checkboxes