### PR TITLE
feat: add EntityReference AST node for idempotent entity roundtrip

### DIFF
--- a/cxxmodule/pltxt2htm/pltxt2htm.cppm
+++ b/cxxmodule/pltxt2htm/pltxt2htm.cppm
@@ -50,6 +50,7 @@ using ::pltxt2htm::Tab;
 using ::pltxt2htm::Ampersand;
 using ::pltxt2htm::SingleQuote;
 using ::pltxt2htm::DoubleQuote;
+using ::pltxt2htm::EntityReference;
 
 // html_node
 using ::pltxt2htm::HtmlBr;

--- a/include/pltxt2htm/ast/ast.hh
+++ b/include/pltxt2htm/ast/ast.hh
@@ -41,6 +41,7 @@ class PlTxtNode {
         ::pltxt2htm::Ampersand ampersand_node;
         ::pltxt2htm::SingleQuote single_quote_node;
         ::pltxt2htm::DoubleQuote double_quote_node;
+        ::pltxt2htm::EntityReference entity_reference_node;
         ::pltxt2htm::HtmlHr html_hr_node;
         ::pltxt2htm::HtmlH1<ndebug> html_h1_node;
         ::pltxt2htm::HtmlH2<ndebug> html_h2_node;
@@ -287,6 +288,11 @@ public:
     constexpr PlTxtNode(::pltxt2htm::DoubleQuote node) noexcept
         : double_quote_node{node},
           node_kind{::pltxt2htm::NodeKind::double_quote} {
+    }
+
+    constexpr PlTxtNode(::pltxt2htm::EntityReference node) noexcept
+        : entity_reference_node{::std::move(node)},
+          node_kind{::pltxt2htm::NodeKind::entity_reference} {
     }
 
     constexpr PlTxtNode(::pltxt2htm::HtmlHr node) noexcept
@@ -883,6 +889,10 @@ public:
             new (::std::addressof(ampersand_node))::pltxt2htm::Ampersand(other.ampersand_node);
             break;
         }
+        case ::pltxt2htm::NodeKind::entity_reference: {
+            new (::std::addressof(entity_reference_node))::pltxt2htm::EntityReference(other.entity_reference_node);
+            break;
+        }
         case ::pltxt2htm::NodeKind::single_quote: {
             new (::std::addressof(single_quote_node))::pltxt2htm::SingleQuote(other.single_quote_node);
             break;
@@ -1430,6 +1440,11 @@ public:
 
         case ::pltxt2htm::NodeKind::ampersand: {
             new (::std::addressof(ampersand_node))::pltxt2htm::Ampersand(::std::move(other.ampersand_node));
+            break;
+        }
+
+        case ::pltxt2htm::NodeKind::entity_reference: {
+            new (::std::addressof(entity_reference_node))::pltxt2htm::EntityReference(::std::move(other.entity_reference_node));
             break;
         }
 
@@ -2020,6 +2035,10 @@ public:
             ampersand_node.~Ampersand();
             break;
         }
+        case ::pltxt2htm::NodeKind::entity_reference: {
+            entity_reference_node.~EntityReference();
+            break;
+        }
         case ::pltxt2htm::NodeKind::single_quote: {
             single_quote_node.~SingleQuote();
             break;
@@ -2519,6 +2538,9 @@ public:
         case ::pltxt2htm::NodeKind::ampersand: {
             return self.ampersand_node == other.ampersand_node;
         }
+        case ::pltxt2htm::NodeKind::entity_reference: {
+            return self.entity_reference_node == other.entity_reference_node;
+        }
         case ::pltxt2htm::NodeKind::single_quote: {
             return self.single_quote_node == other.single_quote_node;
         }
@@ -2904,6 +2926,13 @@ public:
         bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::ampersand};
         pltxt2htm_assert(is_type, u8"node kind mismatch");
         return ::std::forward_like<decltype(self)>(self.ampersand_node);
+    }
+
+    [[nodiscard]]
+    constexpr auto as_entity_reference(this auto&& self) noexcept -> decltype(auto) {
+        bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::entity_reference};
+        pltxt2htm_assert(is_type, u8"node kind mismatch");
+        return ::std::forward_like<decltype(self)>(self.entity_reference_node);
     }
 
     [[nodiscard]]

