### PR TITLE
feat: support `internal` attribute on `<a>` tags for parser and backends

### DIFF
--- a/include/pltxt2htm/ast/impl/html_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/html_node_decl.hh
@@ -514,9 +514,11 @@ template<::pltxt2htm::Contracts ndebug>
 class HtmlA {
     ::pltxt2htm::Ast<ndebug> subast;
     ::pltxt2htm::Url<ndebug> url;
+    bool internal;
 
 public:
-    constexpr explicit HtmlA(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::Url<ndebug>&& url_) noexcept;
+    constexpr explicit HtmlA(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::Url<ndebug>&& url_,
+                             bool internal_) noexcept;
     constexpr HtmlA(::pltxt2htm::HtmlA<ndebug> const&) noexcept;
     constexpr HtmlA(::pltxt2htm::HtmlA<ndebug>&&) noexcept;
     constexpr ~HtmlA() noexcept;
@@ -535,6 +537,11 @@ public:
     [[nodiscard]]
     constexpr auto get_url(this auto&& self) noexcept -> decltype(auto) {
         return ::std::forward_like<decltype(self)>(self.url);
+    }
+
+    [[nodiscard]]
+    constexpr auto get_internal(this auto&& self) noexcept -> bool {
+        return self.internal;
     }
 };
 

--- a/include/pltxt2htm/ast/impl/html_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/html_node_decl.hh
@@ -540,7 +540,7 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto get_internal(this auto&& self) noexcept -> bool {
+    constexpr auto get_internal(this HtmlA const& self) noexcept -> bool {
         return self.internal;
     }
 };

