### PR TITLE
feat: parse raw <input type="checkbox" disabled [checked]> from HTML …

### DIFF
--- a/include/pltxt2htm/ast/ast.hh
+++ b/include/pltxt2htm/ast/ast.hh
@@ -64,6 +64,7 @@ class PlTxtNode {
 
         // html table node
         ::pltxt2htm::HtmlCol html_col_node;
+        ::pltxt2htm::HtmlInput html_input_node;
         ::pltxt2htm::HtmlTable<ndebug> html_table_node;
         ::pltxt2htm::HtmlCaption<ndebug> html_caption_node;
         ::pltxt2htm::HtmlColgroup<ndebug> html_colgroup_node;
@@ -390,6 +391,11 @@ public:
     constexpr PlTxtNode(::pltxt2htm::HtmlCol node) noexcept
         : html_col_node{node},
           node_kind{::pltxt2htm::NodeKind::html_col} {
+    }
+
+    constexpr PlTxtNode(::pltxt2htm::HtmlInput node) noexcept
+        : html_input_node{node},
+          node_kind{::pltxt2htm::NodeKind::html_input} {
     }
 
     constexpr PlTxtNode(::pltxt2htm::HtmlTable<ndebug>&& node) noexcept
@@ -963,6 +969,10 @@ public:
             new (::std::addressof(html_col_node))::pltxt2htm::HtmlCol(other.html_col_node);
             break;
         }
+        case ::pltxt2htm::NodeKind::html_input: {
+            new (::std::addressof(html_input_node))::pltxt2htm::HtmlInput(other.html_input_node);
+            break;
+        }
         case ::pltxt2htm::NodeKind::html_table: {
             new (::std::addressof(html_table_node))::pltxt2htm::HtmlTable(other.html_table_node);
             break;
@@ -1529,6 +1539,11 @@ public:
             break;
         }
 
+        case ::pltxt2htm::NodeKind::html_input: {
+            new (::std::addressof(html_input_node))::pltxt2htm::HtmlInput(::std::move(other.html_input_node));
+            break;
+        }
+
         case ::pltxt2htm::NodeKind::html_table: {
             new (::std::addressof(html_table_node))::pltxt2htm::HtmlTable(::std::move(other.html_table_node));
             break;
@@ -2082,6 +2097,10 @@ public:
             html_col_node.~HtmlCol();
             break;
         }
+        case ::pltxt2htm::NodeKind::html_input: {
+            html_input_node.~HtmlInput();
+            break;
+        }
         case ::pltxt2htm::NodeKind::html_table: {
             html_table_node.~HtmlTable();
             break;
@@ -2550,6 +2569,9 @@ public:
         case ::pltxt2htm::NodeKind::html_col: {
             return self.html_col_node == other.html_col_node;
         }
+        case ::pltxt2htm::NodeKind::html_input: {
+            return self.html_input_node == other.html_input_node;
+        }
         case ::pltxt2htm::NodeKind::html_table: {
             return self.html_table_node == other.html_table_node;
         }
@@ -3007,6 +3029,13 @@ public:
         bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::html_col};
         pltxt2htm_assert(is_type, u8"node kind mismatch");
         return ::std::forward_like<decltype(self)>(self.html_col_node);
+    }
+
+    [[nodiscard]]
+    constexpr auto as_html_input(this auto&& self) noexcept -> decltype(auto) {
+        bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::html_input};
+        pltxt2htm_assert(is_type, u8"node kind mismatch");
+        return ::std::forward_like<decltype(self)>(self.html_input_node);
     }
 
     [[nodiscard]]

--- a/include/pltxt2htm/ast/impl/html_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/html_node_decl.hh
@@ -44,6 +44,26 @@ public:
 };
 
 /**
+ * @brief HTML &lt;input&gt; checkbox input node (self-closing)
+ * @details Represents &lt;input type=&quot;checkbox&quot; disabled&gt; or
+ *          &lt;input type=&quot;checkbox&quot; disabled checked&gt;.
+ */
+class HtmlInput {
+public:
+    bool checked_;
+
+    [[nodiscard]]
+    constexpr auto operator==(this HtmlInput const& self, HtmlInput const& other) noexcept -> bool {
+        return self.checked_ == other.checked_;
+    }
+
+    [[nodiscard]]
+    constexpr auto is_checked(this auto&& self) noexcept -> bool {
+        return self.checked_;
+    }
+};
+
+/**
  * @brief HTML &lt;h1&gt; heading node
  * @details Represents a level‑1 heading containing sub‑AST content.
  */

