### PR TITLE
refactor: replace exception::unreachable with pltxt2htm_unreachable m…

### DIFF
--- a/include/pltxt2htm/ast/ast.hh
+++ b/include/pltxt2htm/ast/ast.hh
@@ -1288,7 +1288,7 @@ public:
     #if 0
         default:
             [[unlikely]] {
-                ::exception::unreachable();
+                pltxt2htm_unreachable(u8"Unexpected node kind in PlTxtNode copy constructor");
             }
     #endif
         }
@@ -1878,7 +1878,7 @@ public:
 #if 0
         default:
             [[unlikely]] {
-                ::exception::unreachable();
+                pltxt2htm_unreachable(u8"Unexpected node kind in PlTxtNode move constructor");
             }
 #endif
         }
@@ -2375,7 +2375,7 @@ public:
 #if 0
         default:
             [[unlikely]] {
-                ::exception::unreachable();
+                pltxt2htm_unreachable(u8"Unexpected node kind in PlTxtNode destructor");
             }
 #endif
         }
@@ -2766,12 +2766,12 @@ public:
 #if 0
         default:
             [[unlikely]] {
-                ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                pltxt2htm_unreachable(u8"Unexpected node kind in PlTxtNode operator==");
             }
 #endif
         }
         // reduce MSVC return-path warning
-        ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+        pltxt2htm_unreachable(u8"Unreachable after PlTxtNode operator== switch");
     }
 
     /// @name as_xxx() accessors — one per union member type

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -185,7 +185,7 @@ constexpr auto convert_simple_pltxt_ast_to_plunity_richtext(::pltxt2htm::Ast<nde
         }
         default:
             [[unlikely]] {
-                ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                pltxt2htm_unreachable(u8"Unexpected node kind in Unity text escaping");
             }
         }
     }
@@ -628,11 +628,11 @@ entry:
                         result.append(u8"\u25ab ");
                     }
                     else [[unlikely]] {
-                        ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        pltxt2htm_unreachable(u8"Unexpected indent level remainder");
                     }
                 }
                 else [[unlikely]] {
-                    ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    pltxt2htm_unreachable(u8"Unexpected nested tag type for list item");
                 }
                 goto entry;
             }
@@ -664,7 +664,7 @@ entry:
                     }
                 }
                 else [[unlikely]] {
-                    ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    pltxt2htm_unreachable(u8"Unexpected nested tag type for checkbox list item");
                 }
                 goto entry;
             }
@@ -1055,7 +1055,7 @@ entry:
 #if 0
             default:
                 [[unlikely]] {
-                    ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    pltxt2htm_unreachable(u8"Unexpected macro node kind in Unity backend");
                 }
 #endif
             }
@@ -1286,7 +1286,7 @@ entry:
             }
             default:
                 [[unlikely]] {
-                    ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    pltxt2htm_unreachable(u8"Unexpected nested tag type in Unity text backend");
                 }
             }
         }

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -184,7 +184,7 @@ constexpr auto convert_simple_pltxt_ast_to_plweb_text(::pltxt2htm::Ast<ndebug> c
         }
         default:
             [[unlikely]] {
-                ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                pltxt2htm_unreachable(u8"Unexpected node kind in HTML escaping");
             }
         }
     }
@@ -1144,7 +1144,7 @@ entry:
 #if 0
             default:
                 [[unlikely]] {
-                    ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    pltxt2htm_unreachable(u8"Unexpected macro node kind in text backend");
                 }
 #endif
             }
@@ -1368,7 +1368,7 @@ entry:
             }
             default:
                 [[unlikely]] {
-                    ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    pltxt2htm_unreachable(u8"Unexpected nested tag type in text backend");
                 }
             }
         }

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -141,7 +141,7 @@ constexpr auto url_ast_to_string(::pltxt2htm::Ast<ndebug> const& ast) noexcept -
             continue;
         default:
             [[unlikely]] {
-                ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                pltxt2htm_unreachable(u8"Unexpected node kind in title character rendering");
             }
         }
     }
