### PR TITLE
feat: add <td> text-align support via style attribute, reject unknown…

### DIFF
--- a/include/pltxt2htm/ast/impl/html_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/html_node_decl.hh
@@ -12,6 +12,7 @@
 #include <fast_io/fast_io_dsal/string.h>
 #include <exception/exception.hh>
 #include "ast_decl.hh"
+#include "../node_kind.hh"
 
 namespace pltxt2htm {
 
@@ -586,10 +587,11 @@ public:
 template<::pltxt2htm::Contracts ndebug>
 class HtmlTd {
     ::pltxt2htm::Ast<ndebug> subast{};
+    ::pltxt2htm::MdTableAlign align_;
 
 public:
     constexpr HtmlTd() noexcept = delete;
-    constexpr explicit HtmlTd(::pltxt2htm::Ast<ndebug>&& subast_) noexcept;
+    constexpr explicit HtmlTd(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::MdTableAlign align_) noexcept;
     constexpr HtmlTd(::pltxt2htm::HtmlTd<ndebug> const&) noexcept;
     constexpr HtmlTd(::pltxt2htm::HtmlTd<ndebug>&&) noexcept;
     constexpr ~HtmlTd() noexcept;
@@ -603,6 +605,11 @@ public:
     [[nodiscard]]
     constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
         return ::std::forward_like<decltype(self)>(self.subast);
+    }
+
+    [[nodiscard]]
+    constexpr auto get_align(this auto&& self) noexcept -> ::pltxt2htm::MdTableAlign {
+        return self.align_;
     }
 };
 

--- a/include/pltxt2htm/ast/impl/html_node_def.inc
+++ b/include/pltxt2htm/ast/impl/html_node_def.inc
@@ -389,8 +389,10 @@ constexpr auto ::pltxt2htm::HtmlTr<ndebug>::operator==(this ::pltxt2htm::HtmlTr<
                                                        ::pltxt2htm::HtmlTr<ndebug> const&) noexcept -> bool = default;
 
 template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::HtmlTd<ndebug>::HtmlTd(::pltxt2htm::Ast<ndebug>&& subast_) noexcept
-    : subast(::std::move(subast_)) {
+constexpr ::pltxt2htm::HtmlTd<ndebug>::HtmlTd(::pltxt2htm::Ast<ndebug>&& subast_,
+                                              ::pltxt2htm::MdTableAlign align) noexcept
+    : subast(::std::move(subast_)),
+      align_{align} {
 }
 
 template<::pltxt2htm::Contracts ndebug>

--- a/include/pltxt2htm/ast/node_kind.hh
+++ b/include/pltxt2htm/ast/node_kind.hh
@@ -221,7 +221,7 @@ constexpr auto is_plain_pltext_type(::pltxt2htm::NodeKind const node_type) noexc
     return !(::pltxt2htm::details::is_equal_sign_tag_type(node_type) ||
              node_type == ::pltxt2htm::NodeKind::pl_external || node_type == ::pltxt2htm::NodeKind::pl_size ||
              node_type == ::pltxt2htm::NodeKind::md_block_quotes || node_type == ::pltxt2htm::NodeKind::md_link ||
-             node_type == ::pltxt2htm::NodeKind::html_span ||
+             node_type == ::pltxt2htm::NodeKind::html_span || node_type == ::pltxt2htm::NodeKind::html_td ||
              ::pltxt2htm::details::is_md_list_ul_or_ol_type(node_type));
 }
 

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -288,7 +288,7 @@ entry:
                 ++current_index;
                 result.append(u8"<experiment=");
                 result.append(node.as_pl_experiment().get_id());
