### PR TITLE
feat(code): strict <code class="language-..."> with XSS protection

### DIFF
--- a/include/pltxt2htm/ast/impl/html_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/html_node_decl.hh
@@ -456,9 +456,11 @@ public:
 template<::pltxt2htm::Contracts ndebug>
 class HtmlCode {
     ::pltxt2htm::Ast<ndebug> subast;
+    ::exception::optional<::fast_io::u8string> language;
 
 public:
-    constexpr explicit HtmlCode(::pltxt2htm::Ast<ndebug>&& subast_) noexcept;
+    constexpr explicit HtmlCode(::pltxt2htm::Ast<ndebug>&& subast_,
+                                ::exception::optional<::fast_io::u8string>&& language_) noexcept;
     constexpr HtmlCode(::pltxt2htm::HtmlCode<ndebug> const&) noexcept;
     constexpr HtmlCode(::pltxt2htm::HtmlCode<ndebug>&&) noexcept;
     constexpr ~HtmlCode() noexcept;
@@ -472,6 +474,11 @@ public:
     [[nodiscard]]
     constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
         return ::std::forward_like<decltype(self)>(self.subast);
+    }
+
+    [[nodiscard]]
+    constexpr auto get_language(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.language);
     }
 };
 

--- a/include/pltxt2htm/ast/impl/html_node_def.inc
+++ b/include/pltxt2htm/ast/impl/html_node_def.inc
@@ -286,7 +286,7 @@ constexpr auto ::pltxt2htm::HtmlLi<ndebug>::operator==(this ::pltxt2htm::HtmlLi<
 
 template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::HtmlCode<ndebug>::HtmlCode(::pltxt2htm::Ast<ndebug>&& subast_,
-                                                   ::exception::optional<::fast_io::u8string>&& language_) noexcept
+                                                  ::exception::optional<::fast_io::u8string>&& language_) noexcept
     : subast(::std::move(subast_)),
       language(::std::move(language_)) {
 }

--- a/include/pltxt2htm/ast/impl/html_node_def.inc
+++ b/include/pltxt2htm/ast/impl/html_node_def.inc
@@ -285,8 +285,10 @@ constexpr auto ::pltxt2htm::HtmlLi<ndebug>::operator==(this ::pltxt2htm::HtmlLi<
                                                        ::pltxt2htm::HtmlLi<ndebug> const&) noexcept -> bool = default;
 
 template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::HtmlCode<ndebug>::HtmlCode(::pltxt2htm::Ast<ndebug>&& subast_) noexcept
-    : subast(::std::move(subast_)) {
+constexpr ::pltxt2htm::HtmlCode<ndebug>::HtmlCode(::pltxt2htm::Ast<ndebug>&& subast_,
+                                                   ::exception::optional<::fast_io::u8string>&& language_) noexcept
+    : subast(::std::move(subast_)),
+      language(::std::move(language_)) {
 }
 
 template<::pltxt2htm::Contracts ndebug>

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -733,13 +733,11 @@ entry:
                                                                                    ::pltxt2htm::NodeKind::html_code, 0));
                 ++current_index;
                 result.append(u8"<code");
-                {
-                    auto const& language = node.as_html_code().get_language();
-                    if (language.has_value()) {
-                        result.append(u8" class=\"");
-                        result.append(language.template value<ndebug == ::pltxt2htm::Contracts::ignore>());
-                        result.append(u8"\"");
-                    }
+                auto const& language = node.as_html_code().get_language();
+                if (language.has_value()) {
+                    result.append(u8" class=\"");
+                    result.append(language.template value<ndebug == ::pltxt2htm::Contracts::ignore>());
+                    result.append(u8"\"");
                 }
                 result.push_back(u8'>');
                 goto entry;

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -741,14 +741,14 @@ entry:
                         result.append(u8"\"");
                     }
                 }
-                result.append(u8">");
+                result.push_back(u8'>');
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_latex_inline: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
                     node.as_md_latex_inline().get_subast(), ::pltxt2htm::NodeKind::md_latex_inline, 0));
                 ++current_index;