@@ -839,7 +839,7 @@ entry:
 #if 0
             default:
                 [[unlikely]] {
-                    ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    pltxt2htm_unreachable(u8"Unexpected node kind in title backend");
                 }
 #endif
             }
@@ -899,7 +899,7 @@ entry:
             }
             default:
                 [[unlikely]] {
-                    ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    pltxt2htm_unreachable(u8"Unexpected nested tag type in title backend");
                 }
             }
         }

--- a/include/pltxt2htm/details/panic.hh
+++ b/include/pltxt2htm/details/panic.hh
@@ -37,9 +37,9 @@ template<::pltxt2htm::details::U8LiteralString expression, ::pltxt2htm::details:
 [[noreturn]]
 inline void panic() noexcept {
     auto to_be_printed = ::pltxt2htm::details::concat(
-        pltxt2htm::details::U8LiteralString{u8"Program panicked because \"assert("}, expression,
+        pltxt2htm::details::U8LiteralString{u8"Program panicked because "}, expression,
         pltxt2htm::details::U8LiteralString{
-            u8")\" failed, please file a bug at \"https://github.com/SekaiArendelle/pltxt2htm/issues\" and attach the "
+            u8", please file a bug at \"https://github.com/SekaiArendelle/pltxt2htm/issues\" and attach the "
             u8"crash info along with the source text\n* in file: "},
         file_name,
         pltxt2htm::details::U8LiteralString{u8"\n"

--- a/include/pltxt2htm/details/parser/frame_concext.hh
+++ b/include/pltxt2htm/details/parser/frame_concext.hh
@@ -473,7 +473,7 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_hr:
             [[unlikely]] {
-                ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                pltxt2htm_unreachable(u8"Unexpected node kind in ContextVariant move");
             }
         }
     }
@@ -749,7 +749,7 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_hr:
             [[unlikely]] {
-                ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                pltxt2htm_unreachable(u8"Unexpected node kind in ContextVariant destructor");
             }
         }
     }
@@ -1140,11 +1140,11 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_ol:
             [[unlikely]] {
-                ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                pltxt2htm_unreachable(u8"Unexpected node kind in context-kind switch");
             }
         }
         // suppress GCC -Wreturn-type warning
-        ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+        pltxt2htm_unreachable(u8"Unreachable after context-kind switch");
     }
 
     [[nodiscard]]

--- a/include/pltxt2htm/details/parser/md_list.hh
+++ b/include/pltxt2htm/details/parser/md_list.hh
@@ -285,7 +285,7 @@ public:
 #if 0
         default:
             [[unlikely]] {
-                ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                pltxt2htm_unreachable(u8"Unexpected MdListNodeType in move constructor");
             }
 #endif
         }
@@ -314,7 +314,7 @@ public:
 #if 0
         default:
             [[unlikely]] {
-                ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                pltxt2htm_unreachable(u8"Unexpected MdListNodeType in destructor");
             }
 #endif
         }
@@ -352,10 +352,10 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::details::MdListNodeType::md_ol:
             [[unlikely]] {
-                ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                pltxt2htm_unreachable(u8"Unexpected md_ul/md_ol in get_text()");
             }
         }
-        ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+        pltxt2htm_unreachable(u8"Unreachable after get_text() switch");
     }
 
     [[nodiscard]]
@@ -371,10 +371,10 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::details::MdListNodeType::md_ol:
             [[unlikely]] {
-                ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                pltxt2htm_unreachable(u8"Unexpected md_ul/md_ol in get_text_view()");
             }
         }
-        ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+        pltxt2htm_unreachable(u8"Unreachable after get_text_view() switch");
     }
 
     [[nodiscard]]
@@ -390,10 +390,10 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::details::MdListNodeType::md_li_checkbox:
             [[unlikely]] {
-                ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                pltxt2htm_unreachable(u8"Unexpected md_li/md_li_checkbox in get_sublist()");
             }
         }
-        ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+        pltxt2htm_unreachable(u8"Unreachable after get_sublist() switch");
     }
 
     [[nodiscard]]