-                result.append(u8">");
+                result.push_back(u8'>');
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::pl_discussion: {
@@ -297,7 +297,7 @@ entry:
                 ++current_index;
                 result.append(u8"<discussion=");
                 result.append(node.as_pl_discussion().get_id());
-                result.append(u8">");
+                result.push_back(u8'>');
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::pl_external: {
@@ -307,7 +307,7 @@ entry:
                 result.append(u8"<external=");
                 result.append(::pltxt2htm::details::convert_simple_pltxt_ast_to_plunity_richtext<ndebug>(
                     node.as_pl_external().get_url().get_url_ast()));
-                result.append(u8">");
+                result.push_back(u8'>');
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::pl_user: {
@@ -389,7 +389,7 @@ entry:
             case ::pltxt2htm::NodeKind::html_br:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::line_break: {
-                result.push_back('\n');
+                result.push_back(u8'\n');
                 continue;
             }
             case ::pltxt2htm::NodeKind::html_h1: {
@@ -778,7 +778,15 @@ entry:
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_td().get_subast(),
                                                                                   ::pltxt2htm::NodeKind::html_td, 0));
                 ++current_index;
-                result.append(u8"<td>");
+                result.append(u8"<td");
+                auto const align = node.as_html_td().get_align();
+                if (align == ::pltxt2htm::MdTableAlign::center) {
+                    result.append(u8" style=\"text-align:center\"");
+                }
+                else if (align == ::pltxt2htm::MdTableAlign::right) {
+                    result.append(u8" style=\"text-align:right\"");
+                }
+                result.push_back(u8'>');
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_th: {

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -533,7 +533,7 @@ entry:
             case ::pltxt2htm::NodeKind::line_break: {
                 if (nested_tag_type == ::pltxt2htm::NodeKind::md_code_fence_backtick ||
                     nested_tag_type == ::pltxt2htm::NodeKind::md_code_fence_tilde) {
-                    result.push_back('\n');
+                    result.push_back(u8'\n');
                 }
                 else {
                     result.append(u8"<br>");
@@ -844,14 +844,22 @@ entry:
                 else if (align == ::pltxt2htm::MdTableAlign::right) {
                     result.append(u8" style=\"text-align:right\"");
                 }
-                result.append(u8">");
+                result.push_back(u8'>');
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_td: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_td().get_subast(),
                                                                                   ::pltxt2htm::NodeKind::html_td, 0));
                 ++current_index;
-                result.append(u8"<td>");
+                result.append(u8"<td");
+                auto const align = node.as_html_td().get_align();
+                if (align == ::pltxt2htm::MdTableAlign::center) {
+                    result.append(u8" style=\"text-align:center\"");
+                }
+                else if (align == ::pltxt2htm::MdTableAlign::right) {
+                    result.append(u8" style=\"text-align:right\"");
+                }
+                result.push_back(u8'>');
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_th: {
@@ -866,7 +874,7 @@ entry:
                 else if (align == ::pltxt2htm::MdTableAlign::right) {
                     result.append(u8" style=\"text-align:right\"");
                 }
-                result.append(u8">");
+                result.push_back(u8'>');
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_th: {

--- a/include/pltxt2htm/details/parser/frame_concext.hh
+++ b/include/pltxt2htm/details/parser/frame_concext.hh
@@ -299,8 +299,6 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_tr:
             [[fallthrough]];
-        case ::pltxt2htm::NodeKind::html_td:
-            [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_th:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_thead:
@@ -455,6 +453,8 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_escape_tilde:
             [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_td:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_th:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_td: {
@@ -570,8 +570,6 @@ public:
         case ::pltxt2htm::NodeKind::html_table:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_tr:
-            [[fallthrough]];
-        case ::pltxt2htm::NodeKind::html_td:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_th:
             [[fallthrough]];
@@ -727,6 +725,8 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_escape_tilde:
             [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_td:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_th:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_td: {
@@ -853,7 +853,8 @@ public:
                                           ::pltxt2htm::NodeKind node_type) noexcept
         : context_data{::pltxt2htm::details::ContextVariant<ndebug>{
               ::pltxt2htm::details::ParserFrameContextWithMdCellInfo{.pltext = pltext_, .align = align_}, node_type}} {
-        pltxt2htm_assert(node_type == ::pltxt2htm::NodeKind::md_th || node_type == ::pltxt2htm::NodeKind::md_td,
+        pltxt2htm_assert(node_type == ::pltxt2htm::NodeKind::html_td || node_type == ::pltxt2htm::NodeKind::md_th ||
+                             node_type == ::pltxt2htm::NodeKind::md_td,
                          u8"mismatch node type");
     }
 
@@ -964,8 +965,6 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_tr:
             [[fallthrough]];
-        case ::pltxt2htm::NodeKind::html_td:
-            [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_th:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_thead:
@@ -1055,6 +1054,8 @@ public:
         case ::pltxt2htm::NodeKind::md_link: {
             return context_data_ref.md_link.pltext;
         }
+        case ::pltxt2htm::NodeKind::html_td:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_th:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_td: {
@@ -1260,7 +1261,8 @@ public:
     [[nodiscard]]
     constexpr auto get_md_cell_align(this auto&& self) noexcept -> ::pltxt2htm::MdTableAlign {
         auto&& context_data_ref = self.context_data;
-        pltxt2htm_assert(context_data_ref.kind == ::pltxt2htm::NodeKind::md_th ||
+        pltxt2htm_assert(context_data_ref.kind == ::pltxt2htm::NodeKind::html_td ||
+                             context_data_ref.kind == ::pltxt2htm::NodeKind::md_th ||
                              context_data_ref.kind == ::pltxt2htm::NodeKind::md_td,
                          u8"context kind mismatch");
         return context_data_ref.md_cell.align;

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -1140,13 +1140,14 @@ entry:
                             ::pltxt2htm::NodeKind::html_th));
                         goto entry;
                     }
-                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_td_tag<ndebug>(
+                    if (auto opt_td_tag = ::pltxt2htm::details::try_parse_td_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
                             ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
-                        opt_tag_len.has_value()) {
-                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        opt_td_tag.has_value()) {
+                        auto&& [tag_len, align] = opt_td_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 3;
                         call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), align,
                             ::pltxt2htm::NodeKind::html_td));
                         goto entry;
                     }
@@ -1789,7 +1790,8 @@ entry:
                             opt_tag_len.has_value()) {
                             // parsing end tag </td> successed
                             ::std::size_t const staged_index{current_index};
-                            ::pltxt2htm::HtmlTd staged_node(::std::move(result));
+                            auto align = frame.get_md_cell_align();
+                            ::pltxt2htm::HtmlTd staged_node(::std::move(result), align);
                             call_stack.pop();
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(
@@ -2343,7 +2345,9 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_td: {
-                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlTd<ndebug>{::std::move(subast)}));
+                auto align = frame.get_md_cell_align();
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlTd<ndebug>{::std::move(subast), align}));
                 parent_index += staged_index;
                 goto entry;
             }

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -525,25 +525,197 @@ constexpr auto try_parse_th_tag(::fast_io::u8string_view pltext, ::pltxt2htm::No
 }
 
 /**
- * @brief Parse &lt;td&gt; and validate parent container type.
+ * @brief Parse a CSS text-align value to a MdTableAlign.
+ * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled.
+ * @param[in] value The text-align value string (e.g. "center", "CENTER").
+ * @return The corresponding alignment on success, or nullopt on failure.
+ */
+[[nodiscard]]
+constexpr auto parse_text_align_value(::fast_io::u8string_view value) noexcept
+    -> ::exception::optional<::pltxt2htm::MdTableAlign> {
+    // only exact lowercase values accepted
+    if (value == ::fast_io::u8string_view{u8"left"}) {
+        return ::pltxt2htm::MdTableAlign::left;
+    }
+    if (value == ::fast_io::u8string_view{u8"center"}) {
+        return ::pltxt2htm::MdTableAlign::center;
+    }
+    if (value == ::fast_io::u8string_view{u8"right"}) {
+        return ::pltxt2htm::MdTableAlign::right;
+    }
+    return ::exception::nullopt_t{};
+}
+
+struct TryParseTdTagResult {
+    ::std::size_t tag_len; ///< Length of the matched tag up to the closing `>`.
+    ::pltxt2htm::MdTableAlign align; ///< Cell alignment parsed from `style="text-align:..."`.
+};
+
+/**
+ * @brief Parse &lt;td&gt; (optionally with `style="text-align:..."`) and validate parent container type.
  * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
  * @param[in] pltext The input text to parse, starting after `<t`.
  * @param[in] nested_tag_type Current parent tag type from parsing context.
- * @return Matched tag length when valid under &lt;tr&gt;; otherwise nullopt.
+ * @return Parsed tag length and alignment when valid under &lt;tr&gt;; otherwise nullopt.
  */
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
 constexpr auto try_parse_td_tag(::fast_io::u8string_view pltext, ::pltxt2htm::NodeKind const nested_tag_type) noexcept
-    -> ::exception::optional<::std::size_t> {
-    auto opt_tag_len =
-        ::pltxt2htm::details::try_parse_bare_tag<ndebug, ::pltxt2htm::details::U8LiteralString{u8"d"}>(pltext);
-    if (!opt_tag_len.has_value()) {
+    -> ::exception::optional<TryParseTdTagResult> {
+    if (!::pltxt2htm::details::is_prefix_match<ndebug, ::pltxt2htm::details::U8LiteralString{u8"d"}>(pltext)) {
         return ::exception::nullopt_t{};
     }
     if (nested_tag_type != ::pltxt2htm::NodeKind::html_tr) {
         return ::exception::nullopt_t{};
     }
-    return opt_tag_len;
+
+    ::std::size_t pos{1}; // skip past "d"
+    ::pltxt2htm::MdTableAlign align{::pltxt2htm::MdTableAlign::left};
+
+    while (pos < pltext.size()) {
+        // skip whitespace
+        while (pos < pltext.size() && (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
+                                       ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
+            ++pos;
+        }
+        if (pos >= pltext.size()) {
+            return ::exception::nullopt_t{};
+        }
+        if (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'>') {
+            return TryParseTdTagResult{pos, align};
+        }
+
+        // parse attribute name
+        ::std::size_t const attr_start{pos};
+        while (pos < pltext.size() && ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'=' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'>' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8' ' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'\t' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'/') {
+            ++pos;
+        }
+        ::fast_io::u8string_view const attr_name{pltext.data() + attr_start, pos - attr_start};
+
+        // skip whitespace before '='
+        while (pos < pltext.size() && (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
+                                       ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
+            ++pos;
+        }
+        if (pos >= pltext.size() || ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'=') {
+            return ::exception::nullopt_t{};
+        }
+        ++pos; // skip '='
+
+        // skip whitespace after '='
+        while (pos < pltext.size() && (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
+                                       ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
+            ++pos;
+        }
+        if (pos >= pltext.size()) {
+            return ::exception::nullopt_t{};
+        }
+
+        // parse quoted attribute value
+        char8_t const quote{::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos)};
+        if (quote != u8'"' && quote != u8'\'') {
+            return ::exception::nullopt_t{};
+        }
+        ++pos; // skip opening quote
+        ::std::size_t const val_start{pos};
+        while (pos < pltext.size() && ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != quote) {
+            ++pos;
+        }
+        if (pos >= pltext.size()) {
+            return ::exception::nullopt_t{};
+        }
+        ::fast_io::u8string_view const attr_val{pltext.data() + val_start, pos - val_start};
+        ++pos; // skip closing quote
+
+        // only lowercase "style" attribute is checked for text-align
+        if (::pltxt2htm::details::is_prefix_match<ndebug, ::pltxt2htm::details::U8LiteralString{u8"style"}>(
+                attr_name) &&
+            attr_name.size() == 5) {
+            // parse CSS property:value pairs from the style value
+            ::std::size_t css_pos{};
+            while (css_pos < attr_val.size()) {
+                // skip leading whitespace
+                while (css_pos < attr_val.size() &&
+                       (::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) == u8' ' ||
+                        ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) == u8'\t')) {
+                    ++css_pos;
+                }
+                if (css_pos >= attr_val.size()) {
+                    break;
+                }
+
+                // find next ';' or end of value
+                ::std::size_t const seg_start{css_pos};
+                while (css_pos < attr_val.size() &&
+                       ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) != u8';') {
+                    ++css_pos;
+                }
+                auto segment = ::fast_io::u8string_view{attr_val.data() + seg_start, css_pos - seg_start};
+                if (css_pos < attr_val.size() &&
+                    ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) == u8';') {
+                    ++css_pos; // skip ';'
+                }
+
+                // trim trailing whitespace
+                while (!segment.empty() && (segment.back() == u8' ' || segment.back() == u8'\t')) {
+                    segment = ::fast_io::u8string_view{segment.data(), segment.size() - 1};
+                }
+                if (segment.empty()) {
+                    continue;
+                }
+
+                // find ':' to split property:value
+                ::std::size_t colon{};
+                while (colon < segment.size() &&
+                       ::pltxt2htm::details::u8string_view_index<ndebug>(segment, colon) != u8':') {
+                    ++colon;
+                }
+                if (colon == 0 || colon >= segment.size()) {
+                    continue; // malformed CSS segment, ignore
+                }
+
+                // extract property name
+                auto prop = ::fast_io::u8string_view{segment.data(), colon};
+                while (!prop.empty() && (prop.back() == u8' ' || prop.back() == u8'\t')) {
+                    prop = ::fast_io::u8string_view{prop.data(), prop.size() - 1};
+                }
+
+                // extract value
+                ::std::size_t val_idx{colon + 1};
+                while (val_idx < segment.size() &&
+                       (::pltxt2htm::details::u8string_view_index<ndebug>(segment, val_idx) == u8' ' ||
+                        ::pltxt2htm::details::u8string_view_index<ndebug>(segment, val_idx) == u8'\t')) {
+                    ++val_idx;
+                }
+                auto val = ::fast_io::u8string_view{segment.data() + val_idx, segment.size() - val_idx};
+                while (!val.empty() && (val.back() == u8' ' || val.back() == u8'\t')) {
+                    val = ::fast_io::u8string_view{val.data(), val.size() - 1};
+                }
+
+                // only lowercase "text-align" property is recognized
+                if (::pltxt2htm::details::is_prefix_match<ndebug, u8"text-align">(prop) && prop.size() == 10) {
+                    auto opt_align_val = ::pltxt2htm::details::parse_text_align_value(val);
+                    if (opt_align_val.has_value()) {
+                        align = opt_align_val.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    }
+                    else {
+                        // invalid text-align value → reject tag
+                        return ::exception::nullopt_t{};
+                    }
+                }
+                else {
+                    // unknown CSS property → reject tag
+                    return ::exception::nullopt_t{};
+                }
+            }
+        }
+        // else: unknown attribute, ignore
+    }
+    return ::exception::nullopt_t{};
 }
 
 struct TryParseEqualSignTagResult {
@@ -759,7 +931,8 @@ constexpr auto parse_font_size_value(::fast_io::u8string_view value) noexcept ->
     }
     ::std::size_t len{value.size()};
     // strip optional "px" suffix (lowercase only)
-    if (len >= 2 && value[len - 2] == u8'p' && value[len - 1] == u8'x') {
+    if (len >= 2 && ::pltxt2htm::details::u8string_view_index<ndebug>(value, len - 2) == u8'p' &&
+        ::pltxt2htm::details::u8string_view_index<ndebug>(value, len - 1) == u8'x') {
         len -= 2;
     }
     ::exception::optional<::std::size_t> result{
@@ -794,35 +967,46 @@ constexpr auto try_parse_span_tag(::fast_io::u8string_view pltext) noexcept
 
     while (pos < pltext.size()) {
         // skip whitespace
-        while (pos < pltext.size() && (pltext[pos] == u8' ' || pltext[pos] == u8'\t')) {
+        while (pos < pltext.size() &&
+               (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
+                ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
             ++pos;
         }
         if (pos >= pltext.size()) {
             return ::exception::nullopt_t{};
         }
-        if (pltext[pos] == u8'>') {
+        if (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'>') {
             break;
         }
 
         // parse attribute name
         ::std::size_t const attr_start = pos;
-        while (pos < pltext.size() && pltext[pos] != u8'=' && pltext[pos] != u8'>' && pltext[pos] != u8' ' &&
-               pltext[pos] != u8'\t' && pltext[pos] != u8'/') {
+        while (pos < pltext.size() &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'=' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'>' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8' ' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'\t' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'/') {
             ++pos;
         }
         ::fast_io::u8string_view const attr_name{pltext.data() + attr_start, pos - attr_start};
 
         // skip whitespace before '='
-        while (pos < pltext.size() && (pltext[pos] == u8' ' || pltext[pos] == u8'\t')) {
+        while (pos < pltext.size() &&
+               (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
+                ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
             ++pos;
         }
-        if (pos >= pltext.size() || pltext[pos] != u8'=') {
+        if (pos >= pltext.size() ||
+            ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'=') {
             return ::exception::nullopt_t{};
         }
         ++pos; // skip '='
 
         // skip whitespace after '='
-        while (pos < pltext.size() && (pltext[pos] == u8' ' || pltext[pos] == u8'\t')) {
+        while (pos < pltext.size() &&
+               (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
+                ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
             ++pos;
         }
         if (pos >= pltext.size()) {
@@ -830,13 +1014,14 @@ constexpr auto try_parse_span_tag(::fast_io::u8string_view pltext) noexcept
         }
 
         // parse quoted attribute value
-        char8_t const quote = pltext[pos];
+        char8_t const quote{::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos)};
         if (quote != u8'"' && quote != u8'\'') {
             return ::exception::nullopt_t{};
         }
         ++pos; // skip opening quote
         ::std::size_t const val_start = pos;
-        while (pos < pltext.size() && pltext[pos] != quote) {
+        while (pos < pltext.size() &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != quote) {
             ++pos;
         }
         if (pos >= pltext.size()) {
@@ -855,7 +1040,9 @@ constexpr auto try_parse_span_tag(::fast_io::u8string_view pltext) noexcept
         ::std::size_t css_pos = 0;
         while (css_pos < attr_val.size()) {
             // skip leading whitespace
-            while (css_pos < attr_val.size() && (attr_val[css_pos] == u8' ' || attr_val[css_pos] == u8'\t')) {
+            while (css_pos < attr_val.size() &&
+                   (::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) == u8' ' ||
+                    ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) == u8'\t')) {
                 ++css_pos;
             }
             if (css_pos >= attr_val.size()) {
@@ -863,12 +1050,14 @@ constexpr auto try_parse_span_tag(::fast_io::u8string_view pltext) noexcept
             }
             // find next ';' or end of value
             ::std::size_t prop_end = css_pos;
-            while (prop_end < attr_val.size() && attr_val[prop_end] != u8';') {
+            while (prop_end < attr_val.size() &&
+                   ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, prop_end) != u8';') {
                 ++prop_end;
             }
             auto segment = ::fast_io::u8string_view{attr_val.data() + css_pos, prop_end - css_pos};
             css_pos = prop_end;
-            if (css_pos < attr_val.size() && attr_val[css_pos] == u8';') {
+            if (css_pos < attr_val.size() &&
+                ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) == u8';') {
                 ++css_pos; // skip ';'
             }
 
@@ -882,7 +1071,8 @@ constexpr auto try_parse_span_tag(::fast_io::u8string_view pltext) noexcept
 
             // find ':' to split property:value
             ::std::size_t colon = 0;
-            while (colon < segment.size() && segment[colon] != u8':') {
+            while (colon < segment.size() &&
+                   ::pltxt2htm::details::u8string_view_index<ndebug>(segment, colon) != u8':') {
                 ++colon;
             }
             if (colon == 0 || colon >= segment.size()) {
@@ -897,7 +1087,9 @@ constexpr auto try_parse_span_tag(::fast_io::u8string_view pltext) noexcept
 
             // extract value
             ::std::size_t val_idx = colon + 1;
-            while (val_idx < segment.size() && (segment[val_idx] == u8' ' || segment[val_idx] == u8'\t')) {
+            while (val_idx < segment.size() &&
+                   (::pltxt2htm::details::u8string_view_index<ndebug>(segment, val_idx) == u8' ' ||
+                    ::pltxt2htm::details::u8string_view_index<ndebug>(segment, val_idx) == u8'\t')) {
                 ++val_idx;
             }
             auto val = ::fast_io::u8string_view{segment.data() + val_idx, segment.size() - val_idx};
@@ -936,7 +1128,7 @@ constexpr auto try_parse_span_tag(::fast_io::u8string_view pltext) noexcept
     if (!found_style || (color.empty() && !font_size.has_value())) {
         return ::exception::nullopt_t{};
     }
-    if (pos >= pltext.size() || pltext[pos] != u8'>') {
+    if (pos >= pltext.size() || ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'>') {
         return ::exception::nullopt_t{};
     }
     return TryParseSpanTagResult{pos + 1, ::std::move(color), ::std::move(font_size)};

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -712,8 +712,10 @@ constexpr auto try_parse_td_tag(::fast_io::u8string_view pltext, ::pltxt2htm::No
                     return ::exception::nullopt_t{};
                 }
             }
+            continue; // processed "style", check next attribute or '>'
         }
-        // else: unknown attribute, ignore
+        // else: unknown attribute → reject tag
+        return ::exception::nullopt_t{};
     }
     return ::exception::nullopt_t{};
 }

--- a/tests/test_html_table.cc
+++ b/tests/test_html_table.cc
@@ -261,10 +261,11 @@ int main() {
     }
 
     {
-        // <td> with multiple attributes — unknown attributes (class, id) ignored
+        // <td> with multiple attributes — unknown attributes (class, id) → tag rejected, escaped
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"<table><tr><td class=\"foo\" style=\"text-align:center\" id=\"bar\">cell</td></tr></table>");
-        auto answer = ::fast_io::u8string_view{u8"<table><tr><td style=\"text-align:center\">cell</td></tr></table>"};
+        auto answer = ::fast_io::u8string_view{
+            u8"<table><tr>&lt;td&nbsp;class=&quot;foo&quot;&nbsp;style=&quot;text-align:center&quot;&nbsp;id=&quot;bar&quot;&gt;cell&lt;/td&gt;</tr></table>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_html_table.cc
+++ b/tests/test_html_table.cc
@@ -227,5 +227,102 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
     }
 
+    // ── <td style="text-align:..."> ──
+
+    {
+        // <td> without style → no style attribute
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td>cell</td></tr></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><tr><td>cell</td></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <td style="text-align:center">
+        auto html =
+            ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td style=\"text-align:center\">cell</td></tr></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><tr><td style=\"text-align:center\">cell</td></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <td style="text-align:right">
+        auto html =
+            ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td style=\"text-align:right\">cell</td></tr></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><tr><td style=\"text-align:right\">cell</td></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <td style="text-align:left"> → accepted (valid), default align → no style attr
+        auto html =
+            ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td style=\"text-align:left\">cell</td></tr></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><tr><td>cell</td></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <td> with multiple attributes — unknown attributes (class, id) ignored
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<table><tr><td class=\"foo\" style=\"text-align:center\" id=\"bar\">cell</td></tr></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><tr><td style=\"text-align:center\">cell</td></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <td style="color:red;text-align:center"> → unknown CSS → tag rejected, escaped
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<table><tr><td style=\"color:red;text-align:center\">cell</td></tr></table>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<table><tr>&lt;td&nbsp;style=&quot;color:red;text-align:center&quot;&gt;cell&lt;/td&gt;</tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <td style="text-align:center;color:red"> → unknown CSS → tag rejected, escaped
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<table><tr><td style=\"text-align:center;color:red\">cell</td></tr></table>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<table><tr>&lt;td&nbsp;style=&quot;text-align:center;color:red&quot;&gt;cell&lt;/td&gt;</tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    // ── uppercase text-align values rejected ──
+
+    {
+        // <td style="text-align:LEFT"> → uppercase → rejected
+        auto html =
+            ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td style=\"text-align:LEFT\">cell</td></tr></table>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<table><tr>&lt;td&nbsp;style=&quot;text-align:LEFT&quot;&gt;cell&lt;/td&gt;</tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <td style="text-align:Left"> → mixed case → rejected
+        auto html =
+            ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td style=\"text-align:Left\">cell</td></tr></table>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<table><tr>&lt;td&nbsp;style=&quot;text-align:Left&quot;&gt;cell&lt;/td&gt;</tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <td style="text-align:CENTER"> → uppercase → rejected
+        auto html =
+            ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td style=\"text-align:CENTER\">cell</td></tr></table>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<table><tr>&lt;td&nbsp;style=&quot;text-align:CENTER&quot;&gt;cell&lt;/td&gt;</tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <td style="text-align:Right"> → mixed case → rejected
+        auto html =
+            ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td style=\"text-align:Right\">cell</td></tr></table>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<table><tr>&lt;td&nbsp;style=&quot;text-align:Right&quot;&gt;cell&lt;/td&gt;</tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
     return 0;
 }


### PR DESCRIPTION
… CSS for XSS safety

- try_parse_td_tag: full CSS parser accepting only lowercase text-align with left/center/right values; unknown CSS properties reject the entire tag
- parse_text_align_value: new helper matching exact lowercase values
- HtmlTd: add align_ member, constructor parameter, and get_align() accessor
- frame_concext.hh: html_td shares md_cell variant with md_td/md_th
- parser.hh: pass alignment through open/close tag paths
- Backends: output style="text-align:center|right" when non-default
- Tests: bare td, center/right/left, unknown CSS rejection, case rejection, multi-attribute handling

Also: migrate all operator[] on u8string_view to u8string_view_index<ndebug>
in try_parse.hh (td_tag, span_tag, parse_font_size_value). Minor consistency fixes for append vs push_back and character literal prefixes.