-                result.append(u8"$");
+                result.push_back(u8'$');
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_latex_block: {
@@ -1276,7 +1276,7 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_latex_inline: {
-                result.append(u8"$");
+                result.push_back(u8'$');
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_latex_block: {

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -730,7 +730,7 @@ entry:
             case ::pltxt2htm::NodeKind::html_code: {
                 // Note: Despite `<code></code>` is empty, we still need to handle it
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_code().get_subast(),
-                                                                                   ::pltxt2htm::NodeKind::html_code, 0));
+                                                                                  ::pltxt2htm::NodeKind::html_code, 0));
                 ++current_index;
                 result.append(u8"<code");
                 auto const& language = node.as_html_code().get_language();

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -737,7 +737,7 @@ entry:
                 if (language.has_value()) {
                     result.append(u8" class=\"");
                     result.append(language.template value<ndebug == ::pltxt2htm::Contracts::ignore>());
-                    result.append(u8"\"");
+                    result.push_back(u8'\"');
                 }
                 result.push_back(u8'>');
                 goto entry;

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -730,9 +730,18 @@ entry:
             case ::pltxt2htm::NodeKind::html_code: {
                 // Note: Despite `<code></code>` is empty, we still need to handle it
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_code().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::html_code, 0));
+                                                                                   ::pltxt2htm::NodeKind::html_code, 0));
                 ++current_index;
-                result.append(u8"<code>");
+                result.append(u8"<code");
+                {
+                    auto const& language = node.as_html_code().get_language();
+                    if (language.has_value()) {
+                        result.append(u8" class=\"");
+                        result.append(language.template value<ndebug == ::pltxt2htm::Contracts::ignore>());
+                        result.append(u8"\"");
+                    }
+                }
+                result.append(u8">");
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_latex_inline: {

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -822,7 +822,7 @@ entry:
                         result.append(u8"\"");
                     }
                 }
-                result.append(u8">");
+                result.push_back(u8'>');
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_latex_inline: {
@@ -833,7 +833,7 @@ entry:
                     ++current_index;
                     call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
                         node.as_md_latex_inline().get_subast(), ::pltxt2htm::NodeKind::md_latex_inline, 0));
-                    result.append(u8"$");
+                    result.push_back(u8'$');
                     goto entry;
                 }
             }
@@ -1383,7 +1383,7 @@ entry:
             case ::pltxt2htm::NodeKind::md_latex_inline: {
                 pltxt2htm_assert(mode != PlWebTextBackendMode::no_latex,
                                  u8"Unexpected md_latex_inline node in no_latex mode");
-                result.append(u8"$");
+                result.push_back(u8'$');
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_latex_block: {

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -811,7 +811,7 @@ entry:
             }
             case ::pltxt2htm::NodeKind::html_code: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_code().get_subast(),
-                                                                                   ::pltxt2htm::NodeKind::html_code, 0));
+                                                                                  ::pltxt2htm::NodeKind::html_code, 0));
                 ++current_index;
                 result.append(u8"<code");
                 auto const& language = node.as_html_code().get_language();

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -811,9 +811,18 @@ entry:
             }
             case ::pltxt2htm::NodeKind::html_code: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_code().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::html_code, 0));
+                                                                                   ::pltxt2htm::NodeKind::html_code, 0));
                 ++current_index;
-                result.append(u8"<code>");
+                result.append(u8"<code");
+                {
+                    auto const& language = node.as_html_code().get_language();
+                    if (language.has_value()) {
+                        result.append(u8" class=\"");
+                        result.append(language.template value<ndebug == ::pltxt2htm::Contracts::ignore>());
+                        result.append(u8"\"");
+                    }
+                }
+                result.append(u8">");
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_latex_inline: {

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -818,7 +818,7 @@ entry:
                 if (language.has_value()) {
                     result.append(u8" class=\"");
                     result.append(language.template value<ndebug == ::pltxt2htm::Contracts::ignore>());
-                    result.append(u8"\"");
+                    result.push_back(u8'\"');
                 }
                 result.push_back(u8'>');
                 goto entry;

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -814,13 +814,11 @@ entry:
                                                                                    ::pltxt2htm::NodeKind::html_code, 0));
                 ++current_index;
                 result.append(u8"<code");