--- a/include/pltxt2htm/ast/impl/html_node_def.inc
+++ b/include/pltxt2htm/ast/impl/html_node_def.inc
@@ -560,10 +560,11 @@ constexpr auto ::pltxt2htm::HtmlSpan<ndebug>::operator==(this ::pltxt2htm::HtmlS
     -> bool = default;
 
 template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::HtmlA<ndebug>::HtmlA(::pltxt2htm::Ast<ndebug>&& subast_,
-                                            ::pltxt2htm::Url<ndebug>&& url_) noexcept
+constexpr ::pltxt2htm::HtmlA<ndebug>::HtmlA(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::Url<ndebug>&& url_,
+                                            bool internal_) noexcept
     : subast(::std::move(subast_)),
-      url(::std::move(url_)) {
+      url(::std::move(url_)),
+      internal(internal_) {
 }
 
 template<::pltxt2htm::Contracts ndebug>

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -499,7 +499,12 @@ entry:
                 ++current_index;
                 result.append(u8"<a href=\"");
                 ::pltxt2htm::details::append_url_attr_from_ast<ndebug>(result, node.as_html_a().get_url());
-                result.append(u8"\">");
+                if (node.as_html_a().get_internal()) {
+                    result.append(u8"\" internal>");
+                }
+                else {
+                    result.append(u8"\">");
+                }
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_double_emphasis_underscore: {

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -281,7 +281,12 @@ entry:
                 result.append(u8"<a href=\"");
                 result.append(
                     ::pltxt2htm::details::url_ast_to_string<ndebug>(node.as_html_a().get_url().get_url_ast()));
-                result.append(u8"\">");
+                if (node.as_html_a().get_internal()) {
+                    result.append(u8"\" internal>");
+                }
+                else {
+                    result.append(u8"\">");
+                }
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_double_emphasis_underscore: {

--- a/include/pltxt2htm/details/parser/frame_concext.hh
+++ b/include/pltxt2htm/details/parser/frame_concext.hh
@@ -47,6 +47,14 @@ public:
     ::pltxt2htm::Url<ndebug> url;
 };
 
+template<::pltxt2htm::Contracts ndebug>
+class ParserFrameContextWithHtmlATagInfo {
+public:
+    ::fast_io::u8string_view pltext;
+    ::pltxt2htm::Url<ndebug> url;
+    bool internal;
+};
+
 class ParserFrameContextWithPlSizeTagInfo {
 public:
     ::fast_io::u8string_view pltext;
@@ -121,6 +129,7 @@ public:
         ::pltxt2htm::details::ParserFrameContextWithEqualSignTagInfo equal_sign_tag;
         ::pltxt2htm::details::ParserFrameContextWithHtmlSpanInfo html_span_info;
         ::pltxt2htm::details::ParserFrameContextWithUrlInfo<ndebug> url_info;
+        ::pltxt2htm::details::ParserFrameContextWithHtmlATagInfo<ndebug> html_a_tag_info;
         ::pltxt2htm::details::ParserFrameContextWithPlSizeTagInfo pl_size_tag;
         ::pltxt2htm::details::ParserFrameContextWithMdBlockQuotesInfo md_block_quotes;
         ::pltxt2htm::details::ParserFrameContextWithMdListInfo<ndebug> md_list;
@@ -148,6 +157,12 @@ public:
                                      ::pltxt2htm::NodeKind node_kind_) noexcept
         : html_span_info{::std::move(html_span_context)},
           kind{node_kind_} {
+    }
+
+    constexpr FrontendContextVariant(
+        ::pltxt2htm::details::ParserFrameContextWithHtmlATagInfo<ndebug>&& html_a_tag_context) noexcept
+        : html_a_tag_info{::std::move(html_a_tag_context)},
+          kind{::pltxt2htm::NodeKind::html_a} {
     }
 
     constexpr FrontendContextVariant(::pltxt2htm::details::ParserFrameContextWithUrlInfo<ndebug>&& url_context,
@@ -209,9 +224,11 @@ public:
             ::std::construct_at(::std::addressof(this->equal_sign_tag), ::std::move(other.equal_sign_tag));
             return;
         }
+        case ::pltxt2htm::NodeKind::html_a: {
+            ::std::construct_at(::std::addressof(this->html_a_tag_info), ::std::move(other.html_a_tag_info));
+            return;
+        }
         case ::pltxt2htm::NodeKind::pl_external:
-            [[fallthrough]];
-        case ::pltxt2htm::NodeKind::html_a:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_link: {
             ::std::construct_at(::std::addressof(this->url_info), ::std::move(other.url_info));
@@ -487,9 +504,11 @@ public:
             ::std::destroy_at(::std::addressof(this->equal_sign_tag));
             return;
         }
+        case ::pltxt2htm::NodeKind::html_a: {
+            ::std::destroy_at(::std::addressof(this->html_a_tag_info));
+            return;
+        }
         case ::pltxt2htm::NodeKind::pl_external:
-            [[fallthrough]];
-        case ::pltxt2htm::NodeKind::html_a:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_link: {
             ::std::destroy_at(::std::addressof(this->url_info));
@@ -948,7 +967,7 @@ public:
             return context_data_ref.html_span_info.pltext;
         }
         case ::pltxt2htm::NodeKind::html_a: {
-            return context_data_ref.url_info.pltext;
+            return context_data_ref.html_a_tag_info.pltext;
         }
         case ::pltxt2htm::NodeKind::md_block_quotes: {
             auto const& pltext = context_data_ref.md_block_quotes.pltext;
@@ -1096,7 +1115,15 @@ public:
         auto&& context_data_ref = self.context_data;
         bool const is_html_a_type{context_data_ref.kind == ::pltxt2htm::NodeKind::html_a};
         pltxt2htm_assert(is_html_a_type, u8"context kind mismatch");
-        return ::std::forward_like<decltype(self)>(context_data_ref.url_info.url);
+        return ::std::forward_like<decltype(self)>(context_data_ref.html_a_tag_info.url);
+    }
+
+    [[nodiscard]]
+    constexpr auto get_html_a_internal(this auto&& self) noexcept -> bool {
+        auto&& context_data_ref = self.context_data;
+        bool const is_html_a_type{context_data_ref.kind == ::pltxt2htm::NodeKind::html_a};
+        pltxt2htm_assert(is_html_a_type, u8"context kind mismatch");
+        return context_data_ref.html_a_tag_info.internal;
     }
 
     [[nodiscard]]

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -763,14 +763,15 @@ entry:
                     if (auto opt_a_tag = ::pltxt2htm::details::try_parse_html_a_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                         opt_a_tag.has_value()) {
-                        auto&& [tag_len, url] = opt_a_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        auto&& [tag_len, url, internal] =
+                            opt_a_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                         current_index += tag_len + 2;
                         call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                             ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithUrlInfo<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithHtmlATagInfo<ndebug>{
                                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
-                                    ::std::move(url)},
-                                ::pltxt2htm::NodeKind::html_a},
+                                    ::std::move(url),
+                                    internal}}, // ::pltxt2htm::NodeKind::html_a is automatically set in ctor
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
                     }
@@ -1123,8 +1124,7 @@ entry:
                         auto&& [tag_len, checked] =
                             opt_input_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                         current_index += tag_len + 1;
-                        result.push_back(
-                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlInput{checked}));
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlInput{checked}));
                         ++current_index;
                         continue;
                     }