@@ -427,11 +427,11 @@ public:
 #if 0
         default:
             [[unlikely]] {
-                ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                pltxt2htm_unreachable(u8"Unexpected MdListNodeType in operator==");
             }
 #endif
         }
-        ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+        pltxt2htm_unreachable(u8"Unreachable after MdListNodeType operator== switch");
     }
 };
 
@@ -874,7 +874,7 @@ constexpr auto optionally_to_md_list_ast(::fast_io::u8string_view pltext) noexce
 #if 0
             default:
                 [[unlikely]] {
-                    ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    pltxt2htm_unreachable(u8"Unexpected MdUlListItemKind");
                 }
 #endif
             }
@@ -940,7 +940,7 @@ constexpr auto optionally_to_md_list_ast(::fast_io::u8string_view pltext) noexce
 #if 0
         default:
             [[unlikely]] {
-                ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                pltxt2htm_unreachable(u8"Unexpected MdUlListItemKind");
             }
 #endif
         }

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -81,7 +81,7 @@ constexpr auto find_next_block_after_line_break(
             }
             default:
                 [[unlikely]] {
-                    ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    pltxt2htm_unreachable(u8"Unexpected heading node kind");
                 }
             }
             current_index += advance_count;
@@ -221,7 +221,7 @@ entry:
 #if 0
             default:
                 [[unlikely]] {
-                    ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    pltxt2htm_unreachable(u8"Unexpected MdListNodeType");
                 }
 #endif
             }
@@ -291,7 +291,7 @@ entry:
 #if 0
             default:
                 [[unlikely]] {
-                    ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    pltxt2htm_unreachable(u8"Unexpected MdListNodeType");
                 }
 #endif
             }
@@ -392,12 +392,12 @@ entry:
 #if 0
             default:
                 [[unlikely]] {
-                    ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    pltxt2htm_unreachable(u8"Unexpected MdTableParsePhase");
                 }
 #endif
             }
 
-            ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+            pltxt2htm_unreachable(u8"Unreachable after MdTableParsePhase switch");
         }
 
         auto&& top_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
@@ -1607,7 +1607,7 @@ entry:
                     }
                     case ::pltxt2htm::NodeKind::html_note:
                         [[unlikely]] {
-                            ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                            pltxt2htm_unreachable(u8"Unexpected html_note node during end-tag parsing");
                         }
                     case ::pltxt2htm::NodeKind::html_em: {
                         if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"em">(
@@ -2123,10 +2123,10 @@ entry:
                         [[fallthrough]];
                     case ::pltxt2htm::NodeKind::md_escape_tilde:
                         [[unlikely]] {
-                            ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                            pltxt2htm_unreachable(u8"Unexpected escape node kind in inner switch");
                         }
                     }
-                    ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    pltxt2htm_unreachable(u8"Unreachable after escape-node inner switch");
                 }
 
                 default: {
@@ -2136,7 +2136,7 @@ entry:
                 }
                 }
 
-                ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                pltxt2htm_unreachable(u8"Unreachable after outer switch");
             }
             if (auto opt_url = ::pltxt2htm::details::try_parse_auto_url<ndebug>(pltext, current_index);
                 opt_url.has_value()) {
@@ -2648,10 +2648,10 @@ entry:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::pl_macro_coauthors:
                 [[unlikely]] {
-                    ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    pltxt2htm_unreachable(u8"Unexpected block node kind in inline context");
                 }
             }
-            ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+            pltxt2htm_unreachable(u8"Unreachable after block-node-in-inline switch");
         }
     }
 }

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1700,7 +1700,7 @@ constexpr auto try_parse_md_code_span(::fast_io::u8string_view pltext) noexcept
                                                                       .subast = ::std::move(ast)};
     }
     else {
-        ::exception::unreachable();
+        pltxt2htm_unreachable(u8"Unexpected embraced size for code span");
     }
 }
 

--- a/include/pltxt2htm/details/pop_macro.hh
+++ b/include/pltxt2htm/details/pop_macro.hh
@@ -9,6 +9,7 @@
  * @warning Always include this file after push_macro.hh to restore macro state
  */
 