-                {
-                    auto const& language = node.as_html_code().get_language();
-                    if (language.has_value()) {
-                        result.append(u8" class=\"");
-                        result.append(language.template value<ndebug == ::pltxt2htm::Contracts::ignore>());
-                        result.append(u8"\"");
-                    }
+                auto const& language = node.as_html_code().get_language();
+                if (language.has_value()) {
+                    result.append(u8" class=\"");
+                    result.append(language.template value<ndebug == ::pltxt2htm::Contracts::ignore>());
+                    result.append(u8"\"");
                 }
                 result.push_back(u8'>');
                 goto entry;

--- a/include/pltxt2htm/details/parser/frame_concext.hh
+++ b/include/pltxt2htm/details/parser/frame_concext.hh
@@ -203,6 +203,7 @@ public:
         : html_span_info{::std::move(html_span_context)},
           kind{node_kind_} {
     }
+
     constexpr FrontendContextVariant(::pltxt2htm::details::ParserFrameContextWithHtmlCodeInfo&& html_code_context,
                                      ::pltxt2htm::NodeKind node_kind_) noexcept
         : html_code_info{::std::move(html_code_context)},
@@ -1034,7 +1035,8 @@ public:
         }
         case ::pltxt2htm::NodeKind::html_span: {
             return context_data_ref.html_span_info.pltext;
-        }        case ::pltxt2htm::NodeKind::html_code: {
+        }
+        case ::pltxt2htm::NodeKind::html_code: {
             return context_data_ref.html_code_info.pltext;
         }
         case ::pltxt2htm::NodeKind::html_a: {
@@ -1183,7 +1185,6 @@ public:
         return ::std::forward_like<decltype(self)>(context_data_ref.html_span_info.font_size);
     }
 
-
     [[nodiscard]]
     constexpr auto get_html_code_language(this auto&& self) noexcept -> decltype(auto) {
         auto&& context_data_ref = self.context_data;
@@ -1191,7 +1192,6 @@ public:
         pltxt2htm_assert(is_html_code_type, u8"context kind mismatch");
         return ::std::forward_like<decltype(self)>(context_data_ref.html_code_info.language);
     }
-
 
     [[nodiscard]]
     constexpr auto get_html_a_url(this auto&& self) noexcept -> decltype(auto) {

--- a/include/pltxt2htm/details/parser/frame_concext.hh
+++ b/include/pltxt2htm/details/parser/frame_concext.hh
@@ -50,6 +50,15 @@ public:
 };
 
 /**
+ * @brief Context for HTML <code> tag frames during parsing; stores class attribute.
+ */
+class ParserFrameContextWithHtmlCodeInfo {
+public:
+    ::fast_io::u8string_view pltext;
+    ::exception::optional<::fast_io::u8string> language;
+};
+
+/**
  * @brief Context for URL frames during parsing; stores the raw text and parsed URL.
  */
 template<::pltxt2htm::Contracts ndebug>
@@ -163,6 +172,7 @@ public:
         ::pltxt2htm::details::ParserFrameContextWithPltextInfo pltext;
         ::pltxt2htm::details::ParserFrameContextWithEqualSignTagInfo equal_sign_tag;
         ::pltxt2htm::details::ParserFrameContextWithHtmlSpanInfo html_span_info;
+        ::pltxt2htm::details::ParserFrameContextWithHtmlCodeInfo html_code_info;
         ::pltxt2htm::details::ParserFrameContextWithUrlInfo<ndebug> url_info;
         ::pltxt2htm::details::ParserFrameContextWithHtmlATagInfo<ndebug> html_a_tag_info;
         ::pltxt2htm::details::ParserFrameContextWithPlSizeTagInfo pl_size_tag;
@@ -191,6 +201,11 @@ public:
     constexpr FrontendContextVariant(::pltxt2htm::details::ParserFrameContextWithHtmlSpanInfo&& html_span_context,
                                      ::pltxt2htm::NodeKind node_kind_) noexcept
         : html_span_info{::std::move(html_span_context)},
+          kind{node_kind_} {
+    }
+    constexpr FrontendContextVariant(::pltxt2htm::details::ParserFrameContextWithHtmlCodeInfo&& html_code_context,
+                                     ::pltxt2htm::NodeKind node_kind_) noexcept
+        : html_code_info{::std::move(html_code_context)},
           kind{node_kind_} {
     }
 
@@ -277,6 +292,10 @@ public:
             ::std::construct_at(::std::addressof(this->html_span_info), ::std::move(other.html_span_info));
             return;
         }
