### PR TITLE
feat: eliminate redundant em/strong nesting around md_triple_emphasis

### DIFF
--- a/include/pltxt2htm/ast/node_type.hh
+++ b/include/pltxt2htm/ast/node_type.hh
@@ -195,6 +195,24 @@ constexpr auto is_equal_sign_tag_type(::pltxt2htm::NodeKind const node_type) noe
 }
 
 [[nodiscard]]
+constexpr auto is_em_like(::pltxt2htm::NodeKind const node_type) noexcept -> bool {
+    return node_type == ::pltxt2htm::NodeKind::html_em || node_type == ::pltxt2htm::NodeKind::pl_i ||
+           node_type == ::pltxt2htm::NodeKind::md_single_emphasis_asterisk ||
+           node_type == ::pltxt2htm::NodeKind::md_single_emphasis_underscore ||
+           node_type == ::pltxt2htm::NodeKind::md_triple_emphasis_asterisk ||
+           node_type == ::pltxt2htm::NodeKind::md_triple_emphasis_underscore;
+}
+
+[[nodiscard]]
+constexpr auto is_strong_like(::pltxt2htm::NodeKind const node_type) noexcept -> bool {
+    return node_type == ::pltxt2htm::NodeKind::html_strong || node_type == ::pltxt2htm::NodeKind::pl_b ||
+           node_type == ::pltxt2htm::NodeKind::md_double_emphasis_asterisk ||
+           node_type == ::pltxt2htm::NodeKind::md_double_emphasis_underscore ||
+           node_type == ::pltxt2htm::NodeKind::md_triple_emphasis_asterisk ||
+           node_type == ::pltxt2htm::NodeKind::md_triple_emphasis_underscore;
+}
+
+[[nodiscard]]
 constexpr auto is_md_list_ul_or_ol_type(::pltxt2htm::NodeKind const node_type) noexcept -> bool {
     return node_type == ::pltxt2htm::NodeKind::md_ul || node_type == ::pltxt2htm::NodeKind::md_ol;
 }

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -527,10 +527,7 @@ entry:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::pl_b: {
             auto&& nested_tag_type = ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type();
-            bool const is_not_same_tag{nested_tag_type != ::pltxt2htm::NodeKind::pl_b &&
-                                       nested_tag_type != ::pltxt2htm::NodeKind::html_strong &&
-                                       nested_tag_type != ::pltxt2htm::NodeKind::md_double_emphasis_asterisk &&
-                                       nested_tag_type != ::pltxt2htm::NodeKind::md_double_emphasis_underscore};
+            bool const is_not_same_tag{!::pltxt2htm::details::is_strong_like(nested_tag_type)};
             if (is_not_same_tag) {
                 auto&& subast = node.get_subast();
                 if (subast.empty()) {
@@ -652,10 +649,7 @@ entry:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_em: {
             auto&& nested_tag_type = ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type();
-            bool const is_not_same_tag{nested_tag_type != ::pltxt2htm::NodeKind::html_em &&
-                                       nested_tag_type != ::pltxt2htm::NodeKind::pl_i &&
-                                       nested_tag_type != ::pltxt2htm::NodeKind::md_single_emphasis_asterisk &&
-                                       nested_tag_type != ::pltxt2htm::NodeKind::md_single_emphasis_underscore};
+            bool const is_not_same_tag{!::pltxt2htm::details::is_em_like(nested_tag_type)};
             if (is_not_same_tag) {
                 auto&& subast = node.get_subast();
                 if (subast.empty()) {
@@ -840,8 +834,47 @@ entry:
             auto&& subast = node.get_subast();
             bool const ast_not_empty = !subast.empty();
             pltxt2htm_assert(ast_not_empty, u8"md_triple_emphasis subast must not be empty");
-            ++current_iter;
-            continue;
+            auto const& nested_tag_type = ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type();
+            // Parent provides both em and strong → triple emphasis fully redundant, flatten
+            if (nested_tag_type == ::pltxt2htm::NodeKind::md_triple_emphasis_asterisk ||
+                nested_tag_type == ::pltxt2htm::NodeKind::md_triple_emphasis_underscore) {
+                node = ::pltxt2htm::PlTxtNode<ndebug>{::pltxt2htm::Text<ndebug>{::std::move(subast)}};
+                ++current_iter;
+                continue;
+            }
+            // If parent is em-like → em part redundant, convert to double emphasis (strong)
+            if (::pltxt2htm::details::is_em_like(nested_tag_type)) {
+                auto tmp = ::std::move(subast);
+                if (node.get_node_kind() == ::pltxt2htm::NodeKind::md_triple_emphasis_asterisk) {
+                    *current_iter = ::pltxt2htm::PlTxtNode<ndebug>(
+                        ::pltxt2htm::MdDoubleEmphasisAsterisk<ndebug>{::std::move(tmp)});
+                } else {
+                    *current_iter = ::pltxt2htm::PlTxtNode<ndebug>(
+                        ::pltxt2htm::MdDoubleEmphasisUnderscore<ndebug>{::std::move(tmp)});
+                }
+                continue;
+            }
+            // If parent is strong-like → strong part redundant, convert to single emphasis (em)
+            if (::pltxt2htm::details::is_strong_like(nested_tag_type)) {
+                auto tmp = ::std::move(subast);
+                if (node.get_node_kind() == ::pltxt2htm::NodeKind::md_triple_emphasis_asterisk) {
+                    *current_iter = ::pltxt2htm::PlTxtNode<ndebug>(
+                        ::pltxt2htm::MdSingleEmphasisAsterisk<ndebug>{::std::move(tmp)});
+                } else {
+                    *current_iter = ::pltxt2htm::PlTxtNode<ndebug>(
+                        ::pltxt2htm::MdSingleEmphasisUnderscore<ndebug>{::std::move(tmp)});
+                }
+                continue;
+            }
+            // Parent is neither em-like nor strong-like → push frame for child traversal
+            if (subast.empty()) {
+                ast.erase(current_iter);
+                continue;
+            }
+            call_stack.push(
+                ::pltxt2htm::details::OptimizerFrameContext<typename ::pltxt2htm::Ast<ndebug>::iterator, ndebug>(
+                    ::std::addressof(subast), node.get_node_kind(), subast.begin()));
+            goto entry;
         }
         case ::pltxt2htm::NodeKind::md_block_quotes:
             [[fallthrough]];

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -834,12 +834,17 @@ entry:
             ++current_iter;
             continue;
         }
+        case ::pltxt2htm::NodeKind::md_triple_emphasis_underscore:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::md_triple_emphasis_asterisk: {
+            auto&& subast = node.get_subast();
+            bool const ast_not_empty = !subast.empty();
+            pltxt2htm_assert(ast_not_empty, u8"md_triple_emphasis subast must not be empty");
+            ++current_iter;
+            continue;
+        }
         case ::pltxt2htm::NodeKind::md_block_quotes:
             [[fallthrough]];
-        case ::pltxt2htm::NodeKind::md_triple_emphasis_underscore:
-            [[fallthrough]]; // TODO optimization support for md_triple_emphasis
-        case ::pltxt2htm::NodeKind::md_triple_emphasis_asterisk:
-            [[fallthrough]]; // TODO optimization support for md_triple_emphasis
         case ::pltxt2htm::NodeKind::md_escape_backslash:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_escape_exclamation:

--- a/tests/test_md_emphasis.cc
+++ b/tests/test_md_emphasis.cc
@@ -117,5 +117,79 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
     }
 
+    // Redundant tag elimination: triple emphasis inside em-like parent → em part redundant
+    {
+        // <em> wrapping *** → em part of triple is redundant, convert to <strong>
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<em>***text***</em>");
+        auto answer = ::fast_io::u8string_view{u8"<em><strong>text</strong></em>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <i> wrapping *** → same as <em>, convert to <strong>
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<i>***text***</i>");
+        auto answer = ::fast_io::u8string_view{u8"<em><strong>text</strong></em>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    // Redundant tag elimination: triple emphasis inside strong-like parent → strong part redundant
+    {
+        // <strong> wrapping *** → strong part of triple is redundant, convert to <em>
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<strong>***text***</strong>");
+        auto answer = ::fast_io::u8string_view{u8"<strong><em>text</em></strong>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <b> wrapping *** → same as <strong>, convert to <em>
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<b>***text***</b>");
+        auto answer = ::fast_io::u8string_view{u8"<strong><em>text</em></strong>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    // Redundant tag elimination: em/strong inside triple emphasis → child redundant
+    {
+        // <em> inside *** → em redundant (triple already provides <em>)
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"***<em>text</em>***");
+        auto answer = ::fast_io::u8string_view{u8"<em><strong>text</strong></em>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <strong> inside *** → strong redundant (triple already provides <strong>)
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"***<strong>text</strong>***");
+        auto answer = ::fast_io::u8string_view{u8"<em><strong>text</strong></em>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    // Redundant tag elimination: with surrounding text content
+    {
+        // <em> wrapping text***text***text → triple converted to <strong> in em context
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<em>text***text***text</em>");
+        auto answer = ::fast_io::u8string_view{u8"<em>text<strong>text</strong>text</em>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <strong> wrapping text***text***text → triple converted to <em> in strong context
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<strong>text***text***text</strong>");
+        auto answer = ::fast_io::u8string_view{u8"<strong>text<em>text</em>text</strong>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // *** surrounding text<em>text</em>text → inner em redundant, unwrapped
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"text***<em>text</em>***text");
+        auto answer = ::fast_io::u8string_view{u8"text<em><strong>text</strong></em>text"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // *** surrounding text<strong>text</strong>text → inner strong redundant, unwrapped
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"text***<strong>text</strong>***text");
+        auto answer = ::fast_io::u8string_view{u8"text<em><strong>text</strong></em>text"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
     return 0;
 }


### PR DESCRIPTION
- Add is_em_like / is_strong_like helpers for unified NodeKind checks
- Simplify em/strong handler checks to use the helpers, automatically
  covering triple emphasis as a parent context
- Replace md_triple_emphasis pass-through with proper optimization:
  - inside em-like parent -> convert to double emphasis (strong)
  - inside strong-like parent -> convert to single emphasis (em)
  - inside another triple emphasis -> fully flatten (unwrap)
- Add 10 test cases covering all transformation paths