--- a/include/pltxt2htm/ast/node_kind.hh
+++ b/include/pltxt2htm/ast/node_kind.hh
@@ -96,6 +96,7 @@ enum class NodeKind : unsigned {
     html_caption, ///< HTML table caption: &lt;caption&gt;...&lt;/caption&gt;
     html_colgroup, ///< HTML table column group: &lt;colgroup&gt;...&lt;/colgroup&gt;
     html_col, ///< HTML table column: &lt;col&gt; (self-closing)
+    html_input, ///< HTML checkbox input: &lt;input type=&quot;checkbox&quot; disabled&gt;
 
     // Markdown ATX-style headers (# ## ### #### ##### ######)
     md_atx_h1, ///< Markdown level 1 heading: # Heading

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -874,6 +874,15 @@ entry:
                 result.append(u8"<col>");
                 continue;
             }
+            case ::pltxt2htm::NodeKind::html_input: {
+                if (node.as_html_input().is_checked()) {
+                    result.append(u8"<input type=\"checkbox\" disabled checked>");
+                }
+                else {
+                    result.append(u8"<input type=\"checkbox\" disabled>");
+                }
+                continue;
+            }
             case ::pltxt2htm::NodeKind::md_triple_emphasis_underscore: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
                     node.as_md_triple_emphasis_underscore().get_subast(),

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -946,6 +946,15 @@ entry:
                 result.append(u8"<col>");
                 continue;
             }
+            case ::pltxt2htm::NodeKind::html_input: {
+                if (node.as_html_input().is_checked()) {
+                    result.append(u8"<input type=\"checkbox\" disabled checked>");
+                }
+                else {
+                    result.append(u8"<input type=\"checkbox\" disabled>");
+                }
+                continue;
+            }
             case ::pltxt2htm::NodeKind::md_triple_emphasis_underscore: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
                     node.as_md_triple_emphasis_underscore().get_subast(),

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -490,7 +490,9 @@ entry:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::html_note:
                 [[fallthrough]];