+        case ::pltxt2htm::NodeKind::html_code: {
+            ::std::construct_at(::std::addressof(this->html_code_info), ::std::move(other.html_code_info));
+            return;
+        }
         case ::pltxt2htm::NodeKind::md_block_quotes: {
             ::std::construct_at(::std::addressof(this->md_block_quotes), ::std::move(other.md_block_quotes));
             return;
@@ -324,8 +343,6 @@ public:
         case ::pltxt2htm::NodeKind::html_ol:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_li:
-            [[fallthrough]];
-        case ::pltxt2htm::NodeKind::html_code:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_pre:
             [[fallthrough]];
@@ -561,6 +578,10 @@ public:
             ::std::destroy_at(::std::addressof(this->html_span_info));
             return;
         }
+        case ::pltxt2htm::NodeKind::html_code: {
+            ::std::destroy_at(::std::addressof(this->html_code_info));
+            return;
+        }
         case ::pltxt2htm::NodeKind::md_block_quotes: {
             ::std::destroy_at(::std::addressof(this->md_block_quotes));
             return;
@@ -604,8 +625,6 @@ public:
         case ::pltxt2htm::NodeKind::html_ol:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_li:
-            [[fallthrough]];
-        case ::pltxt2htm::NodeKind::html_code:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_pre:
             [[fallthrough]];
@@ -922,8 +941,6 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_li:
             [[fallthrough]];
-        case ::pltxt2htm::NodeKind::html_code:
-            [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_pre:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_blockquote:
@@ -1017,6 +1034,8 @@ public:
         }
         case ::pltxt2htm::NodeKind::html_span: {
             return context_data_ref.html_span_info.pltext;
+        }        case ::pltxt2htm::NodeKind::html_code: {
+            return context_data_ref.html_code_info.pltext;
         }
         case ::pltxt2htm::NodeKind::html_a: {
             return context_data_ref.html_a_tag_info.pltext;
@@ -1163,6 +1182,16 @@ public:
         pltxt2htm_assert(is_html_span_type, u8"context kind mismatch");
         return ::std::forward_like<decltype(self)>(context_data_ref.html_span_info.font_size);
     }
+
+
+    [[nodiscard]]
+    constexpr auto get_html_code_language(this auto&& self) noexcept -> decltype(auto) {
+        auto&& context_data_ref = self.context_data;
+        bool const is_html_code_type{context_data_ref.kind == ::pltxt2htm::NodeKind::html_code};
+        pltxt2htm_assert(is_html_code_type, u8"context kind mismatch");
+        return ::std::forward_like<decltype(self)>(context_data_ref.html_code_info.language);
+    }
+
 
     [[nodiscard]]
     constexpr auto get_html_a_url(this auto&& self) noexcept -> decltype(auto) {

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -881,7 +881,8 @@ entry:
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                         opt_code_tag.has_value()) {
                         // parsing html <code> tag (bare or with class="language-...")
-                        auto&& [tag_len, lang] = opt_code_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        auto&& [tag_len, lang] =
+                            opt_code_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                         current_index += tag_len + 2;
                         call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                             ::pltxt2htm::details::FrontendContextVariant<ndebug>{
@@ -1988,9 +1989,8 @@ entry:
                             // parsing end tag </code> successed
                             ::std::size_t const staged_index{current_index};
                             auto& code_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                            ::pltxt2htm::HtmlCode staged_node(
-                                ::std::move(result),
-                                ::std::move(code_frame.get_html_code_language()));
+                            ::pltxt2htm::HtmlCode staged_node(::std::move(result),
+                                                              ::std::move(code_frame.get_html_code_language()));
                             call_stack.pop();
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
@@ -2609,8 +2609,7 @@ entry:
             }
             case ::pltxt2htm::NodeKind::html_code: {
                 parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                    ::pltxt2htm::HtmlCode<ndebug>{::std::move(subast),
-                                                  ::std::move(frame.get_html_code_language())}));
+                    ::pltxt2htm::HtmlCode<ndebug>{::std::move(subast), ::std::move(frame.get_html_code_language())}));
                 parent_index += staged_index;
                 goto entry;
             }

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -877,15 +877,17 @@ entry:
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
                     }