@@ -1517,7 +1517,8 @@ entry:
                                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                             opt_tag_len.has_value()) {
                             ::std::size_t const staged_index{current_index};
-                            ::pltxt2htm::HtmlA staged_node(::std::move(result), ::std::move(frame.get_html_a_url()));
+                            ::pltxt2htm::HtmlA staged_node(::std::move(result), ::std::move(frame.get_html_a_url()),
+                                                           frame.get_html_a_internal());
                             call_stack.pop();
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(
@@ -2465,8 +2466,8 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_a: {
-                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                    ::pltxt2htm::HtmlA<ndebug>{::std::move(subast), ::std::move(frame.get_html_a_url())}));
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlA<ndebug>{
+                    ::std::move(subast), ::std::move(frame.get_html_a_url()), frame.get_html_a_internal()}));
                 parent_index += staged_index;
                 goto entry;
             }

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -2423,12 +2423,13 @@ constexpr auto try_parse_html_a_tag(::fast_io::u8string_view pltext) noexcept
     if (pos < pltext.size() &&
         ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'>') {
         // only the boolean attribute "internal" is accepted as an extra attribute
-        if (!::pltxt2htm::details::is_prefix_match<ndebug, ::pltxt2htm::details::U8LiteralString{u8"internal"}>(
+        constexpr auto internal_literal = ::pltxt2htm::details::U8LiteralString{u8"internal"};
+        if (!::pltxt2htm::details::is_prefix_match<ndebug, internal_literal>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, pos))) {
             return ::exception::nullopt_t{};
         }
         internal = true;
-        pos += 8; // skip "internal"
+        pos += internal_literal.size();
         while (pos < pltext.size() && (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
                                        ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
             ++pos;

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1275,11 +1275,10 @@ constexpr auto try_parse_input_checkbox_tag(::fast_io::u8string_view pltext) noe
         ::fast_io::u8string_view const attr_name{pltext.data() + attr_start, pos - attr_start};
 
         // boolean attribute without value: "disabled" or "checked"
-        if (pos < pltext.size() &&
-            (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
-             ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t' ||
-             ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'>' ||
-             ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'/')) {
+        if (pos < pltext.size() && (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
+                                    ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t' ||
+                                    ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'>' ||
+                                    ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'/')) {
             if (attr_name == ::fast_io::u8string_view{u8"disabled"}) {
                 found_disabled = true;
                 continue;
@@ -2367,6 +2366,7 @@ template<::pltxt2htm::Contracts ndebug>
 struct TryParseHtmlATagResult {
     ::std::size_t tag_len;
     ::pltxt2htm::Url<ndebug> url;
+    bool internal;
 };
 
 template<::pltxt2htm::Contracts ndebug>
@@ -2419,6 +2419,21 @@ constexpr auto try_parse_html_a_tag(::fast_io::u8string_view pltext) noexcept
                                    ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
         ++pos;
     }
+    bool internal{};
+    if (pos < pltext.size() &&
+        ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'>') {
+        // only the boolean attribute "internal" is accepted as an extra attribute
+        if (!::pltxt2htm::details::is_prefix_match<ndebug, ::pltxt2htm::details::U8LiteralString{u8"internal"}>(
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, pos))) {
+            return ::exception::nullopt_t{};
+        }
+        internal = true;
+        pos += 8; // skip "internal"
+        while (pos < pltext.size() && (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
+                                       ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
+            ++pos;
+        }
+    }
     if (pos >= pltext.size() || ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'>') {
         return ::exception::nullopt_t{};
     }
@@ -2433,7 +2448,7 @@ constexpr auto try_parse_html_a_tag(::fast_io::u8string_view pltext) noexcept
         return ::exception::nullopt_t{};
     }
     return TryParseHtmlATagResult<ndebug>{
-        pos + 1, ::std::move(opt_url_result.template value<ndebug == ::pltxt2htm::Contracts::ignore>().url)};
+        pos + 1, ::std::move(opt_url_result.template value<ndebug == ::pltxt2htm::Contracts::ignore>().url), internal};
 }
 
 /**

--- a/tests/test_html_a_tag.cc
+++ b/tests/test_html_a_tag.cc
@@ -95,5 +95,12 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
     }
 
+    // internal attribute
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<a href=\"https://www.example.com\" internal>text</a>");
+        auto answer = ::fast_io::u8string_view{u8"<a href=\"https://www.example.com\" internal>text</a>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
     return 0;
 }

--- a/tests/test_xss.cc
+++ b/tests/test_xss.cc
@@ -558,7 +558,8 @@ int main() {
     {
         // <input with event handler should be escaped
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<input type=\"checkbox\" onfocus=\"alert(1)\">");
-        pltxt2htm_test_assert_equal(html, u8"&lt;input&nbsp;type=&quot;checkbox&quot;&nbsp;onfocus=&quot;alert(1)&quot;&gt;");
+        pltxt2htm_test_assert_equal(html,
+                                    u8"&lt;input&nbsp;type=&quot;checkbox&quot;&nbsp;onfocus=&quot;alert(1)&quot;&gt;");
         assert_no_raw_xss_tags(to_view(html));
         assert_no_raw_event_handlers(to_view(html));
     }


### PR DESCRIPTION
The `plweb_text_backend` emits `<a href="..." internal>` for experiment and discussion links, but the parser rejected `internal` as an unknown attribute. This commit adds full round-trip support.

Parser:
- `try_parse_html_a_tag` now accepts `internal` as the sole optional boolean attribute after `href="..."`; any other attribute (e.g. `style`, `onmouseover`) still causes the tag to be treated as literal text
- `TryParseHtmlATagResult` carries the `internal` flag

AST:
- `HtmlA` gains a `bool internal` member with no default value; every construction site passes it explicitly

Frame context:
- New `ParserFrameContextWithHtmlATagInfo` replaces the shared `ParserFrameContextWithUrlInfo` for `html_a` nodes, keeping the `internal` flag alongside the URL

Backends:
- `for_plweb_text.hh` and `for_plweb_title.hh` emit `internal` when the flag is set

Tests:
- Round-trip test for `<a href="..." internal>` added
- Existing `style` attribute test (which should be rejected) preserved