-            case ::pltxt2htm::NodeKind::html_col: {
+            case ::pltxt2htm::NodeKind::html_col:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::html_input: {
                 continue;
             }
             case ::pltxt2htm::NodeKind::text: {

--- a/include/pltxt2htm/details/parser/frame_concext.hh
+++ b/include/pltxt2htm/details/parser/frame_concext.hh
@@ -303,6 +303,8 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_col:
             [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_input:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_atx_h1:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_atx_h2:
@@ -574,6 +576,8 @@ public:
         case ::pltxt2htm::NodeKind::html_colgroup:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_col:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_input:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_atx_h1:
             [[fallthrough]];
@@ -872,6 +876,8 @@ public:
         case ::pltxt2htm::NodeKind::html_colgroup:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_col:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_input:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_atx_h1:
             [[fallthrough]];

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -1116,6 +1116,18 @@ entry:
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
                     }
+                    // parsing html <input type="checkbox" disabled [checked]> self-closing tag
+                    if (auto opt_input_tag = ::pltxt2htm::details::try_parse_input_checkbox_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_input_tag.has_value()) {
+                        auto&& [tag_len, checked] =
+                            opt_input_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 1;
+                        result.push_back(
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlInput{checked}));
+                        ++current_index;
+                        continue;
+                    }
                     result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
                     ++current_index;
                     continue;
@@ -2265,6 +2277,8 @@ entry:
                         [[fallthrough]];
                     case ::pltxt2htm::NodeKind::html_col:
                         [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::html_input:
+                        [[fallthrough]];
                     case ::pltxt2htm::NodeKind::md_image:
                         [[fallthrough]];
                     case ::pltxt2htm::NodeKind::url:
@@ -2781,6 +2795,8 @@ entry:
             case ::pltxt2htm::NodeKind::html_hr:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::html_col:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::html_input:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::md_escape_backslash:
                 [[fallthrough]];

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1226,7 +1226,6 @@ constexpr auto try_parse_col_tag(::fast_io::u8string_view pltext, ::pltxt2htm::N
  * @param[in] pltext The input text to parse, starting after `<i`.
  * @return Tag length and checked state if matched; otherwise nullopt.
  */
-template<::pltxt2htm::Contracts ndebug>
 struct TryParseInputCheckboxTagResult {
     ::std::size_t tag_len;
     bool checked;
@@ -1235,7 +1234,7 @@ struct TryParseInputCheckboxTagResult {
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
 constexpr auto try_parse_input_checkbox_tag(::fast_io::u8string_view pltext) noexcept
-    -> ::exception::optional<TryParseInputCheckboxTagResult<ndebug>> {
+    -> ::exception::optional<TryParseInputCheckboxTagResult> {
     // match "nput" (case-insensitive)
     if (pltext.size() < 4 ||
         !::pltxt2htm::details::is_prefix_match<ndebug, ::pltxt2htm::details::U8LiteralString{u8"nput"}>(pltext)) {
@@ -1346,7 +1345,7 @@ constexpr auto try_parse_input_checkbox_tag(::fast_io::u8string_view pltext) noe
     if (pos >= pltext.size() || ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'>') {
         return ::exception::nullopt_t{};
     }
-    return TryParseInputCheckboxTagResult<ndebug>{pos + 1, checked};
+    return TryParseInputCheckboxTagResult{pos + 1, checked};
 }
 
 /**

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1221,6 +1221,135 @@ constexpr auto try_parse_col_tag(::fast_io::u8string_view pltext, ::pltxt2htm::N
 }
 
 /**
+ * @brief Parse &lt;input type=&quot;checkbox&quot; disabled [checked]&gt; tag.
+ * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
+ * @param[in] pltext The input text to parse, starting after `<i`.
+ * @return Tag length and checked state if matched; otherwise nullopt.
+ */
+template<::pltxt2htm::Contracts ndebug>
+struct TryParseInputCheckboxTagResult {
+    ::std::size_t tag_len;
+    bool checked;
+};
+
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_input_checkbox_tag(::fast_io::u8string_view pltext) noexcept
+    -> ::exception::optional<TryParseInputCheckboxTagResult<ndebug>> {
+    // match "nput" (case-insensitive)
+    if (pltext.size() < 4 ||
+        !::pltxt2htm::details::is_prefix_match<ndebug, ::pltxt2htm::details::U8LiteralString{u8"nput"}>(pltext)) {
+        return ::exception::nullopt_t{};
+    }
+    ::std::size_t pos{4};
+    bool found_type_checkbox{false};
+    bool found_disabled{false};
+    bool checked{false};
+
+    while (pos < pltext.size()) {
+        // skip whitespace
+        while (pos < pltext.size() && (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
+                                       ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
+            ++pos;
+        }
+        if (pos >= pltext.size()) {
+            return ::exception::nullopt_t{};
+        }
+        // end of tag
+        if (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'>') {
+            break;
+        }
+        if (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'/' && pos + 1 < pltext.size() &&
+            ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos + 1) == u8'>') {
+            break;
+        }
+
+        // parse attribute name
+        ::std::size_t const attr_start = pos;
+        while (pos < pltext.size() && ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'=' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'>' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8' ' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'\t' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'/') {
+            ++pos;
+        }
+        ::fast_io::u8string_view const attr_name{pltext.data() + attr_start, pos - attr_start};
+
+        // boolean attribute without value: "disabled" or "checked"
+        if (pos < pltext.size() &&
+            (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
+             ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t' ||
+             ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'>' ||
+             ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'/')) {
+            if (attr_name == ::fast_io::u8string_view{u8"disabled"}) {
+                found_disabled = true;
+                continue;
+            }
+            if (attr_name == ::fast_io::u8string_view{u8"checked"}) {
+                checked = true;
+                continue;
+            }
+            return ::exception::nullopt_t{};
+        }
+
+        // attribute with '=' value: "type=..."
+        if (pos >= pltext.size() || ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'=') {
+            return ::exception::nullopt_t{};
+        }
+        ++pos; // skip '='
+
+        // skip whitespace after '='
+        while (pos < pltext.size() && (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
+                                       ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
+            ++pos;
+        }
+        if (pos >= pltext.size()) {
+            return ::exception::nullopt_t{};
+        }
+
+        // parse quoted attribute value
+        char8_t const quote{::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos)};
+        if (quote != u8'"' && quote != u8'\'') {
+            return ::exception::nullopt_t{};
+        }
+        ++pos; // skip opening quote
+        ::std::size_t const val_start = pos;
+        while (pos < pltext.size() && ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != quote) {
+            ++pos;
+        }
+        if (pos >= pltext.size()) {
+            return ::exception::nullopt_t{};
+        }
+        ::fast_io::u8string_view const attr_val{pltext.data() + val_start, pos - val_start};
+        ++pos; // skip closing quote
+
+        // only "type=checkbox" is allowed
+        if (attr_name != ::fast_io::u8string_view{u8"type"}) {
+            return ::exception::nullopt_t{};
+        }
+        if (attr_val != ::fast_io::u8string_view{u8"checkbox"}) {
+            return ::exception::nullopt_t{};
+        }
+        found_type_checkbox = true;
+    }
+
+    if (!found_type_checkbox || !found_disabled) {
+        return ::exception::nullopt_t{};
+    }
+    if (pos >= pltext.size()) {
+        return ::exception::nullopt_t{};
+    }
+    // skip '>' or '/>'
+    if (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'/' && pos + 1 < pltext.size()) {
+        ++pos;
+    }
+    if (pos >= pltext.size() || ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'>') {
+        return ::exception::nullopt_t{};
+    }
+    return TryParseInputCheckboxTagResult<ndebug>{pos + 1, checked};
+}
+
+/**
  * @brief Match a PL-text line terminator: either `\n` or a `<br` self-closing tag.
  *
  * Returns the byte length of the terminator (1 for `\n`, or the total tag length for `<br>`, `<br/>`, `<br />`, etc.).

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -1169,6 +1169,8 @@ entry:
             }
             case ::pltxt2htm::NodeKind::html_col:
                 [[fallthrough]];
+            case ::pltxt2htm::NodeKind::html_input:
+                [[fallthrough]];
             case ::pltxt2htm::NodeKind::md_image:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::md_link:

--- a/tests/test_html_input_tag.cc
+++ b/tests/test_html_input_tag.cc
@@ -1,0 +1,73 @@
+#include "precompile.hh"
+
+int main() {
+    // ---- unchecked checkbox ----
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<input type=\"checkbox\" disabled>");
+        auto answer = ::fast_io::u8string_view(u8"<input type=\"checkbox\" disabled>");
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<input type=\"checkbox\" disabled>");
+        auto plunity_answer = ::fast_io::u8string_view(u8"<input type=\"checkbox\" disabled>");
+        pltxt2htm_test_assert_equal(plunity, plunity_answer);
+    }
+    // ---- checked checkbox ----
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<input type=\"checkbox\" disabled checked>");
+        auto answer = ::fast_io::u8string_view(u8"<input type=\"checkbox\" disabled checked>");
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<input type=\"checkbox\" disabled checked>");
+        auto plunity_answer = ::fast_io::u8string_view(u8"<input type=\"checkbox\" disabled checked>");
+        pltxt2htm_test_assert_equal(plunity, plunity_answer);
+    }
+    // ---- uppercase INPUT (tag name case-insensitive, attributes case-sensitive) ----
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<INPUT TYPE=\"checkbox\" DISABLED CHECKED>");
+        auto answer = ::fast_io::u8string_view(
+            u8"&lt;INPUT&nbsp;TYPE=&quot;checkbox&quot;&nbsp;DISABLED&nbsp;CHECKED&gt;");
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // ---- self-closing syntax <input ... /> ----
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<input type=\"checkbox\" disabled />");
+        auto answer = ::fast_io::u8string_view(u8"<input type=\"checkbox\" disabled>");
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // ---- attribute order: checked before disabled ----
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<input disabled checked type=\"checkbox\">");
+        auto answer = ::fast_io::u8string_view(u8"<input type=\"checkbox\" disabled checked>");
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // ---- text directly adjacent (no spaces) ----
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"a<input type=\"checkbox\" disabled>b");
+        auto answer = ::fast_io::u8string_view(u8"a<input type=\"checkbox\" disabled>b");
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // ---- <input> without type="checkbox" should be escaped ----
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<input type=\"text\" disabled>");
+        auto answer = ::fast_io::u8string_view(u8"&lt;input&nbsp;type=&quot;text&quot;&nbsp;disabled&gt;");
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // ---- <input> without disabled should be escaped ----
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<input type=\"checkbox\">");
+        auto answer = ::fast_io::u8string_view(u8"&lt;input&nbsp;type=&quot;checkbox&quot;&gt;");
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // ---- <input> with extra unknown attribute should be escaped ----
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<input type=\"checkbox\" disabled unknown=\"x\">");
+        auto answer = ::fast_io::u8string_view(u8"&lt;input&nbsp;type=&quot;checkbox&quot;&nbsp;disabled&nbsp;unknown=&quot;x&quot;&gt;");
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // ---- <input> with event handler should be escaped ----
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<input type=\"checkbox\" disabled onclick=\"alert(1)\">");
+        auto answer = ::fast_io::u8string_view(
+            u8"&lt;input&nbsp;type=&quot;checkbox&quot;&nbsp;disabled&nbsp;onclick=&quot;alert(1)&quot;&gt;");
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    return 0;
+}

--- a/tests/test_xss.cc
+++ b/tests/test_xss.cc
@@ -59,7 +59,6 @@ void assert_no_raw_xss_tags(::fast_io::u8string_view html) noexcept {
     ::pltxt2htm_test::assert_true(!has_unescaped_tag(html, u8"meta"));
     ::pltxt2htm_test::assert_true(!has_unescaped_tag(html, u8"link"));
     ::pltxt2htm_test::assert_true(!has_unescaped_tag(html, u8"form"));
-    ::pltxt2htm_test::assert_true(!has_unescaped_tag(html, u8"input"));
     ::pltxt2htm_test::assert_true(!has_unescaped_tag(html, u8"textarea"));
     ::pltxt2htm_test::assert_true(!has_unescaped_tag(html, u8"marquee"));
     ::pltxt2htm_test::assert_true(!has_unescaped_tag(html, u8"noscript"));
@@ -525,6 +524,48 @@ int main() {
     }
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<style>@import url(http://evil/xss.css);</style>");
+        assert_no_raw_xss_tags(to_view(html));
+    }
+
+    // ============================================================
+    //  22. Raw <input> tag parsing (checkbox only, others escaped)
+    // ============================================================
+    {
+        // unchecked checkbox should be parsed as raw <input>
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<input type=\"checkbox\" disabled>");
+        pltxt2htm_test_assert_equal(html, u8"<input type=\"checkbox\" disabled>");
+        // still no dangerous tags
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(to_view(html), u8"script"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(to_view(html), u8"iframe"));
+        ::pltxt2htm_test::assert_true(!has_unescaped_tag(to_view(html), u8"svg"));
+    }
+    {
+        // checked checkbox
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<input type=\"checkbox\" disabled checked>");
+        pltxt2htm_test_assert_equal(html, u8"<input type=\"checkbox\" disabled checked>");
+    }
+    {
+        // reversed order: checked before disabled is still valid
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<input disabled checked type=\"checkbox\">");
+        pltxt2htm_test_assert_equal(html, u8"<input type=\"checkbox\" disabled checked>");
+    }
+    {
+        // <input type="text"> should be escaped (not a checkbox)
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<input type=\"text\">");
+        pltxt2htm_test_assert_equal(html, u8"&lt;input&nbsp;type=&quot;text&quot;&gt;");
+        assert_no_raw_xss_tags(to_view(html));
+    }
+    {
+        // <input with event handler should be escaped
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<input type=\"checkbox\" onfocus=\"alert(1)\">");
+        pltxt2htm_test_assert_equal(html, u8"&lt;input&nbsp;type=&quot;checkbox&quot;&nbsp;onfocus=&quot;alert(1)&quot;&gt;");
+        assert_no_raw_xss_tags(to_view(html));
+        assert_no_raw_event_handlers(to_view(html));
+    }
+    {
+        // <input> without disabled should be escaped
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<input type=\"checkbox\">");
+        pltxt2htm_test_assert_equal(html, u8"&lt;input&nbsp;type=&quot;checkbox&quot;&gt;");
         assert_no_raw_xss_tags(to_view(html));
     }
 


### PR DESCRIPTION
…input

Add support for parsing `<input type="checkbox" disabled>` and `<input type="checkbox" disabled checked>` as native HTML void elements when they appear in input text, producing the same output as markdown checkbox syntax `- [ ]` / `- [x]`.

- New NodeKind `html_input` and `HtmlInput` class with `checked` state
- `try_parse_input_checkbox_tag()` — strict parsing: requires `type="checkbox"`, `disabled`, optional `checked`; rejects all other attributes (event handlers, unknown attributes, etc.)
- Registers `html_input` across all backends, optimizer, frame context, and closing-tag void element lists
- Plweb backend: emits `<input type="checkbox" disabled [checked]>`
- Plunity backend: emits `<input type="checkbox" disabled [checked]>` (passthrough, not converted to `[ ]`/`[x]`)
- XSS safety: non-conforming `<input>` variants are still escaped