### PR TITLE
refactor: improve naming clarity across headers

### DIFF
--- a/cxxmodule/pltxt2htm/pltxt2htm.cppm
+++ b/cxxmodule/pltxt2htm/pltxt2htm.cppm
@@ -48,8 +48,8 @@ using ::pltxt2htm::LessThan;
 using ::pltxt2htm::GreaterThan;
 using ::pltxt2htm::Tab;
 using ::pltxt2htm::Ampersand;
-using ::pltxt2htm::SingleQuotationMark;
-using ::pltxt2htm::DoubleQuotationMark;
+using ::pltxt2htm::SingleQuote;
+using ::pltxt2htm::DoubleQuote;
 
 // html_node
 using ::pltxt2htm::HtmlBr;

--- a/include/pltxt2htm/ast/ast.hh
+++ b/include/pltxt2htm/ast/ast.hh
@@ -32,15 +32,15 @@ class PlTxtNode {
         ::pltxt2htm::Text<ndebug> text_node;
 
         // html node
-        ::pltxt2htm::LineBreak linebreak_node;
+        ::pltxt2htm::LineBreak line_break_node;
         ::pltxt2htm::HtmlBr br_node;
         ::pltxt2htm::Space space_node;
-        ::pltxt2htm::LessThan lessthan_node;
-        ::pltxt2htm::GreaterThan greaterthan_node;
+        ::pltxt2htm::LessThan less_than_node;
+        ::pltxt2htm::GreaterThan greater_than_node;
         ::pltxt2htm::Tab tab_node;
         ::pltxt2htm::Ampersand ampersand_node;
-        ::pltxt2htm::SingleQuotationMark singlequotationmark_node;
-        ::pltxt2htm::DoubleQuotationMark doublequotationmark_node;
+        ::pltxt2htm::SingleQuote single_quote_node;
+        ::pltxt2htm::DoubleQuote double_quote_node;
         ::pltxt2htm::HtmlHr hr_node;
         ::pltxt2htm::HtmlH1<ndebug> h1_node;
         ::pltxt2htm::HtmlH2<ndebug> h2_node;
@@ -240,7 +240,7 @@ public:
     }
 
     constexpr PlTxtNode(::pltxt2htm::LineBreak&& node) noexcept
-        : linebreak_node(::std::move(node)),
+        : line_break_node(::std::move(node)),
           node_kind{::pltxt2htm::NodeKind::line_break} {
     }
 
@@ -255,12 +255,12 @@ public:
     }
 
     constexpr PlTxtNode(::pltxt2htm::LessThan&& node) noexcept
-        : lessthan_node(::std::move(node)),
+        : less_than_node(::std::move(node)),
           node_kind{::pltxt2htm::NodeKind::less_than} {
     }
 
     constexpr PlTxtNode(::pltxt2htm::GreaterThan&& node) noexcept
-        : greaterthan_node(::std::move(node)),
+        : greater_than_node(::std::move(node)),
           node_kind{::pltxt2htm::NodeKind::greater_than} {
     }
 
@@ -274,13 +274,13 @@ public:
           node_kind{::pltxt2htm::NodeKind::ampersand} {
     }
 
-    constexpr PlTxtNode(::pltxt2htm::SingleQuotationMark&& node) noexcept
-        : singlequotationmark_node(::std::move(node)),
+    constexpr PlTxtNode(::pltxt2htm::SingleQuote&& node) noexcept
+        : single_quote_node(::std::move(node)),
           node_kind{::pltxt2htm::NodeKind::single_quote} {
     }
 
-    constexpr PlTxtNode(::pltxt2htm::DoubleQuotationMark&& node) noexcept
-        : doublequotationmark_node(::std::move(node)),
+    constexpr PlTxtNode(::pltxt2htm::DoubleQuote&& node) noexcept
+        : double_quote_node(::std::move(node)),
           node_kind{::pltxt2htm::NodeKind::double_quote} {
     }
 
@@ -830,7 +830,7 @@ public:
         }
 
         case ::pltxt2htm::NodeKind::line_break: {
-            new (::std::addressof(linebreak_node))::pltxt2htm::LineBreak(::std::move(other.linebreak_node));
+            new (::std::addressof(line_break_node))::pltxt2htm::LineBreak(::std::move(other.line_break_node));
             break;
         }
 
@@ -845,12 +845,12 @@ public:
         }
 
         case ::pltxt2htm::NodeKind::less_than: {
-            new (::std::addressof(lessthan_node))::pltxt2htm::LessThan(::std::move(other.lessthan_node));
+            new (::std::addressof(less_than_node))::pltxt2htm::LessThan(::std::move(other.less_than_node));
             break;
         }
 
         case ::pltxt2htm::NodeKind::greater_than: {
-            new (::std::addressof(greaterthan_node))::pltxt2htm::GreaterThan(::std::move(other.greaterthan_node));
+            new (::std::addressof(greater_than_node))::pltxt2htm::GreaterThan(::std::move(other.greater_than_node));
             break;
         }
 
@@ -865,14 +865,14 @@ public:
         }
 
         case ::pltxt2htm::NodeKind::single_quote: {
-            new (::std::addressof(singlequotationmark_node))::pltxt2htm::SingleQuotationMark(
-                ::std::move(other.singlequotationmark_node));
+            new (::std::addressof(single_quote_node))::pltxt2htm::SingleQuote(
+                ::std::move(other.single_quote_node));
             break;
         }
 
         case ::pltxt2htm::NodeKind::double_quote: {
-            new (::std::addressof(doublequotationmark_node))::pltxt2htm::DoubleQuotationMark(
-                ::std::move(other.doublequotationmark_node));
+            new (::std::addressof(double_quote_node))::pltxt2htm::DoubleQuote(
+                ::std::move(other.double_quote_node));
             break;
         }
 