-                    if (auto opt_code_tag = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"ode">(
+                    if (auto opt_code_tag = ::pltxt2htm::details::try_parse_code_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                         opt_code_tag.has_value()) {
-                        // parsing html <code> tag
-                        current_index += opt_code_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        // parsing html <code> tag (bare or with class="language-...")
+                        auto&& [tag_len, lang] = opt_code_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 2;
                         call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                             ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::details::ParserFrameContextWithHtmlCodeInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                                    ::std::move(lang)},
                                 ::pltxt2htm::NodeKind::html_code},
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
@@ -1985,7 +1987,10 @@ entry:
                             opt_tag_len.has_value()) {
                             // parsing end tag </code> successed
                             ::std::size_t const staged_index{current_index};
-                            ::pltxt2htm::HtmlCode staged_node(::std::move(result));
+                            auto& code_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            ::pltxt2htm::HtmlCode staged_node(
+                                ::std::move(result),
+                                ::std::move(code_frame.get_html_code_language()));
                             call_stack.pop();
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
@@ -2603,8 +2608,9 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_code: {
-                parent_ast.push_back(
-                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlCode<ndebug>{::std::move(subast)}));
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::HtmlCode<ndebug>{::std::move(subast),
+                                                  ::std::move(frame.get_html_code_language())}));
                 parent_index += staged_index;
                 goto entry;
             }

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1243,8 +1243,7 @@ constexpr auto try_parse_code_tag(::fast_io::u8string_view pltext) noexcept
                 return ::exception::nullopt_t{};
             }
             // value must start with "language-" and have at least one char after
-            if (attr_val.size() < 10 ||
-                ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, 0) != u8'l' ||
+            if (attr_val.size() < 10 || ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, 0) != u8'l' ||
                 ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, 1) != u8'a' ||
                 ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, 2) != u8'n' ||
                 ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, 3) != u8'g' ||
@@ -1269,6 +1268,7 @@ constexpr auto try_parse_code_tag(::fast_io::u8string_view pltext) noexcept
     }
     return TryParseCodeTagResult{pos + 1, ::std::move(language)};
 }