+#pragma pop_macro("pltxt2htm_unreachable")
 #pragma pop_macro("pltxt2htm_assert")
 #pragma pop_macro("PLTXT2HTM_U8_CONSTANT_STR_")
 #pragma pop_macro("PLTXT2HTM_U8_CONSTANT_STR_HELPER_")

--- a/include/pltxt2htm/details/push_macro.hh
+++ b/include/pltxt2htm/details/push_macro.hh
@@ -46,7 +46,7 @@
             if ((condition) == false) [[unlikely]] { \
                 constexpr auto source_location = ::std::source_location::current(); \
                 ::pltxt2htm::details::panic< \
-                    ::pltxt2htm::details::U8LiteralString{u8" \"assert(" #condition ")\" failed"}, \
+                    ::pltxt2htm::details::U8LiteralString{u8"\"assert(" #condition ")\" failed"}, \
                     ::pltxt2htm::details::U8LiteralString{PLTXT2HTM_U8_CONSTANT_STR_(__FILE__)}, \
                     source_location.line(), source_location.column(), pltxt2htm::details::U8LiteralString{message}>(); \
             } \

--- a/include/pltxt2htm/details/push_macro.hh
+++ b/include/pltxt2htm/details/push_macro.hh
@@ -46,7 +46,7 @@
             if ((condition) == false) [[unlikely]] { \
                 constexpr auto source_location = ::std::source_location::current(); \
                 ::pltxt2htm::details::panic< \
-                    ::pltxt2htm::details::U8LiteralString{u8"\"assert(" #condition ")\" failed"}, \
+                    ::pltxt2htm::details::U8LiteralString{(#condition)}, \
                     ::pltxt2htm::details::U8LiteralString{PLTXT2HTM_U8_CONSTANT_STR_(__FILE__)}, \
                     source_location.line(), source_location.column(), pltxt2htm::details::U8LiteralString{message}>(); \
             } \

--- a/include/pltxt2htm/details/push_macro.hh
+++ b/include/pltxt2htm/details/push_macro.hh
@@ -46,7 +46,7 @@
             if ((condition) == false) [[unlikely]] { \
                 constexpr auto source_location = ::std::source_location::current(); \
                 ::pltxt2htm::details::panic< \
-                    ::pltxt2htm::details::U8LiteralString{(#condition)}, \
+                    ::pltxt2htm::details::U8LiteralString{u8" \"assert(" #condition ")\" failed"}, \
                     ::pltxt2htm::details::U8LiteralString{PLTXT2HTM_U8_CONSTANT_STR_(__FILE__)}, \
                     source_location.line(), source_location.column(), pltxt2htm::details::U8LiteralString{message}>(); \
             } \

--- a/include/pltxt2htm/details/push_macro.hh
+++ b/include/pltxt2htm/details/push_macro.hh
@@ -46,12 +46,28 @@
             if ((condition) == false) [[unlikely]] { \
                 constexpr auto source_location = ::std::source_location::current(); \
                 ::pltxt2htm::details::panic< \
-                    ::pltxt2htm::details::U8LiteralString{PLTXT2HTM_U8_CONSTANT_STR_(#condition)}, \
+                    ::pltxt2htm::details::U8LiteralString{u8"\"assert(" #condition ")\" failed"}, \
                     ::pltxt2htm::details::U8LiteralString{PLTXT2HTM_U8_CONSTANT_STR_(__FILE__)}, \
                     source_location.line(), source_location.column(), pltxt2htm::details::U8LiteralString{message}>(); \
             } \
         } \
         else { \
             [[assume(condition)]]; \
+        } \
+    } while (0)
+
+#pragma push_macro("pltxt2htm_unreachable")
+#undef pltxt2htm_unreachable
+#define pltxt2htm_unreachable(message) \
+    do { \
+        if constexpr (ndebug != ::pltxt2htm::Contracts::ignore) { \
+            constexpr auto source_location = ::std::source_location::current(); \
+            ::pltxt2htm::details::panic< \
+                ::pltxt2htm::details::U8LiteralString{u8"unreachable code reached"}, \
+                ::pltxt2htm::details::U8LiteralString{PLTXT2HTM_U8_CONSTANT_STR_(__FILE__)}, \
+                source_location.line(), source_location.column(), ::pltxt2htm::details::U8LiteralString{message}>(); \
+        } \
+        else { \
+            ::exception::unreachable<true>(); \
         } \
     } while (0)

--- a/include/pltxt2htm/details/utils.hh
+++ b/include/pltxt2htm/details/utils.hh
@@ -219,7 +219,7 @@ constexpr bool is_prefix_match(::fast_io::u8string_view str) noexcept {
     }(::std::make_index_sequence<prefix_str.size()>{});
 #endif
     // suppress GCC -Wreturn-type warning
-    ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+    pltxt2htm_unreachable(u8"Unreachable - all cases return above");
 }
 
 /**

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -714,7 +714,7 @@ entry:
                     }
                     default:
                         [[unlikely]] {
-                            ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                            pltxt2htm_unreachable(u8"Unexpected node kind in emphasis switch");
                         }
                     }
                 }();
@@ -886,7 +886,7 @@ entry:
                     }
                     default:
                         [[unlikely]] {
-                            ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                            pltxt2htm_unreachable(u8"Unexpected node kind");
                         }
                     }
                 }();
@@ -1132,7 +1132,7 @@ entry:
                             ::pltxt2htm::MdDoubleEmphasisAsterisk<ndebug>(::std::move(tmp)));
                     }
                     else [[unlikely]] {
-                        ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        pltxt2htm_unreachable(u8"Unexpected node kind");
                     }
                     continue;
                 }
@@ -1147,7 +1147,7 @@ entry:
                             ::pltxt2htm::MdSingleEmphasisAsterisk<ndebug>{::std::move(tmp)});
                     }
                     else [[unlikely]] {
-                        ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        pltxt2htm_unreachable(u8"Unexpected node kind");
                     }
                     continue;
                 }
@@ -1243,7 +1243,7 @@ entry:
 #if 0
             default:
                 [[unlikely]] {
-                    ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    pltxt2htm_unreachable(u8"Unexpected node kind in escape/code-fence switch");
                 }
 #endif
             }

--- a/include/pltxt2htm/parser.hh
+++ b/include/pltxt2htm/parser.hh
@@ -103,7 +103,7 @@ constexpr auto parse_pltxt(::fast_io::u8string_view pltext) noexcept -> ::pltxt2
         }
         default:
             [[unlikely]] {
-                ::exception::unreachable<ndebug == ::pltxt2htm::Contracts::ignore>();
+                pltxt2htm_unreachable(u8"Unexpected node kind");
             }
         }
     }

--- a/tests/test_panic.cc
+++ b/tests/test_panic.cc
@@ -59,10 +59,10 @@ void test_panic_basic() noexcept {
     ::pltxt2htm_test::assert_true(total_read > 0);
 
     constexpr auto expected_ls = ::pltxt2htm::details::concat(
-        ::pltxt2htm::details::U8LiteralString{u8"Program panicked because \"assert("},
+        ::pltxt2htm::details::U8LiteralString{u8"Program panicked because "},
         ::pltxt2htm::details::U8LiteralString{u8"test_expression"},
         ::pltxt2htm::details::U8LiteralString{
-            u8")\" failed, please file a bug at \"https://github.com/SekaiArendelle/pltxt2htm/issues\" and attach the "
+            u8", please file a bug at \"https://github.com/SekaiArendelle/pltxt2htm/issues\" and attach the "
             u8"crash info along with the source text\n* in file: "},
         ::pltxt2htm::details::U8LiteralString{u8"test_file.cc"},
         ::pltxt2htm::details::U8LiteralString{u8"\n"


### PR DESCRIPTION
…acro

Migrate all 51 call sites from the old exception::unreachable to the new pltxt2htm_unreachable(message) macro, which provides richer diagnostics (source location + message) when contracts are active and falls back to the built-in unreachable in release builds.