@@ -1401,7 +1401,7 @@ public:
             break;
         }
         case ::pltxt2htm::NodeKind::line_break: {
-            linebreak_node.~LineBreak();
+            line_break_node.~LineBreak();
             break;
         }
         case ::pltxt2htm::NodeKind::html_br: {
@@ -1413,11 +1413,11 @@ public:
             break;
         }
         case ::pltxt2htm::NodeKind::less_than: {
-            lessthan_node.~LessThan();
+            less_than_node.~LessThan();
             break;
         }
         case ::pltxt2htm::NodeKind::greater_than: {
-            greaterthan_node.~GreaterThan();
+            greater_than_node.~GreaterThan();
             break;
         }
         case ::pltxt2htm::NodeKind::tab: {
@@ -1429,11 +1429,11 @@ public:
             break;
         }
         case ::pltxt2htm::NodeKind::single_quote: {
-            singlequotationmark_node.~SingleQuotationMark();
+            single_quote_node.~SingleQuote();
             break;
         }
         case ::pltxt2htm::NodeKind::double_quote: {
-            doublequotationmark_node.~DoubleQuotationMark();
+            double_quote_node.~DoubleQuote();
             break;
         }
         case ::pltxt2htm::NodeKind::html_hr: {

--- a/include/pltxt2htm/ast/impl/basic_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/basic_node_decl.hh
@@ -51,13 +51,13 @@ class Ampersand {};
  * @brief Single quotation mark node
  * @details Represents the "'" character.
  */
-class SingleQuotationMark {};
+class SingleQuote {};
 
 /**
  * @brief Double quotation mark node
  * @details Represents the '"' character.
  */
-class DoubleQuotationMark {};
+class DoubleQuote {};
 
 /**
  * @brief UTF-8 character node

--- a/include/pltxt2htm/details/literal_string.hh
+++ b/include/pltxt2htm/details/literal_string.hh
@@ -42,7 +42,7 @@ constexpr bool is_literal_string_<::pltxt2htm::details::BasicLiteralString<CharT
 } // namespace details
 
 template<typename T>
-concept is_leteral_string = ::pltxt2htm::details::details::is_literal_string_<::std::remove_cvref_t<T>>;
+concept is_literal_string = ::pltxt2htm::details::details::is_literal_string_<::std::remove_cvref_t<T>>;
 
 template<typename CharType, ::std::size_t N>
 class BasicLiteralString {
@@ -82,7 +82,7 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto&& operator[](this ::pltxt2htm::details::is_leteral_string auto&& self,
+    constexpr auto&& operator[](this ::pltxt2htm::details::is_literal_string auto&& self,
                                 ::std::size_t index) noexcept {
         if (index >= N) [[unlikely]] {
             ::exception::terminate();
@@ -96,32 +96,32 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto begin(this ::pltxt2htm::details::is_leteral_string auto const& self) noexcept -> const_iterator {
+    constexpr auto begin(this ::pltxt2htm::details::is_literal_string auto const& self) noexcept -> const_iterator {
         return const_iterator(self.data_);
     }
 
     [[nodiscard]]
-    constexpr auto cbegin(this ::pltxt2htm::details::is_leteral_string auto const& self) noexcept -> const_iterator {
+    constexpr auto cbegin(this ::pltxt2htm::details::is_literal_string auto const& self) noexcept -> const_iterator {
         return const_iterator(self.data_);
     }
 
     [[nodiscard]]
-    constexpr auto end(this ::pltxt2htm::details::is_leteral_string auto const& self) noexcept -> const_iterator {
+    constexpr auto end(this ::pltxt2htm::details::is_literal_string auto const& self) noexcept -> const_iterator {
         return const_iterator(self.data_ + N);
     }
 
     [[nodiscard]]
-    constexpr auto cend(this ::pltxt2htm::details::is_leteral_string auto const& self) noexcept -> const_iterator {
+    constexpr auto cend(this ::pltxt2htm::details::is_literal_string auto const& self) noexcept -> const_iterator {
         return const_iterator(self.data_ + N);
     }
 
     [[nodiscard]]
-    constexpr auto data(this ::pltxt2htm::details::is_leteral_string auto const& self) noexcept -> const_pointer {
+    constexpr auto data(this ::pltxt2htm::details::is_literal_string auto const& self) noexcept -> const_pointer {
         return const_pointer(self.data_);
     }
 
     [[nodiscard]]
-    constexpr auto cdata(this ::pltxt2htm::details::is_leteral_string auto const& self) noexcept -> const_pointer {
+    constexpr auto cdata(this ::pltxt2htm::details::is_literal_string auto const& self) noexcept -> const_pointer {
         return const_pointer(self.data_);
     }
 };
@@ -159,7 +159,7 @@ consteval auto uint_to_literal_string() noexcept {
 }
 
 template<typename result_type>
-consteval void concat_memcpy(::pltxt2htm::details::is_leteral_string auto const& args, ::std::size_t& index,
+consteval void concat_memcpy(::pltxt2htm::details::is_literal_string auto const& args, ::std::size_t& index,
                              result_type& result) noexcept {
     for (::std::size_t i{}; i < args.size(); ++i) {
         result[i + index] = args[i];
@@ -173,7 +173,7 @@ consteval void concat_memcpy(::pltxt2htm::details::is_leteral_string auto const&
  * @param[in] args The strings to concatenate
  * @return A new LiteralString containing all input strings concatenated
  */
-template<::pltxt2htm::details::is_leteral_string Arg, ::pltxt2htm::details::is_leteral_string... Args>
+template<::pltxt2htm::details::is_literal_string Arg, ::pltxt2htm::details::is_literal_string... Args>
     requires (::std::is_same_v<typename Arg::value_type, typename Args::value_type> && ...)
 consteval auto concat(Arg const& arg, Args const&... args) noexcept {
     auto result =

--- a/include/pltxt2htm/details/parser/md_list.hh
+++ b/include/pltxt2htm/details/parser/md_list.hh
@@ -671,7 +671,7 @@ constexpr auto is_valid_md_ol_list_hierarchy(
  */
 struct TryParseItemResult {
     ::std::size_t space_hierarchy;
-    ::std::size_t forward_index;
+    ::std::size_t advance_count;
     ::fast_io::u8string text;
     ::pltxt2htm::details::MdUlListItemKind item_kind;
     bool checkbox{};
@@ -774,7 +774,7 @@ constexpr auto try_parse_item(
     }
     return ::pltxt2htm::details::TryParseItemResult{
         .space_hierarchy = space_hierarchy,
-        .forward_index = current_index,
+        .advance_count = current_index,
         .text = ::std::move(text),
         .item_kind = item_kind,
         .checkbox = checkbox,
@@ -788,7 +788,7 @@ constexpr auto try_parse_item(
 template<::pltxt2htm::Contracts ndebug>
 struct ToMdListAstResult {
     ::pltxt2htm::details::MdListAst<ndebug> ast;
-    ::std::size_t forward_index;
+    ::std::size_t advance_count;
     ::pltxt2htm::NodeKind item_kind;
 };
 
@@ -801,10 +801,10 @@ constexpr auto optionally_to_md_list_ast(::fast_io::u8string_view pltext) noexce
     // manually managing stack to avoid stack-overflow
     {
         if (auto opt_item = ::pltxt2htm::details::try_parse_item<ndebug>(pltext); opt_item.has_value()) {
-            auto&& [space_hierarchy, forward_index, text, item_kind, checkbox, checked] =
+            auto&& [space_hierarchy, advance_count, text, item_kind, checkbox, checked] =
                 opt_item.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
             ::pltxt2htm::details::MdListFrameContext<ndebug> current_frame{item_kind, space_hierarchy, pltext,
-                                                                           forward_index};
+                                                                           advance_count};
             if (checkbox) {
                 current_frame.md_list_ast.emplace_back(
                     ::pltxt2htm::details::MdListLiCheckboxNode(::std::move(text), checked));
@@ -812,10 +812,10 @@ constexpr auto optionally_to_md_list_ast(::fast_io::u8string_view pltext) noexce
             else {
                 current_frame.md_list_ast.emplace_back(::pltxt2htm::details::MdListLiNode(::std::move(text)));
             }
-            if (forward_index >= current_frame.pltext.size()) {
+            if (advance_count >= current_frame.pltext.size()) {
                 return ::pltxt2htm::details::ToMdListAstResult<ndebug>{
                     .ast = ::std::move(current_frame.md_list_ast),
-                    .forward_index = forward_index,
+                    .advance_count = advance_count,
                     .item_kind = item_kind == ::pltxt2htm::details::MdUlListItemKind::ordered_item
                                      ? ::pltxt2htm::NodeKind::md_ol
                                      : ::pltxt2htm::NodeKind::md_ul};
@@ -842,7 +842,7 @@ constexpr auto optionally_to_md_list_ast(::fast_io::u8string_view pltext) noexce
             if (call_stack.empty()) {
                 return ::pltxt2htm::details::ToMdListAstResult<ndebug>{
                     .ast = ::std::move(frame.md_list_ast),
-                    .forward_index = frame.current_index,
+                    .advance_count = frame.current_index,
                     .item_kind = frame.get_item_kind() == ::pltxt2htm::details::MdUlListItemKind::ordered_item
                                      ? ::pltxt2htm::NodeKind::md_ol
                                      : ::pltxt2htm::NodeKind::md_ul};
@@ -873,9 +873,9 @@ constexpr auto optionally_to_md_list_ast(::fast_io::u8string_view pltext) noexce
             parent_frame.current_index += frame.current_index;
             continue;
         }
-        auto&& [space_hierarchy, forward_index, text, item_kind, checkbox, checked] =
+        auto&& [space_hierarchy, advance_count, text, item_kind, checkbox, checked] =
             opt_list_item.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-        current_index += forward_index;
+        current_index += advance_count;
         if (space_hierarchy > top_frame.space_hierarchy + 1) {
             call_stack.push(::pltxt2htm::details::MdListFrameContext<ndebug>{
                 item_kind, space_hierarchy,
@@ -906,7 +906,7 @@ constexpr auto optionally_to_md_list_ast(::fast_io::u8string_view pltext) noexce
         if (call_stack.empty()) {
             return ::pltxt2htm::details::ToMdListAstResult<ndebug>{
                 .ast = ::std::move(frame.md_list_ast),
-                .forward_index = pltext_size,
+                .advance_count = pltext_size,
                 .item_kind = frame.get_item_kind() == ::pltxt2htm::details::MdUlListItemKind::ordered_item
                                  ? ::pltxt2htm::NodeKind::md_ol
                                  : ::pltxt2htm::NodeKind::md_ul};

--- a/include/pltxt2htm/details/parser/md_table.hh
+++ b/include/pltxt2htm/details/parser/md_table.hh
@@ -17,7 +17,7 @@ namespace pltxt2htm::details {
  */
 struct TryParseMdTableRowResult {
     ::fast_io::vector<::fast_io::u8string> cells;
-    ::std::size_t forward_index;
+    ::std::size_t advance_count;
 };
 
 /**
@@ -292,7 +292,7 @@ public:
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseMdTableRawResult {
     ::pltxt2htm::details::MdTableAstRaw<ndebug> raw_ast; ///< parsed table AST
-    ::std::size_t forward_index; ///< number of characters consumed from input
+    ::std::size_t advance_count; ///< number of characters consumed from input
 };
 
 /**
@@ -387,7 +387,7 @@ constexpr auto try_parse_md_table_raw(::fast_io::u8string_view pltext) noexcept
     }
 
     return ::pltxt2htm::details::TryParseMdTableRawResult<ndebug>{.raw_ast = ::std::move(raw_ast),
-                                                                  .forward_index = current_index};
+                                                                  .advance_count = current_index};
 }
 
 } // namespace pltxt2htm::details

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -17,35 +17,35 @@
 
 namespace pltxt2htm::details {
 
-struct DevilStuffAfterLineBreakResult {
-    ::std::size_t forward_index;
+struct FindNextBlockAfterLineBreakResult {
+    ::std::size_t advance_count;
     bool new_frame_been_pushed_into_call_stack;
 };
 
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
-constexpr auto devil_stuff_after_line_break(
+constexpr auto find_next_block_after_line_break(
     ::fast_io::u8string_view pltext, ::fast_io::stack<::pltxt2htm::details::ParserFrameContext<ndebug>>& call_stack,
-    ::pltxt2htm::Ast<ndebug>& result) noexcept -> ::pltxt2htm::details::DevilStuffAfterLineBreakResult {
+    ::pltxt2htm::Ast<ndebug>& result) noexcept -> ::pltxt2htm::details::FindNextBlockAfterLineBreakResult {
     ::std::size_t current_index{};
     while (true) {
         if (current_index >= pltext.size()) {
-            return ::pltxt2htm::details::DevilStuffAfterLineBreakResult{.forward_index = current_index,
+            return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{.advance_count = current_index,
                                                                         .new_frame_been_pushed_into_call_stack = false};
         }
 
         if (auto opt_md_atx_heading = ::pltxt2htm::details::try_parse_md_atx_heading<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_md_atx_heading.has_value()) {
-            auto&& [start_index, sublength, forward_index, md_atx_heading_type] =
+            auto&& [start_index, sublength, advance_count, md_atx_heading_type] =
                 opt_md_atx_heading.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
             if (sublength != 0) {
                 auto subtext =
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + start_index, sublength);
                 call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(subtext, md_atx_heading_type));
-                current_index += forward_index;
-                return ::pltxt2htm::details::DevilStuffAfterLineBreakResult{
-                    .forward_index = current_index, .new_frame_been_pushed_into_call_stack = true};
+                current_index += advance_count;
+                return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{
+                    .advance_count = current_index, .new_frame_been_pushed_into_call_stack = true};
             }
 
             switch (md_atx_heading_type) {
@@ -84,7 +84,7 @@ constexpr auto devil_stuff_after_line_break(
                     ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
                 }
             }
-            current_index += forward_index;
+            current_index += advance_count;
             continue;
         }
         if (auto opt_len = ::pltxt2htm::details::try_parse_md_thematic_break<ndebug>(
@@ -97,39 +97,39 @@ constexpr auto devil_stuff_after_line_break(
         if (auto opt_code_fence = ::pltxt2htm::details::try_parse_md_code_fence<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_code_fence.has_value()) {
-            auto&& [node, forward_index] = opt_code_fence.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+            auto&& [node, advance_count] = opt_code_fence.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
             result.push_back(::std::move(node));
-            return ::pltxt2htm::details::DevilStuffAfterLineBreakResult{.forward_index = current_index + forward_index,
+            return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{.advance_count = current_index + advance_count,
                                                                         .new_frame_been_pushed_into_call_stack = false};
         }
         if (auto opt_block_quote = ::pltxt2htm::details::try_parse_md_block_quotes<ndebug>(pltext);
             opt_block_quote.has_value()) {
-            auto&& [forward_index, subpltext] =
+            auto&& [advance_count, subpltext] =
                 opt_block_quote.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
             call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(::std::move(subpltext)));
-            return ::pltxt2htm::details::DevilStuffAfterLineBreakResult{.forward_index = current_index + forward_index,
+            return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{.advance_count = current_index + advance_count,
                                                                         .new_frame_been_pushed_into_call_stack = true};
         }
         if (auto opt_md_list_ast = ::pltxt2htm::details::optionally_to_md_list_ast<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_md_list_ast.has_value()) {
-            auto&& [md_list_ast, forward_index, item_kind] =
+            auto&& [md_list_ast, advance_count, item_kind] =
                 opt_md_list_ast.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
             call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(item_kind, ::std::move(md_list_ast)));
-            return ::pltxt2htm::details::DevilStuffAfterLineBreakResult{.forward_index = current_index + forward_index,
+            return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{.advance_count = current_index + advance_count,
                                                                         .new_frame_been_pushed_into_call_stack = true};
         }
         if (auto opt_md_table_raw = ::pltxt2htm::details::try_parse_md_table_raw<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_md_table_raw.has_value()) {
-            auto&& [raw_ast, forward_index] =
+            auto&& [raw_ast, advance_count] =
                 opt_md_table_raw.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
             call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(::pltxt2htm::NodeKind::md_table,
                                                                              ::std::move(raw_ast)));
-            return ::pltxt2htm::details::DevilStuffAfterLineBreakResult{.forward_index = current_index + forward_index,
+            return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{.advance_count = current_index + advance_count,
                                                                         .new_frame_been_pushed_into_call_stack = true};
         }
-        return ::pltxt2htm::details::DevilStuffAfterLineBreakResult{.forward_index = current_index,
+        return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{.advance_count = current_index,
                                                                     .new_frame_been_pushed_into_call_stack = false};
     }
 }
@@ -160,12 +160,12 @@ entry:
                 .subast.emplace_back(
                     ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdUl<ndebug>{::std::move(previous_frame.subast)}));
             // Given "before\n- item\nbetween\n+ another\n- last\nafter":
-            //   devil_stuff_after_line_break first sees "- item\nbetween\n...",
+            //   find_next_block_after_line_break first sees "- item\nbetween\n...",
             //   but optionally_to_md_list_ast stops at "between" (not a list marker),
             //   returning only "- item\n".  After that <ul> pops, the remaining text
             //   "between\n+ another\n- last\nafter" is processed by the parent loop.
             //   When the parent hits "\n" before "+ another",
-            //   devil_stuff_after_line_break is called again and sees
+            //   find_next_block_after_line_break is called again and sees
             //   "+ another\n- last\nafter".  optionally_to_md_list_ast stops at
             //   "- last" (different marker at root level), returning only
             //   "+ another\n".  After that <ul> pops, the parent has unconsumed
@@ -178,7 +178,7 @@ entry:
             if (::pltxt2htm::details::is_md_list_ul_or_ol_type(parent_frame.get_nested_tag_type()) == false) {
                 ::std::size_t& parent_index = parent_frame.current_index;
                 auto parent_text = parent_frame.get_pltext();
-                auto&& [fwd, restart] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
+                auto&& [fwd, restart] = ::pltxt2htm::details::find_next_block_after_line_break<ndebug>(
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(parent_text, parent_index), call_stack,
                     parent_frame.subast);
                 parent_index += fwd;
@@ -245,7 +245,7 @@ entry:
             if (::pltxt2htm::details::is_md_list_ul_or_ol_type(parent_frame.get_nested_tag_type()) == false) {
                 ::std::size_t& parent_index = parent_frame.current_index;
                 auto parent_text = parent_frame.get_pltext();
-                auto&& [fwd, restart] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
+                auto&& [fwd, restart] = ::pltxt2htm::details::find_next_block_after_line_break<ndebug>(
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(parent_text, parent_index), call_stack,
                     parent_frame.subast);
                 parent_index += fwd;
@@ -397,9 +397,9 @@ entry:
     if (top_frame.get_nested_tag_type() == ::pltxt2htm::NodeKind::md_block_quotes && current_index == 0) {
         // https://spec.commonmark.org/0.31.2/#example-228
         // to support parsing md-atx-heading e.t.c inside md-block-quotes
-        auto&& [forward_index, require_restart] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
+        auto&& [advance_count, require_restart] = ::pltxt2htm::details::find_next_block_after_line_break<ndebug>(
             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), call_stack, result);
-        current_index += forward_index;
+        current_index += advance_count;
         if (require_restart) {
             goto entry;
         }
@@ -411,9 +411,9 @@ entry:
         if (chr == u8'\n') {
             result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LineBreak{}));
 
-            auto&& [forward_index, require_restart] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
+            auto&& [advance_count, require_restart] = ::pltxt2htm::details::find_next_block_after_line_break<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 1), call_stack, result);
-            current_index += forward_index;
+            current_index += advance_count;
             if (require_restart) {
                 current_index += 1;
                 goto entry;
@@ -432,12 +432,12 @@ entry:
             continue;
         }
         if (chr == u8'\'') {
-            result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::SingleQuotationMark{}));
+            result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::SingleQuote{}));
             ++current_index;
             continue;
         }
         if (chr == u8'\"') {
-            result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::DoubleQuotationMark{}));
+            result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::DoubleQuote{}));
             ++current_index;
             continue;
         }
@@ -500,92 +500,92 @@ entry:
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_triple_emphasis_asterisk.has_value()) {
             // parsing markdown ***example***
-            ::std::size_t const forward_index{
+            ::std::size_t const advance_count{
                 opt_triple_emphasis_asterisk.template value<ndebug == ::pltxt2htm::Contracts::ignore>()};
             call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 3, forward_index),
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 3, advance_count),
                 ::pltxt2htm::NodeKind::md_triple_emphasis_asterisk));
-            current_index += forward_index + 6;
+            current_index += advance_count + 6;
             goto entry;
         }
         if (auto opt_double_emphasis_asterisk = ::pltxt2htm::details::try_parse_md_inlines<ndebug, u8"**">(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_double_emphasis_asterisk.has_value()) {
             // parsing markdown **example**
-            ::std::size_t const forward_index{
+            ::std::size_t const advance_count{
                 opt_double_emphasis_asterisk.template value<ndebug == ::pltxt2htm::Contracts::ignore>()};
             call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2, forward_index),
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2, advance_count),
                 ::pltxt2htm::NodeKind::md_double_emphasis_asterisk));
-            current_index += forward_index + 4;
+            current_index += advance_count + 4;
             goto entry;
         }
         if (auto opt_single_emphasis_asterisk = ::pltxt2htm::details::try_parse_md_inlines<ndebug, u8"*">(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_single_emphasis_asterisk.has_value()) {
             // parsing markdown *example*
-            ::std::size_t const forward_index{
+            ::std::size_t const advance_count{
                 opt_single_emphasis_asterisk.template value<ndebug == ::pltxt2htm::Contracts::ignore>()};
             call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 1, forward_index),
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 1, advance_count),
                 ::pltxt2htm::NodeKind::md_single_emphasis_asterisk));
-            current_index += forward_index + 2;
+            current_index += advance_count + 2;
             goto entry;
         }
         if (auto opt_triple_emphasis_underscore = ::pltxt2htm::details::try_parse_md_inlines<ndebug, u8"___">(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_triple_emphasis_underscore.has_value()) {
             // parsing markdown ___example___
-            ::std::size_t const forward_index{
+            ::std::size_t const advance_count{
                 opt_triple_emphasis_underscore.template value<ndebug == ::pltxt2htm::Contracts::ignore>()};
             call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 3, forward_index),
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 3, advance_count),
                 ::pltxt2htm::NodeKind::md_triple_emphasis_underscore));
-            current_index += forward_index + 6;
+            current_index += advance_count + 6;
             goto entry;
         }
         if (auto opt_double_emphasis_undersore = ::pltxt2htm::details::try_parse_md_inlines<ndebug, u8"__">(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_double_emphasis_undersore.has_value()) {
             // parsing markdown __example__
-            ::std::size_t const forward_index{
+            ::std::size_t const advance_count{
                 opt_double_emphasis_undersore.template value<ndebug == ::pltxt2htm::Contracts::ignore>()};
             call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2, forward_index),
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2, advance_count),
                 ::pltxt2htm::NodeKind::md_double_emphasis_underscore));
-            current_index += forward_index + 4;
+            current_index += advance_count + 4;
             goto entry;
         }
         if (auto opt_single_emphasis_undersore = ::pltxt2htm::details::try_parse_md_inlines<ndebug, u8"_">(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_single_emphasis_undersore.has_value()) {
             // parsing markdown _example_
-            ::std::size_t const forward_index{
+            ::std::size_t const advance_count{
                 opt_single_emphasis_undersore.template value<ndebug == ::pltxt2htm::Contracts::ignore>()};
             call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 1, forward_index),
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 1, advance_count),
                 ::pltxt2htm::NodeKind::md_single_emphasis_underscore));
-            current_index += forward_index + 2;
+            current_index += advance_count + 2;
             goto entry;
         }
         if (auto opt_md_del = ::pltxt2htm::details::try_parse_md_inlines<ndebug, u8"~~">(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_md_del.has_value()) {
             // parsing markdown ~~example~~
-            ::std::size_t const forward_index{opt_md_del.template value<ndebug == ::pltxt2htm::Contracts::ignore>()};
+            ::std::size_t const advance_count{opt_md_del.template value<ndebug == ::pltxt2htm::Contracts::ignore>()};
             call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2, forward_index),
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2, advance_count),
                 ::pltxt2htm::NodeKind::md_del));
-            current_index += forward_index + 4;
+            current_index += advance_count + 4;
             goto entry;
         }
         if (auto opt_code_span_3_backtick = ::pltxt2htm::details::try_parse_md_code_span<ndebug, u8"```">(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_code_span_3_backtick.has_value()) {
             // parsing markdown ```example```
-            auto&& [forward_index, subast] =
+            auto&& [advance_count, subast] =
                 opt_code_span_3_backtick.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-            current_index += forward_index;
+            current_index += advance_count;
             result.push_back(
                 ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdCodeSpan3Backtick<ndebug>{::std::move(subast)}));
             continue;
@@ -594,9 +594,9 @@ entry:
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_code_span_2_backtick.has_value()) {
             // parsing markdown ``example``
-            auto&& [forward_index, subast] =
+            auto&& [advance_count, subast] =
                 opt_code_span_2_backtick.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-            current_index += forward_index;
+            current_index += advance_count;
             result.push_back(
                 ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdCodeSpan2Backtick<ndebug>{::std::move(subast)}));
             continue;
@@ -605,9 +605,9 @@ entry:
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_code_span_1_backtick.has_value()) {
             // parsing markdown `example`
-            auto&& [forward_index, subast] =
+            auto&& [advance_count, subast] =
                 opt_code_span_1_backtick.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-            current_index += forward_index;
+            current_index += advance_count;
             result.push_back(
                 ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdCodeSpan1Backtick<ndebug>{::std::move(subast)}));
             continue;
@@ -615,36 +615,36 @@ entry:
         if (auto opt_md_latex_block_dollar = ::pltxt2htm::details::try_parse_md_latex_block_dollar<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_md_latex_block_dollar.has_value()) {
-            auto&& [forward_index, subast] =
+            auto&& [advance_count, subast] =
                 opt_md_latex_block_dollar.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-            current_index += forward_index;
+            current_index += advance_count;
             result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdLatexBlock<ndebug>{::std::move(subast)}));
             continue;
         }
         if (auto opt_md_latex_inline = ::pltxt2htm::details::try_parse_md_latex_inline<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_md_latex_inline.has_value()) {
-            auto&& [forward_index, subast] =
+            auto&& [advance_count, subast] =
                 opt_md_latex_inline.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-            current_index += forward_index;
+            current_index += advance_count;
             result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdLatexInline<ndebug>{::std::move(subast)}));
             continue;
         }
         if (auto opt_md_link = ::pltxt2htm::details::try_parse_md_link<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_md_link.has_value()) {
-            auto&& [forward_index, url_text, url_link] =
+            auto&& [advance_count, url_text, url_link] =
                 opt_md_link.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-            current_index += forward_index;
+            current_index += advance_count;
             call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(url_text, ::std::move(url_link)));
             goto entry;
         }
         if (auto opt_md_image = ::pltxt2htm::details::try_parse_md_image<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_md_image.has_value()) {
-            auto&& [forward_index, text, link] =
+            auto&& [advance_count, text, link] =
                 opt_md_image.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-            current_index += forward_index;
+            current_index += advance_count;
             result.push_back(
                 ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdImage<ndebug>{::std::move(text), ::std::move(link)}));
             continue;
@@ -698,11 +698,11 @@ entry:
                     current_index += opt_br_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
                     result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlBr{}));
 
-                    auto&& [forward_index, require_restart] =
-                        ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
+                    auto&& [advance_count, require_restart] =
+                        ::pltxt2htm::details::find_next_block_after_line_break<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 1), call_stack,
                             result);
-                    current_index += forward_index;
+                    current_index += advance_count;
                     if (require_restart) {
                         current_index += 1;
                         goto entry;
@@ -2055,9 +2055,9 @@ entry:
 
             ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
         }
-        auto forward_index = ::pltxt2htm::details::parse_utf8_code_point<ndebug>(
+        auto advance_count = ::pltxt2htm::details::parse_utf8_code_point<ndebug>(
             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), result);
-        current_index += forward_index;
+        current_index += advance_count;
         continue;
     }
 
@@ -2291,55 +2291,55 @@ entry:
         case ::pltxt2htm::NodeKind::md_atx_h1: {
             ::fast_io::u8string_view super_pltext{::pltxt2htm::details::stack_top<ndebug>(call_stack).get_pltext()};
             parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdAtxH1<ndebug>{::std::move(subast)}));
-            auto&& [forward_index, _] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
+            auto&& [advance_count, _] = ::pltxt2htm::details::find_next_block_after_line_break<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(super_pltext, parent_index), call_stack,
                 parent_ast);
-            parent_index += forward_index;
+            parent_index += advance_count;
             goto entry;
         }
         case ::pltxt2htm::NodeKind::md_atx_h2: {
             ::fast_io::u8string_view super_pltext{::pltxt2htm::details::stack_top<ndebug>(call_stack).get_pltext()};
             parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdAtxH2<ndebug>{::std::move(subast)}));
-            auto&& [forward_index, _] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
+            auto&& [advance_count, _] = ::pltxt2htm::details::find_next_block_after_line_break<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(super_pltext, parent_index), call_stack,
                 parent_ast);
-            parent_index += forward_index;
+            parent_index += advance_count;
             goto entry;
         }
         case ::pltxt2htm::NodeKind::md_atx_h3: {
             ::fast_io::u8string_view super_pltext{::pltxt2htm::details::stack_top<ndebug>(call_stack).get_pltext()};
             parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdAtxH3<ndebug>{::std::move(subast)}));
-            auto&& [forward_index, _] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
+            auto&& [advance_count, _] = ::pltxt2htm::details::find_next_block_after_line_break<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(super_pltext, parent_index), call_stack,
                 parent_ast);
-            parent_index += forward_index;
+            parent_index += advance_count;
             goto entry;
         }
         case ::pltxt2htm::NodeKind::md_atx_h4: {
             ::fast_io::u8string_view super_pltext{::pltxt2htm::details::stack_top<ndebug>(call_stack).get_pltext()};
             parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdAtxH4<ndebug>{::std::move(subast)}));
-            auto&& [forward_index, _] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
+            auto&& [advance_count, _] = ::pltxt2htm::details::find_next_block_after_line_break<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(super_pltext, parent_index), call_stack,
                 parent_ast);
-            parent_index += forward_index;
+            parent_index += advance_count;
             goto entry;
         }
         case ::pltxt2htm::NodeKind::md_atx_h5: {
             ::fast_io::u8string_view super_pltext{::pltxt2htm::details::stack_top<ndebug>(call_stack).get_pltext()};
             parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdAtxH5<ndebug>{::std::move(subast)}));
-            auto&& [forward_index, _] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
+            auto&& [advance_count, _] = ::pltxt2htm::details::find_next_block_after_line_break<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(super_pltext, parent_index), call_stack,
                 parent_ast);
-            parent_index += forward_index;
+            parent_index += advance_count;
             goto entry;
         }
         case ::pltxt2htm::NodeKind::md_atx_h6: {
             ::fast_io::u8string_view super_pltext{::pltxt2htm::details::stack_top<ndebug>(call_stack).get_pltext()};
             parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdAtxH6<ndebug>{::std::move(subast)}));
-            auto&& [forward_index, _] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
+            auto&& [advance_count, _] = ::pltxt2htm::details::find_next_block_after_line_break<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(super_pltext, parent_index), call_stack,
                 parent_ast);
-            parent_index += forward_index;
+            parent_index += advance_count;
             goto entry;
         }
         case ::pltxt2htm::NodeKind::md_code_span_1_backtick: {

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -831,7 +831,7 @@ constexpr auto try_parse_pltext_line_break(::fast_io::u8string_view pltext) noex
 struct TryParseMdAtxHeadingResult {
     ::std::size_t start_index; ///< Start index of the heading content.
     ::std::size_t sublength; ///< Length of the heading content.
-    ::std::size_t forward_index; ///< Index to continue parsing from.
+    ::std::size_t advance_count; ///< Number of characters consumed.
     ::pltxt2htm::NodeKind md_atx_heading_type; ///< Type of the ATX heading.
 };
 
@@ -924,7 +924,7 @@ constexpr auto try_parse_md_atx_heading(::fast_io::u8string_view pltext) noexcep
     return ::pltxt2htm::details::TryParseMdAtxHeadingResult{
         .start_index = start_index,
         .sublength = end_index - start_index,
-        .forward_index = end_index + extra_length,
+        .advance_count = end_index + extra_length,
         .md_atx_heading_type = static_cast<::pltxt2htm::NodeKind>(md_atx_heading_type)};
 }
 
@@ -1027,7 +1027,7 @@ constexpr auto try_parse_md_thematic_break(::fast_io::u8string_view text) noexce
 
 template<::pltxt2htm::Contracts ndebug>
 struct SimplyParsePLtextResult {
-    ::std::size_t forward_index; ///< Index to continue parsing from.
+    ::std::size_t advance_count; ///< Number of characters consumed.
     ::pltxt2htm::Ast<ndebug> ast; ///< Parsed AST.
 };
 
@@ -1082,12 +1082,12 @@ constexpr auto simply_parse_pltext(::fast_io::u8string_view pltext) noexcept
             continue;
         }
         else if (chr == u8'\'') {
-            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::SingleQuotationMark{}));
+            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::SingleQuote{}));
             ++current_index;
             continue;
         }
         else if (chr == u8'\"') {
-            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::DoubleQuotationMark{}));
+            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::DoubleQuote{}));
             ++current_index;
             continue;
         }
@@ -1125,20 +1125,20 @@ constexpr auto simply_parse_pltext(::fast_io::u8string_view pltext) noexcept
             continue;
         }
         else {
-            auto forward_index = ::pltxt2htm::details::parse_utf8_code_point<ndebug>(
+            auto advance_count = ::pltxt2htm::details::parse_utf8_code_point<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), ast);
-            current_index += forward_index;
+            current_index += advance_count;
             continue;
         }
         ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
     }
-    return {.forward_index = current_index, .ast = ::std::move(ast)};
+    return {.advance_count = current_index, .ast = ::std::move(ast)};
 }
 
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseMdCodeFenceResult {
     ::pltxt2htm::PlTxtNode<ndebug> node; ///< Parsed code fence node.
-    ::std::size_t forward_index; ///< Index to continue parsing from.
+    ::std::size_t advance_count; ///< Number of characters consumed.
 };
 
 /**
@@ -1210,14 +1210,14 @@ constexpr auto try_parse_md_code_fence_(::fast_io::u8string_view pltext) noexcep
                     return ::pltxt2htm::details::TryParseMdCodeFenceResult<ndebug>{
                         .node =
                             ::pltxt2htm::MdCodeFenceBacktick<ndebug>{::pltxt2htm::Ast<ndebug>{}, ::std::move(opt_lang)},
-                        .forward_index = current_index + 3,
+                        .advance_count = current_index + 3,
                     };
                 }
                 else {
                     return ::pltxt2htm::details::TryParseMdCodeFenceResult<ndebug>{
                         .node =
                             ::pltxt2htm::MdCodeFenceTilde<ndebug>{::pltxt2htm::Ast<ndebug>{}, ::std::move(opt_lang)},
-                        .forward_index = current_index + 3,
+                        .advance_count = current_index + 3,
                     };
                 }
             }
@@ -1255,17 +1255,17 @@ constexpr auto try_parse_md_code_fence_(::fast_io::u8string_view pltext) noexcep
     ::pltxt2htm::Ast<ndebug> ast{};
     if constexpr (is_backtick) {
         constexpr auto end_string = ::pltxt2htm::details::concat(::pltxt2htm::details::U8LiteralString{u8"\n"}, fence);
-        auto&& [forward_index, ast_] = ::pltxt2htm::details::simply_parse_pltext<ndebug, end_string>(
+        auto&& [advance_count, ast_] = ::pltxt2htm::details::simply_parse_pltext<ndebug, end_string>(
             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
         ast = ::std::move(ast_);
-        current_index += forward_index;
+        current_index += advance_count;
     }
     else {
         constexpr auto end_string = ::pltxt2htm::details::concat(::pltxt2htm::details::U8LiteralString{u8"\n"}, fence);
-        auto&& [forward_index, ast_] = ::pltxt2htm::details::simply_parse_pltext<ndebug, end_string>(
+        auto&& [advance_count, ast_] = ::pltxt2htm::details::simply_parse_pltext<ndebug, end_string>(
             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
         ast = ::std::move(ast_);
-        current_index += forward_index;
+        current_index += advance_count;
     }
 
     ::exception::optional<::fast_io::u8string> opt_lang{::exception::nullopt_t{}};
@@ -1275,12 +1275,12 @@ constexpr auto try_parse_md_code_fence_(::fast_io::u8string_view pltext) noexcep
     if constexpr (is_backtick) {
         return ::pltxt2htm::details::TryParseMdCodeFenceResult<ndebug>{
             .node = ::pltxt2htm::MdCodeFenceBacktick<ndebug>{::std::move(ast), ::std::move(opt_lang)},
-            .forward_index = current_index};
+            .advance_count = current_index};
     }
     else {
         return ::pltxt2htm::details::TryParseMdCodeFenceResult<ndebug>{
             .node = ::pltxt2htm::MdCodeFenceTilde<ndebug>{::std::move(ast), ::std::move(opt_lang)},
-            .forward_index = current_index};
+            .advance_count = current_index};
     }
 }
 
@@ -1364,7 +1364,7 @@ constexpr auto try_parse_md_inlines(::fast_io::u8string_view pltext) noexcept ->
 }
 
 struct TryParseMdBlockQuotesResult {
-    ::std::size_t forward_index; ///< Index to continue parsing from.
+    ::std::size_t advance_count; ///< Number of characters consumed.
     ::fast_io::u8string subpltext; ///< Parsed block quote content.
 };
 
@@ -1438,13 +1438,13 @@ constexpr auto try_parse_md_block_quotes(::fast_io::u8string_view pltext) noexce
     if (subpltext.back_unchecked() == u8'\n') {
         subpltext.pop_back();
     }
-    return ::pltxt2htm::details::TryParseMdBlockQuotesResult{.forward_index = current_index,
+    return ::pltxt2htm::details::TryParseMdBlockQuotesResult{.advance_count = current_index,
                                                              .subpltext = ::std::move(subpltext)};
 }
 
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseMdCodeSpanResult {
-    ::std::size_t forward_index; ///< Index to continue parsing from.
+    ::std::size_t advance_count; ///< Number of characters consumed.
     ::pltxt2htm::Ast<ndebug> subast; ///< Parsed AST for the code span.
 };
 
@@ -1475,19 +1475,19 @@ constexpr auto try_parse_md_code_span(::fast_io::u8string_view pltext) noexcept
         return ::exception::nullopt_t{};
     }
 
-    auto&& [forward_index, ast] = ::pltxt2htm::details::simply_parse_pltext<ndebug, embraced_string>(
+    auto&& [advance_count, ast] = ::pltxt2htm::details::simply_parse_pltext<ndebug, embraced_string>(
         ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, embraced_size));
 
     if constexpr (embraced_size == 1) {
-        return ::pltxt2htm::details::TryParseMdCodeSpanResult<ndebug>{.forward_index = forward_index + embraced_size,
+        return ::pltxt2htm::details::TryParseMdCodeSpanResult<ndebug>{.advance_count = advance_count + embraced_size,
                                                                       .subast = ::std::move(ast)};
     }
     else if constexpr (embraced_size == 2) {
-        return ::pltxt2htm::details::TryParseMdCodeSpanResult<ndebug>{.forward_index = forward_index + embraced_size,
+        return ::pltxt2htm::details::TryParseMdCodeSpanResult<ndebug>{.advance_count = advance_count + embraced_size,
                                                                       .subast = ::std::move(ast)};
     }
     else if constexpr (embraced_size == 3) {
-        return ::pltxt2htm::details::TryParseMdCodeSpanResult<ndebug>{.forward_index = forward_index + embraced_size,
+        return ::pltxt2htm::details::TryParseMdCodeSpanResult<ndebug>{.advance_count = advance_count + embraced_size,
                                                                       .subast = ::std::move(ast)};
     }
     else {
@@ -1497,7 +1497,7 @@ constexpr auto try_parse_md_code_span(::fast_io::u8string_view pltext) noexcept
 
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseMdLatexResult {
-    ::std::size_t forward_index; ///< Index to continue parsing from (includes both delimiters).
+    ::std::size_t advance_count; ///< Number of characters consumed (includes both delimiters).
     ::pltxt2htm::Ast<ndebug> subast; ///< Parsed AST inside the latex delimiters.
 };
 
@@ -1554,7 +1554,7 @@ constexpr auto try_parse_md_latex_block_dollar(::fast_io::u8string_view pltext) 
         }
     }
 
-    return ::pltxt2htm::details::TryParseMdLatexResult<ndebug>{.forward_index = close_pos + 4,
+    return ::pltxt2htm::details::TryParseMdLatexResult<ndebug>{.advance_count = close_pos + 4,
                                                                .subast = ::std::move(ast)};
 }
 
@@ -1610,7 +1610,7 @@ constexpr auto try_parse_md_latex_inline(::fast_io::u8string_view pltext) noexce
         idx += forward;
     }
 
-    return ::pltxt2htm::details::TryParseMdLatexResult<ndebug>{.forward_index = close_pos + 2,
+    return ::pltxt2htm::details::TryParseMdLatexResult<ndebug>{.advance_count = close_pos + 2,
                                                                .subast = ::std::move(ast)};
 }
 
@@ -1711,10 +1711,10 @@ constexpr auto make_try_parse_url_result(::fast_io::u8string_view const parsed_u
             ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Ampersand{}));
             break;
         case u8'\'':
-            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::SingleQuotationMark{}));
+            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::SingleQuote{}));
             break;
         case u8'\"':
-            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::DoubleQuotationMark{}));
+            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::DoubleQuote{}));
             break;
         case u8'<':
             ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
@@ -1879,7 +1879,7 @@ constexpr auto try_parse_external_tag(
 
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseMdLinkResult {
-    ::std::size_t forward_index;
+    ::std::size_t advance_count;
     ::fast_io::u8string_view link_text;
     ::pltxt2htm::Url<ndebug> link_url;
 };
@@ -1954,14 +1954,14 @@ constexpr auto try_parse_md_link(::fast_io::u8string_view pltext) noexcept
         return ::exception::nullopt_t{};
     }
     ++current_index;
-    return ::pltxt2htm::details::TryParseMdLinkResult<ndebug>{.forward_index = current_index,
+    return ::pltxt2htm::details::TryParseMdLinkResult<ndebug>{.advance_count = current_index,
                                                               .link_text = pltext.subview(1, link_text_end - 1),
                                                               .link_url = ::std::move(urlobj)};
 }
 
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseMdImageResult {
-    ::std::size_t forward_index;
+    ::std::size_t advance_count;
     ::pltxt2htm::Ast<ndebug> link_text;
     ::pltxt2htm::Url<ndebug> link_url;
 };
@@ -2006,12 +2006,12 @@ constexpr auto try_parse_md_image(::fast_io::u8string_view pltext) noexcept
             continue;
         }
         else if (chr == u8'\'') {
-            link_text_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::SingleQuotationMark{}));
+            link_text_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::SingleQuote{}));
             ++current_index;
             continue;
         }
         else if (chr == u8'\"') {
-            link_text_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::DoubleQuotationMark{}));
+            link_text_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::DoubleQuote{}));
             ++current_index;
             continue;
         }
@@ -2050,9 +2050,9 @@ constexpr auto try_parse_md_image(::fast_io::u8string_view pltext) noexcept
             continue;
         }
         else {
-            auto forward_index = ::pltxt2htm::details::parse_utf8_code_point<ndebug>(
+            auto advance_count = ::pltxt2htm::details::parse_utf8_code_point<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), link_text_ast);
-            current_index += forward_index;
+            current_index += advance_count;
             continue;
         }
         ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
@@ -2081,7 +2081,7 @@ constexpr auto try_parse_md_image(::fast_io::u8string_view pltext) noexcept
         ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, current_index) != u8')') {
         return ::exception::nullopt_t{};
     }
-    return ::pltxt2htm::details::TryParseMdImageResult<ndebug>{.forward_index = current_index + 1,
+    return ::pltxt2htm::details::TryParseMdImageResult<ndebug>{.advance_count = current_index + 1,
                                                                .link_text = ::std::move(link_text_ast),
                                                                .link_url = ::std::move(link_url_result.url)};
 }

--- a/include/pltxt2htm/parser.hh
+++ b/include/pltxt2htm/parser.hh
@@ -52,9 +52,9 @@ constexpr auto parse_pltxt(::fast_io::u8string_view pltext) noexcept -> ::pltxt2
     ::std::size_t start_index{};
 
     while (true) {
-        auto&& [forward_index, has_new_frame] = ::pltxt2htm::details::devil_stuff_after_line_break<ndebug>(
+        auto&& [advance_count, has_new_frame] = ::pltxt2htm::details::find_next_block_after_line_break<ndebug>(
             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, start_index), call_stack, result);
-        start_index += forward_index;
+        start_index += advance_count;
         if (has_new_frame == false) {
             break;
         }


### PR DESCRIPTION
- fix typo: is_leteral_string -> is_literal_string
- rename cryptic devil_stuff_after_line_break -> find_next_block_after_line_break
- rename struct DevilStuffAfterLineBreakResult -> FindNextBlockAfterLineBreakResult
- rename union members for consistency with enum values: linebreak_node -> line_break_node lessthan_node -> less_than_node greaterthan_node -> greater_than_node singlequotationmark_node -> single_quote_node doublequotationmark_node -> double_quote_node
- rename verbose SingleQuotationMark/DoubleQuotationMark -> SingleQuote/DoubleQuote
- rename forward_index (delta/offset pattern) -> advance_count