+
 /**
  * @brief Parse a self-closing HTML tag without a specific tag name (e.g., `<tag/>`).
  *

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1145,6 +1145,131 @@ constexpr auto try_parse_span_tag(::fast_io::u8string_view pltext) noexcept
 }
 
 /**
+ * @brief Result of parsing a <code class="language-..."> tag.
+ */
+struct TryParseCodeTagResult {
+    ::std::size_t tag_len; ///< Length of the matched tag.
+    ::exception::optional<::fast_io::u8string> language;
+};
+
+/**
+ * @brief Parse <code> or <code class="language-..."> with strict validation.
+ * @tparam ndebug When set to Contracts::ignore, runtime assertions are disabled for performance.
+ * @param[in] pltext Input text starting at "ode ..." (after "<c").
+ * @return Parsed tag result on success; nullopt on any deviation.
+ * @note Bare <code> (no attributes) is accepted. If "class" attribute is present,
+ *       the value must start with "language-" and have at least one character after.
+ *       Any other attribute, duplicate class, empty class, or non-"language-" prefix fails.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_code_tag(::fast_io::u8string_view pltext) noexcept
+    -> ::exception::optional<TryParseCodeTagResult> {
+    // match "ode" prefix (case-insensitive)
+    if (::pltxt2htm::details::is_prefix_match<ndebug, ::pltxt2htm::details::U8LiteralString{u8"ode"}>(pltext) ==
+        false) {
+        return ::exception::nullopt_t{};
+    }
+
+    ::std::size_t pos{3}; // skip past "ode" (the 'c' was consumed by the trie dispatch)
+    bool found_class{false};
+    ::exception::optional<::fast_io::u8string> language{::exception::nullopt_t{}};
+
+    while (pos < pltext.size()) {
+        // skip whitespace
+        while (pos < pltext.size() && (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
+                                       ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
+            ++pos;
+        }
+        if (pos >= pltext.size()) {
+            return ::exception::nullopt_t{};
+        }
+        if (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'>') {
+            break;
+        }
+
+        // parse attribute name
+        ::std::size_t const attr_start = pos;
+        while (pos < pltext.size() && ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'=' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'>' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8' ' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'\t' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'/') {
+            ++pos;
+        }
+        ::fast_io::u8string_view const attr_name{pltext.data() + attr_start, pos - attr_start};
+
+        // skip whitespace before '='
+        while (pos < pltext.size() && (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
+                                       ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
+            ++pos;
+        }
+        if (pos >= pltext.size() || ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'=') {
+            return ::exception::nullopt_t{};
+        }
+        ++pos; // skip '='
+
+        // skip whitespace after '='
+        while (pos < pltext.size() && (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
+                                       ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
+            ++pos;
+        }
+        if (pos >= pltext.size()) {
+            return ::exception::nullopt_t{};
+        }
+
+        // parse quoted attribute value
+        char8_t const quote{::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos)};
+        if (quote != u8'"' && quote != u8'\'') {
+            return ::exception::nullopt_t{};
+        }
+        ++pos; // skip opening quote
+        ::std::size_t const val_start = pos;
+        while (pos < pltext.size() && ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != quote) {
+            ++pos;
+        }
+        if (pos >= pltext.size()) {
+            return ::exception::nullopt_t{};
+        }
+        ::fast_io::u8string_view const attr_val{pltext.data() + val_start, pos - val_start};
+        ++pos; // skip closing quote
+
+        // only lowercase "class" attribute is allowed
+        if (attr_name == ::fast_io::u8string_view{u8"class"}) {
+            if (found_class) {
+                return ::exception::nullopt_t{}; // duplicate class
+            }
+            if (attr_val.empty()) {
+                return ::exception::nullopt_t{};
+            }
+            // value must start with "language-" and have at least one char after
+            if (attr_val.size() < 10 ||
+                ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, 0) != u8'l' ||
+                ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, 1) != u8'a' ||
+                ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, 2) != u8'n' ||
+                ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, 3) != u8'g' ||
+                ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, 4) != u8'u' ||
+                ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, 5) != u8'a' ||
+                ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, 6) != u8'g' ||
+                ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, 7) != u8'e' ||
+                ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, 8) != u8'-') {
+                return ::exception::nullopt_t{};
+            }
+            language = ::fast_io::u8string{attr_val};
+            found_class = true;
+        }
+        else {
+            return ::exception::nullopt_t{}; // unknown attribute
+        }
+    }
+
+    // bare tag with no attributes is accepted
+    if (pos >= pltext.size() || ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'>') {
+        return ::exception::nullopt_t{};
+    }
+    return TryParseCodeTagResult{pos + 1, ::std::move(language)};
+}
+/**
  * @brief Parse a self-closing HTML tag without a specific tag name (e.g., `<tag/>`).
  *
  * This function attempts to parse any self-closing HTML tag by looking for the pattern

--- a/include/pltxt2htm/experimental/html_parser.hh
+++ b/include/pltxt2htm/experimental/html_parser.hh
@@ -144,7 +144,8 @@ entry:
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                         opt_code_tag.has_value()) {
                         // parsing html <code> tag (bare or with class="language-...")
-                        auto&& [tag_len, lang] = opt_code_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        auto&& [tag_len, lang] =
+                            opt_code_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                         current_index += tag_len + 2;
                         call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                             ::pltxt2htm::details::FrontendContextVariant<ndebug>{
@@ -906,9 +907,8 @@ entry:
                             opt_tag_len.has_value()) {
                             ::std::size_t const staged_index{current_index};
                             auto& code_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                            ::pltxt2htm::HtmlCode staged_node(
-                                ::std::move(result),
-                                ::std::move(code_frame.get_html_code_language()));
+                            ::pltxt2htm::HtmlCode staged_node(::std::move(result),
+                                                              ::std::move(code_frame.get_html_code_language()));
                             call_stack.pop();
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
@@ -1233,8 +1233,7 @@ entry:
             }
             case ::pltxt2htm::NodeKind::html_code: {
                 parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                    ::pltxt2htm::HtmlCode<ndebug>{::std::move(subast),
-                                                  ::std::move(frame.get_html_code_language())}));
+                    ::pltxt2htm::HtmlCode<ndebug>{::std::move(subast), ::std::move(frame.get_html_code_language())}));
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_pre: {

--- a/include/pltxt2htm/experimental/html_parser.hh
+++ b/include/pltxt2htm/experimental/html_parser.hh
@@ -140,14 +140,17 @@ entry:
                 case u8'c':
                     [[fallthrough]];
                 case u8'C': {
-                    if (auto opt_code_tag = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"ode">(
+                    if (auto opt_code_tag = ::pltxt2htm::details::try_parse_code_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                         opt_code_tag.has_value()) {
-                        current_index += opt_code_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        // parsing html <code> tag (bare or with class="language-...")
+                        auto&& [tag_len, lang] = opt_code_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 2;
                         call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                             ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::details::ParserFrameContextWithHtmlCodeInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                                    ::std::move(lang)},
                                 ::pltxt2htm::NodeKind::html_code},
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
@@ -902,7 +905,10 @@ entry:
                                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                             opt_tag_len.has_value()) {
                             ::std::size_t const staged_index{current_index};
-                            ::pltxt2htm::HtmlCode staged_node(::std::move(result));
+                            auto& code_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            ::pltxt2htm::HtmlCode staged_node(
+                                ::std::move(result),
+                                ::std::move(code_frame.get_html_code_language()));
                             call_stack.pop();
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
@@ -1226,8 +1232,9 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_code: {
-                parent_ast.push_back(
-                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlCode<ndebug>{::std::move(subast)}));
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::HtmlCode<ndebug>{::std::move(subast),
+                                                  ::std::move(frame.get_html_code_language())}));
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_pre: {

--- a/tests/precompile.cpp
+++ b/tests/precompile.cpp
@@ -75,8 +75,7 @@ PLTXT2HTM_VISIBILITY_DEFAULT auto pltxt4htmlunittest(::fast_io::u8string_view pl
 #if __has_cpp_attribute(__gnu__::__pure__)
 [[__gnu__::__pure__]]
 #endif
-PLTXT2HTM_VISIBILITY_DEFAULT auto pltxt2nolatex_htmld(::fast_io::u8string_view pltext) noexcept
-    -> ::fast_io::u8string {
+PLTXT2HTM_VISIBILITY_DEFAULT auto pltxt2nolatex_htmld(::fast_io::u8string_view pltext) noexcept -> ::fast_io::u8string {
     auto ast = ::pltxt2htm::parse_pltxt<::pltxt2htm::Contracts::quick_enforce>(pltext);
     ::pltxt2htm::optimize_ast<::pltxt2htm::Contracts::quick_enforce>(ast);
     return ::pltxt2htm::details::plweb_text_backend<::pltxt2htm::Contracts::quick_enforce,

--- a/tests/test_html_code_tag.cc
+++ b/tests/test_html_code_tag.cc
@@ -49,5 +49,47 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
     }
 
+    // --- <code class="language-..."> tests ---
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code class=\"language-bash\">echo</code>");
+        auto answer = ::fast_io::u8string_view{u8"<code class=\"language-bash\">echo</code>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code class=\"language-cpp\">fn()</code>");
+        auto answer = ::fast_io::u8string_view{u8"<code class=\"language-cpp\">fn()</code>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // case-sensitive: Language- vs language-
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code class=\"Language-bash\">echo</code>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;code&nbsp;class=&quot;Language-bash&quot;&gt;echo&lt;/code&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // non-language- prefix
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code class=\"xxx\">echo</code>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;code&nbsp;class=&quot;xxx&quot;&gt;echo&lt;/code&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // empty class value
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code class=\"\">echo</code>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;code&nbsp;class=&quot;&quot;&gt;echo&lt;/code&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // unknown attribute (style) — should fall back
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code style=\"color:red\">echo</code>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;code&nbsp;style=&quot;color:red&quot;&gt;echo&lt;/code&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // language- with empty language suffix — should fall back
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code class=\"language-\">echo</code>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;code&nbsp;class=&quot;language-&quot;&gt;echo&lt;/code&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
     return 0;
 }


### PR DESCRIPTION
## Summary

Strict `<code class="language-...">` parsing with XSS protection. The `<code>` tag now only accepts bare tags or `class="language-..."` with strict validation — any other attribute, duplicate class, empty class, or non-`language-` prefix value causes parse failure and falls back to literal text output.

## Changes

- **`HtmlCode`** stripped down: removed `color`, `font_size`, `class_name`; renamed to `language` (matching `MdCodeFence` convention).
- **`try_parse_code_tag`**: now accepts both bare `<code>` and `<code class="language-...">`. Class value must start with `language-` and have at least one character after the prefix. Any deviation → parse failure → `<` rendered as `&lt;` (XSS safe).
- **Removed** `try_parse_bare_tag<ndebug, u8"ode">` dispatch path — merged into `try_parse_code_tag`.
- **Fixed** `class=""` bug: bare `<code>` correctly passes `nullopt` instead of an empty string wrapped in `optional`.
- **Single-char `append` → `push_back`** for efficiency.
- **`-Wshadow` fix**: renamed inner `frame` to `code_frame` in `html_code` cases.
- Added unit tests for valid, invalid, and fallback `<code>` variants.