--- a/include/pltxt2htm/ast/impl/basic_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/basic_node_decl.hh
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <utility>
+#include <fast_io/fast_io_dsal/string.h>
 #include "ast_decl.hh"
 
 namespace pltxt2htm {
@@ -81,6 +82,36 @@ public:
 class DoubleQuote {
 public:
     constexpr auto operator==(this DoubleQuote const&, DoubleQuote const&) noexcept -> bool = default;
+};
+
+/**
+ * @brief ::pltxt2htm::EntityReference node
+ * @details Represents an HTML entity reference like &amp;quot;, &amp;amp;, &amp;#38;.
+ *          Stores the entity content between &amp; and ; (e.g. &amp;quot; stores "quot").
+ *          The backend outputs it as &amp; + value + ; verbatim.
+ */
+class EntityReference {
+    ::fast_io::u8string value;
+
+public:
+    constexpr EntityReference(::fast_io::u8string&& value_) noexcept
+        : value(::std::move(value_)) {
+    }
+
+    constexpr EntityReference(::pltxt2htm::EntityReference const&) noexcept = default;
+    constexpr EntityReference(::pltxt2htm::EntityReference&&) noexcept = default;
+    constexpr ~EntityReference() noexcept = default;
+    constexpr auto operator=(::pltxt2htm::EntityReference const&) noexcept -> ::pltxt2htm::EntityReference& = delete;
+    constexpr auto operator=(this ::pltxt2htm::EntityReference& self, ::pltxt2htm::EntityReference&&) noexcept
+        -> ::pltxt2htm::EntityReference& = default;
+
+    [[nodiscard]]
+    constexpr auto operator==(this EntityReference const&, EntityReference const&) noexcept -> bool = default;
+
+    [[nodiscard]]
+    constexpr auto get_value(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.value);
+    }
 };
 
 /**

--- a/include/pltxt2htm/ast/node_kind.hh
+++ b/include/pltxt2htm/ast/node_kind.hh
@@ -33,6 +33,7 @@ enum class NodeKind : unsigned {
     single_quote, ///< Single quote character (') - escaped to &apos;
     less_than, ///< Less-than character (<) - escaped to &lt;
     greater_than, ///< Greater-than character (>) - escaped to &gt;
+    entity_reference, ///< HTML entity reference: &amp; name &amp;; e.g. &amp;quot;, &amp;amp;, &amp;#38;
     tab, ///< Tab character - rendered as multiple &nbsp; entities
 
     // Physics-Lab specific formatting tags

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -47,6 +47,12 @@ constexpr auto convert_simple_pltxt_ast_to_plunity_richtext(::pltxt2htm::Ast<nde
             result.push_back(u8'&');
             continue;
         }
+        case ::pltxt2htm::NodeKind::entity_reference: {
+            result.push_back(u8'&');
+            result.append(node.as_entity_reference().get_value());
+            result.push_back(u8';');
+            continue;
+        }
         case ::pltxt2htm::NodeKind::md_escape_single_quote:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::single_quote: {
@@ -233,6 +239,12 @@ entry:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::ampersand: {
                 result.push_back(u8'&');
+                continue;
+            }
+            case ::pltxt2htm::NodeKind::entity_reference: {
+                result.push_back(u8'&');
+                result.append(node.as_entity_reference().get_value());
+                result.push_back(u8';');
                 continue;
             }
             case ::pltxt2htm::NodeKind::md_escape_single_quote:

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -46,6 +46,12 @@ constexpr auto convert_simple_pltxt_ast_to_plweb_text(::pltxt2htm::Ast<ndebug> c
             result.append(u8"&amp;");
             continue;
         }
+        case ::pltxt2htm::NodeKind::entity_reference: {
+            result.push_back(u8'&');
+            result.append(node.as_entity_reference().get_value());
+            result.push_back(u8';');
+            continue;
+        }
         case ::pltxt2htm::NodeKind::md_escape_single_quote:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::single_quote: {
@@ -303,6 +309,12 @@ entry:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::ampersand: {
                 result.append(u8"&amp;");
+                continue;
+            }
+            case ::pltxt2htm::NodeKind::entity_reference: {
+                result.push_back(u8'&');
+                result.append(node.as_entity_reference().get_value());
+                result.push_back(u8';');
                 continue;
             }
             case ::pltxt2htm::NodeKind::md_escape_single_quote:

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -127,6 +127,11 @@ constexpr auto url_ast_to_string(::pltxt2htm::Ast<ndebug> const& ast) noexcept -
         case ::pltxt2htm::NodeKind::ampersand:
             result.push_back(u8'&');
             continue;
+        case ::pltxt2htm::NodeKind::entity_reference:
+            result.push_back(u8'&');
+            result.append(node.as_entity_reference().get_value());
+            result.push_back(u8';');
+            continue;
         case ::pltxt2htm::NodeKind::single_quote:
             result.push_back(u8'\'');
             continue;
@@ -189,6 +194,12 @@ entry:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::ampersand: {
                 result.append(u8"&amp;");
+                continue;
+            }
+            case ::pltxt2htm::NodeKind::entity_reference: {
+                result.push_back(u8'&');
+                result.append(node.as_entity_reference().get_value());
+                result.push_back(u8';');
                 continue;
             }
             case ::pltxt2htm::NodeKind::md_escape_single_quote:

--- a/include/pltxt2htm/details/parser/frame_concext.hh
+++ b/include/pltxt2htm/details/parser/frame_concext.hh
@@ -482,6 +482,8 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_tr:
             [[fallthrough]];
+        case ::pltxt2htm::NodeKind::entity_reference:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_hr:
             [[unlikely]] {
                 pltxt2htm_unreachable(u8"Unexpected node kind in FrontendContextVariant move");
@@ -763,6 +765,8 @@ public:
         case ::pltxt2htm::NodeKind::md_tbody:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_tr:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::entity_reference:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_hr:
             [[unlikely]] {
@@ -1060,6 +1064,8 @@ public:
         case ::pltxt2htm::NodeKind::md_escape_right_brace:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_escape_tilde:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::entity_reference:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_table:
             [[fallthrough]];

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -483,6 +483,17 @@ entry:
                 continue;
             }
             if (chr == u8'&') {
+                if (auto const opt_entity_len = ::pltxt2htm::details::try_parse_entity_reference<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                    opt_entity_len.has_value()) {
+                    auto const entity_len = opt_entity_len.value();
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                        ::pltxt2htm::EntityReference{::fast_io::u8string{
+                            pltext.data() + current_index + 1,
+                            pltext.data() + current_index + entity_len - 1}}));
+                    current_index += entity_len;
+                    continue;
+                }
                 result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Ampersand{}));
                 ++current_index;
                 continue;
@@ -2272,6 +2283,8 @@ entry:
                         [[fallthrough]];
                     case ::pltxt2htm::NodeKind::ampersand:
                         [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::entity_reference:
+                        [[fallthrough]];
                     case ::pltxt2htm::NodeKind::double_quote:
                         [[fallthrough]];
                     case ::pltxt2htm::NodeKind::single_quote:
@@ -2794,6 +2807,8 @@ entry:
             case ::pltxt2htm::NodeKind::space:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::ampersand:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::entity_reference:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::double_quote:
                 [[fallthrough]];

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1702,6 +1702,64 @@ struct SimplyParsePLtextResult {
     ::pltxt2htm::Ast<ndebug> ast; ///< Parsed AST.
 };
 
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_entity_reference(::fast_io::u8string_view text) noexcept
+    -> ::exception::optional<::std::size_t> {
+    if (text.empty() || ::pltxt2htm::details::u8string_view_index<ndebug>(text, 0) != u8'&') {
+        return ::exception::nullopt_t{};
+    }
+    auto const max = text.size();
+    auto index = ::std::size_t{1};
+    if (index >= max) {
+        return ::exception::nullopt_t{};
+    }
+    if (::pltxt2htm::details::u8string_view_index<ndebug>(text, index) == u8'#') {
+        ++index;
+        if (index >= max) {
+            return ::exception::nullopt_t{};
+        }
+        bool hex{};
+        auto const prefix = ::pltxt2htm::details::u8string_view_index<ndebug>(text, index);
+        if (prefix == u8'x' || prefix == u8'X') {
+            hex = true;
+            ++index;
+        }
+        if (index >= max) {
+            return ::exception::nullopt_t{};
+        }
+        auto const begin = index;
+        for (; index < max; ++index) {
+            auto const chr = ::pltxt2htm::details::u8string_view_index<ndebug>(text, index);
+            if (chr == u8';') {
+                break;
+            }
+            if (hex ? !::pltxt2htm::details::is_ascii_hexdigit(chr) : !::pltxt2htm::details::is_ascii_digit(chr)) {
+                return ::exception::nullopt_t{};
+            }
+        }
+        if (index == begin || index >= max || ::pltxt2htm::details::u8string_view_index<ndebug>(text, index) != u8';') {
+            return ::exception::nullopt_t{};
+        }
+        return index + 1;
+    }
+
+    if (!::pltxt2htm::details::is_ascii_alpha(::pltxt2htm::details::u8string_view_index<ndebug>(text, index))) {
+        return ::exception::nullopt_t{};
+    }
+    ++index;
+    for (; index < max; ++index) {
+        auto const chr = ::pltxt2htm::details::u8string_view_index<ndebug>(text, index);
+        if (chr == u8';') {
+            return index + 1;
+        }
+        if (!::pltxt2htm::details::is_ascii_alpha(chr) && !::pltxt2htm::details::is_ascii_digit(chr)) {
+            return ::exception::nullopt_t{};
+        }
+    }
+    return ::exception::nullopt_t{};
+}
+
 /**
  * @brief Parse plain text content into an AST until a termination string is encountered.
  *
@@ -1747,6 +1805,17 @@ constexpr auto simply_parse_pltext(::fast_io::u8string_view pltext) noexcept
             continue;
         }
         if (chr == u8'&') {
+            if (auto const opt_entity_len = ::pltxt2htm::details::try_parse_entity_reference<ndebug>(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                opt_entity_len.has_value()) {
+                auto const entity_len = opt_entity_len.value();
+                ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::EntityReference{::fast_io::u8string{
+                        pltext.data() + current_index + 1,
+                        pltext.data() + current_index + entity_len - 1}}));
+                current_index += entity_len;
+                continue;
+            }
             ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Ampersand{}));
             ++current_index;
             continue;
@@ -2948,64 +3017,6 @@ constexpr auto try_parse_md_image(::fast_io::u8string_view pltext) noexcept
     return ::pltxt2htm::details::TryParseMdImageResult<ndebug>{.advance_count = current_index + 1,
                                                                .link_text = ::std::move(link_text_ast),
                                                                .link_url = ::std::move(md_url_result.url)};
-}
-
-template<::pltxt2htm::Contracts ndebug>
-[[nodiscard]]
-constexpr auto try_parse_entity_reference(::fast_io::u8string_view text) noexcept
-    -> ::exception::optional<::std::size_t> {
-    if (text.empty() || ::pltxt2htm::details::u8string_view_index<ndebug>(text, 0) != u8'&') {
-        return ::exception::nullopt_t{};
-    }
-    auto const max = text.size();
-    auto index = ::std::size_t{1};
-    if (index >= max) {
-        return ::exception::nullopt_t{};
-    }
-    if (::pltxt2htm::details::u8string_view_index<ndebug>(text, index) == u8'#') {
-        ++index;
-        if (index >= max) {
-            return ::exception::nullopt_t{};
-        }
-        bool hex{};
-        auto const prefix = ::pltxt2htm::details::u8string_view_index<ndebug>(text, index);
-        if (prefix == u8'x' || prefix == u8'X') {
-            hex = true;
-            ++index;
-        }
-        if (index >= max) {
-            return ::exception::nullopt_t{};
-        }
-        auto const begin = index;
-        for (; index < max; ++index) {
-            auto const chr = ::pltxt2htm::details::u8string_view_index<ndebug>(text, index);
-            if (chr == u8';') {
-                break;
-            }
-            if (hex ? !::pltxt2htm::details::is_ascii_hexdigit(chr) : !::pltxt2htm::details::is_ascii_digit(chr)) {
-                return ::exception::nullopt_t{};
-            }
-        }
-        if (index == begin || index >= max || ::pltxt2htm::details::u8string_view_index<ndebug>(text, index) != u8';') {
-            return ::exception::nullopt_t{};
-        }
-        return index + 1;
-    }
-
-    if (!::pltxt2htm::details::is_ascii_alpha(::pltxt2htm::details::u8string_view_index<ndebug>(text, index))) {
-        return ::exception::nullopt_t{};
-    }
-    ++index;
-    for (; index < max; ++index) {
-        auto const chr = ::pltxt2htm::details::u8string_view_index<ndebug>(text, index);
-        if (chr == u8';') {
-            return index + 1;
-        }
-        if (!::pltxt2htm::details::is_ascii_alpha(chr) && !::pltxt2htm::details::is_ascii_digit(chr)) {
-            return ::exception::nullopt_t{};
-        }
-    }
-    return ::exception::nullopt_t{};
 }
 
 } // namespace pltxt2htm::details

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -294,6 +294,8 @@ entry:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::ampersand:
                 [[fallthrough]];
+            case ::pltxt2htm::NodeKind::entity_reference:
+                [[fallthrough]];
             case ::pltxt2htm::NodeKind::md_escape_single_quote:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::single_quote:

--- a/tests/test_entity_reference.cc
+++ b/tests/test_entity_reference.cc
@@ -83,5 +83,77 @@ int main() {
             false);
     }
 
+    // Full roundtrip tests via pltxt4unittest
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"&quot;");
+        pltxt2htm_test_assert_equal(html, u8"&quot;");
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"&amp;");
+        pltxt2htm_test_assert_equal(html, u8"&amp;");
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"&lt;");
+        pltxt2htm_test_assert_equal(html, u8"&lt;");
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"&gt;");
+        pltxt2htm_test_assert_equal(html, u8"&gt;");
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"&apos;");
+        pltxt2htm_test_assert_equal(html, u8"&apos;");
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"&#38;");
+        pltxt2htm_test_assert_equal(html, u8"&#38;");
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"&#x26;");
+        pltxt2htm_test_assert_equal(html, u8"&#x26;");
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"&#X2A;");
+        pltxt2htm_test_assert_equal(html, u8"&#X2A;");
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"&QUOT;");
+        pltxt2htm_test_assert_equal(html, u8"&QUOT;");
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"a&quot;b");
+        pltxt2htm_test_assert_equal(html, u8"a&quot;b");
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"&quot;&amp;&lt;");
+        pltxt2htm_test_assert_equal(html, u8"&quot;&amp;&lt;");
+    }
+    // Invalid entity &; falls back to bare ampersand
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"&;");
+        pltxt2htm_test_assert_equal(html, u8"&amp;;");
+    }
+    // Bare & without entity
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"&");
+        pltxt2htm_test_assert_equal(html, u8"&amp;");
+    }
+    // Roundtrip: bare " produces &quot;, which parses back to entity reference
+    {
+        auto const first_pass = ::pltxt2htm_test::pltxt4unittest(u8"\"");
+        pltxt2htm_test_assert_equal(first_pass, u8"&quot;");
+        auto const first_pass_view = ::fast_io::u8string_view{first_pass.data(), first_pass.size()};
+        auto const second_pass = ::pltxt2htm_test::pltxt4unittest(first_pass_view);
+        pltxt2htm_test_assert_equal(second_pass, u8"&quot;");
+    }
+    // Roundtrip: bare < produces &lt; which parses back to entity reference
+    {
+        auto const first_pass = ::pltxt2htm_test::pltxt4unittest(u8"<");
+        pltxt2htm_test_assert_equal(first_pass, u8"&lt;");
+        auto const first_pass_view = ::fast_io::u8string_view{first_pass.data(), first_pass.size()};
+        auto const second_pass = ::pltxt2htm_test::pltxt4unittest(first_pass_view);
+        pltxt2htm_test_assert_equal(second_pass, u8"&lt;");
+    }
+
     return 0;
 }


### PR DESCRIPTION
Introduce a non-template `EntityReference` AST node that stores the entity content (part between `&` and `;`) verbatim. The backend outputs it as `&` + value + `;`, so `"` in HTML output is recognized when fed back as input, preventing double-escaping to `&quot;`.

- `node_kind.hh`: add `entity_reference` enum value
- `basic_node_decl.hh`: add `EntityReference` class
- `ast.hh`: wire union member, ctor/copy/move/dtor/==/accessor
- `try_parse.hh`: move `try_parse_entity_reference` before `simply_parse_pltext`; parse `&` as `EntityReference` when valid
- `parser.hh`: same entity handling in inline text parsing
- `frame_concext.hh`: add `entity_reference` to all -Werror=switch fallthrough chains (move ctor, dtor, get_pltext, context-kind)
- `for_plweb_text.hh`, `for_plweb_title.hh`, `for_plunity_text.hh`: render `EntityReference` as `&` + value + `;`
- `optimizer.hh`: passthrough for entity_reference
- `test_entity_reference.cc`: add pltxt4unittest roundtrip tests for named, numeric, hex entities and double-pass idempotency