### PR TITLE
refactor: replace Url AST with u8string; percent-encode '`"<>` in URL…

### DIFF
--- a/benches/src/bench_micro.cc
+++ b/benches/src/bench_micro.cc
@@ -52,10 +52,9 @@ BENCHMARK_REGISTER_F(MicroFixture, NodeCreate_HtmlSpan);
 
 BENCHMARK_DEFINE_F(MicroFixture, NodeCreate_MdLink)(benchmark::State& st) {
     for (auto _ : st) {
-        ::pltxt2htm::Ast<ndebug> text_sub, url_sub;
+        ::pltxt2htm::Ast<ndebug> text_sub;
         text_sub.push_back(::pltxt2htm::PlTxtNode<ndebug>{::pltxt2htm::U8Char{u8'L'}});
-        url_sub.push_back(::pltxt2htm::PlTxtNode<ndebug>{::pltxt2htm::U8Char{u8'/'}});
-        ::pltxt2htm::Url<ndebug> url{::std::move(url_sub)};
+        ::pltxt2htm::Url url{::fast_io::u8string{u8"/"}};
         ::pltxt2htm::PlTxtNode<ndebug> node{::pltxt2htm::MdLink<ndebug>{::std::move(text_sub), ::std::move(url)}};
         ::benchmark::DoNotOptimize(node);
     }

--- a/include/pltxt2htm/ast/ast.hh
+++ b/include/pltxt2htm/ast/ast.hh
@@ -136,7 +136,7 @@ class PlTxtNode {
         ::pltxt2htm::MdTripleEmphasisUnderscore<ndebug> md_triple_emphasis_underscore_node;
         ::pltxt2htm::MdDel<ndebug> md_del_node;
         ::pltxt2htm::MdLink<ndebug> md_link_node;
-        ::pltxt2htm::Url<ndebug> url_node;
+        ::pltxt2htm::Url url_node;
         ::pltxt2htm::MdImage<ndebug> md_image_node;
         ::pltxt2htm::MdBlockQuotes<ndebug> md_block_quotes_node;
         ::pltxt2htm::MdUl<ndebug> md_ul_node;
@@ -721,7 +721,7 @@ public:
           node_kind{::pltxt2htm::NodeKind::md_link} {
     }
 
-    constexpr PlTxtNode(::pltxt2htm::Url<ndebug>&& node) noexcept
+    constexpr PlTxtNode(::pltxt2htm::Url&& node) noexcept
         : url_node(::std::move(node)),
           node_kind{::pltxt2htm::NodeKind::url} {
     }

--- a/include/pltxt2htm/ast/impl/basic_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/basic_node_decl.hh
@@ -165,31 +165,32 @@ public:
 
 /**
  * @brief URL node
- * @details Represents a URL stored as an AST of characters.
+ * @details Represents a URL stored as a plain string.
  */
-template<::pltxt2htm::Contracts ndebug>
 class Url {
-    ::pltxt2htm::Ast<ndebug> url_ast;
+    ::fast_io::u8string url_str;
 
 public:
     /**
-     * @brief Construct a ::pltxt2htm::Url<ndebug> from an AST.
-     * @param attr The AST representing the URL characters.
+     * @brief Construct a ::pltxt2htm::Url from a URL string.
+     * @param url The URL string.
      */
-    constexpr explicit Url(::pltxt2htm::Ast<ndebug>&& attr) noexcept;
-    constexpr Url(::pltxt2htm::Url<ndebug> const&) noexcept;
-    constexpr Url(::pltxt2htm::Url<ndebug>&&) noexcept;
-    constexpr ~Url() noexcept;
-    constexpr auto operator=(::pltxt2htm::Url<ndebug> const&) noexcept -> ::pltxt2htm::Url<ndebug>& = delete;
-    constexpr auto operator=(this ::pltxt2htm::Url<ndebug>& self, ::pltxt2htm::Url<ndebug>&&) noexcept
-        -> ::pltxt2htm::Url<ndebug>&;
+    constexpr explicit Url(::fast_io::u8string&& url) noexcept
+        : url_str(::std::move(url)) {
+    }
+
+    constexpr Url(Url const&) noexcept = default;
+    constexpr Url(Url&&) noexcept = default;
+    constexpr ~Url() noexcept = default;
+    constexpr auto operator=(Url const&) noexcept -> Url& = delete;
+    constexpr auto operator=(this Url& self, Url&&) noexcept -> Url& = default;
 
     [[nodiscard]]
-    constexpr auto operator==(this Url const&, Url const&) noexcept -> bool;
+    constexpr auto operator==(this Url const&, Url const&) noexcept -> bool = default;
 
     [[nodiscard]]
-    constexpr auto get_url_ast(this auto&& self) noexcept -> decltype(auto) {
-        return ::std::forward_like<decltype(self)>(self.url_ast);
+    constexpr auto as_string(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.url_str);
     }
 };
 

--- a/include/pltxt2htm/ast/impl/basic_node_def.inc
+++ b/include/pltxt2htm/ast/impl/basic_node_def.inc
@@ -25,27 +25,4 @@ template<::pltxt2htm::Contracts ndebug>
 constexpr auto ::pltxt2htm::Text<ndebug>::operator==(this ::pltxt2htm::Text<ndebug> const&,
                                                      ::pltxt2htm::Text<ndebug> const&) noexcept -> bool = default;
 
-template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::Url<ndebug>::Url(::pltxt2htm::Ast<ndebug>&& attr) noexcept
-    : url_ast(::std::move(attr)) {
-}
-
-template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::Url<ndebug>::Url(::pltxt2htm::Url<ndebug> const&) noexcept = default;
-
-template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::Url<ndebug>::Url(::pltxt2htm::Url<ndebug>&& other) noexcept = default;
-
-template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::Url<ndebug>::~Url() noexcept = default;
-
-template<::pltxt2htm::Contracts ndebug>
-constexpr auto ::pltxt2htm::Url<ndebug>::operator=(this ::pltxt2htm::Url<ndebug>& self,
-                                                   ::pltxt2htm::Url<ndebug>&& other) noexcept
-    -> ::pltxt2htm::Url<ndebug>& = default;
-
-template<::pltxt2htm::Contracts ndebug>
-constexpr auto ::pltxt2htm::Url<ndebug>::operator==(this ::pltxt2htm::Url<ndebug> const&,
-                                                    ::pltxt2htm::Url<ndebug> const&) noexcept -> bool = default;
-
 } // namespace pltxt2htm

--- a/include/pltxt2htm/ast/impl/html_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/html_node_decl.hh
@@ -555,12 +555,11 @@ public:
 template<::pltxt2htm::Contracts ndebug>
 class HtmlA {
     ::pltxt2htm::Ast<ndebug> subast;
-    ::pltxt2htm::Url<ndebug> url;
+    ::pltxt2htm::Url url;
     bool internal;
 
 public:
-    constexpr explicit HtmlA(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::Url<ndebug>&& url_,
-                             bool internal_) noexcept;
+    constexpr explicit HtmlA(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::Url&& url_, bool internal_) noexcept;
     constexpr HtmlA(::pltxt2htm::HtmlA<ndebug> const&) noexcept;
     constexpr HtmlA(::pltxt2htm::HtmlA<ndebug>&&) noexcept;
     constexpr ~HtmlA() noexcept;

--- a/include/pltxt2htm/ast/impl/html_node_def.inc
+++ b/include/pltxt2htm/ast/impl/html_node_def.inc
@@ -562,7 +562,7 @@ constexpr auto ::pltxt2htm::HtmlSpan<ndebug>::operator==(this ::pltxt2htm::HtmlS
     -> bool = default;
 
 template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::HtmlA<ndebug>::HtmlA(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::Url<ndebug>&& url_,
+constexpr ::pltxt2htm::HtmlA<ndebug>::HtmlA(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::Url&& url_,
                                             bool internal_) noexcept
     : subast(::std::move(subast_)),
       url(::std::move(url_)),

--- a/include/pltxt2htm/ast/impl/markdown_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/markdown_node_decl.hh
@@ -695,7 +695,7 @@ public:
 template<::pltxt2htm::Contracts ndebug>
 class MdLink {
     ::pltxt2htm::Ast<ndebug> subast;
-    ::pltxt2htm::Url<ndebug> url;
+    ::pltxt2htm::Url url;
 
 public:
     /**
@@ -703,7 +703,7 @@ public:
      * @param subast The link text/content AST.
      * @param url The target URL.
      */
-    constexpr explicit MdLink(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::Url<ndebug>&& url_) noexcept;
+    constexpr explicit MdLink(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::Url&& url_) noexcept;
     constexpr MdLink(::pltxt2htm::MdLink<ndebug> const&) noexcept;
     constexpr MdLink(::pltxt2htm::MdLink<ndebug>&&) noexcept;
     constexpr ~MdLink() noexcept;
@@ -731,7 +731,7 @@ public:
 template<::pltxt2htm::Contracts ndebug>
 class MdImage {
     ::pltxt2htm::Ast<ndebug> subast;
-    ::pltxt2htm::Url<ndebug> url;
+    ::pltxt2htm::Url url;
 
 public:
     /**
@@ -739,7 +739,7 @@ public:
      * @param subast The alt text/content AST.
      * @param url The image source URL.
      */
-    constexpr explicit MdImage(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::Url<ndebug>&& url_) noexcept;
+    constexpr explicit MdImage(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::Url&& url_) noexcept;
     constexpr MdImage(::pltxt2htm::MdImage<ndebug> const&) noexcept;
     constexpr MdImage(::pltxt2htm::MdImage<ndebug>&&) noexcept;
     constexpr ~MdImage() noexcept;

--- a/include/pltxt2htm/ast/impl/markdown_node_def.inc
+++ b/include/pltxt2htm/ast/impl/markdown_node_def.inc
@@ -409,8 +409,7 @@ constexpr auto ::pltxt2htm::MdDel<ndebug>::operator==(this ::pltxt2htm::MdDel<nd
                                                       ::pltxt2htm::MdDel<ndebug> const&) noexcept -> bool = default;
 
 template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::MdLink<ndebug>::MdLink(::pltxt2htm::Ast<ndebug>&& subast_,
-                                              ::pltxt2htm::Url<ndebug>&& url_) noexcept
+constexpr ::pltxt2htm::MdLink<ndebug>::MdLink(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::Url&& url_) noexcept
     : subast(::std::move(subast_)),
       url(::std::move(url_)) {
 }
@@ -431,8 +430,7 @@ constexpr auto ::pltxt2htm::MdLink<ndebug>::operator==(this ::pltxt2htm::MdLink<
                                                        ::pltxt2htm::MdLink<ndebug> const&) noexcept -> bool = default;
 
 template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::MdImage<ndebug>::MdImage(::pltxt2htm::Ast<ndebug>&& subast_,
-                                                ::pltxt2htm::Url<ndebug>&& url_) noexcept
+constexpr ::pltxt2htm::MdImage<ndebug>::MdImage(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::Url&& url_) noexcept
     : subast(::std::move(subast_)),
       url(::std::move(url_)) {
 }

--- a/include/pltxt2htm/ast/impl/physics_lab_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/physics_lab_node_decl.hh
@@ -188,10 +188,10 @@ public:
 template<::pltxt2htm::Contracts ndebug>
 class PlExternal {
     ::pltxt2htm::Ast<ndebug> subast;
-    ::pltxt2htm::Url<ndebug> url;
+    ::pltxt2htm::Url url;
 
 public:
-    constexpr PlExternal(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::Url<ndebug>&& url_) noexcept;
+    constexpr PlExternal(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::Url&& url_) noexcept;
     constexpr PlExternal(::pltxt2htm::PlExternal<ndebug> const&) noexcept;
     constexpr PlExternal(::pltxt2htm::PlExternal<ndebug>&&) noexcept;
     constexpr ~PlExternal() noexcept;

--- a/include/pltxt2htm/ast/impl/physics_lab_node_def.inc
+++ b/include/pltxt2htm/ast/impl/physics_lab_node_def.inc
@@ -113,7 +113,7 @@ constexpr auto ::pltxt2htm::PlUser<ndebug>::operator==(this ::pltxt2htm::PlUser<
 
 template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::PlExternal<ndebug>::PlExternal(::pltxt2htm::Ast<ndebug>&& subast_,
-                                                      ::pltxt2htm::Url<ndebug>&& url_) noexcept
+                                                      ::pltxt2htm::Url&& url_) noexcept
     : subast(::std::move(subast_)),
       url(::std::move(url_)) {
 }

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -333,8 +333,7 @@ entry:
                     node.as_pl_external().get_subast(), ::pltxt2htm::NodeKind::pl_external, 0));
                 ++current_index;
                 result.append(u8"<external=");
-                ::pltxt2htm::details::convert_simple_pltxt_ast_to_plunity_richtext<ndebug>(
-                    node.as_pl_external().get_url().get_url_ast(), result);
+                result.append(node.as_pl_external().get_url().as_string());
                 result.push_back(u8'>');
                 goto entry;
             }
@@ -382,8 +381,7 @@ entry:
                                                                                   ::pltxt2htm::NodeKind::html_a, 0));
                 ++current_index;
                 result.append(u8"<external=");
-                ::pltxt2htm::details::convert_simple_pltxt_ast_to_plunity_richtext<ndebug>(
-                    node.as_html_a().get_url().get_url_ast(), result);
+                result.append(node.as_html_a().get_url().as_string());
                 result.push_back(u8'>');
                 goto entry;
             }
@@ -943,22 +941,20 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::url: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_url().get_url_ast(),
-                                                                                  ::pltxt2htm::NodeKind::url, 0));
-                ++current_index;
+                auto const& url_str = node.as_url().as_string();
                 result.append(u8"<external=");
-                ::pltxt2htm::details::convert_simple_pltxt_ast_to_plunity_richtext<ndebug>(node.as_url().get_url_ast(),
-                                                                                           result);
+                result.append(url_str);
                 result.push_back(u8'>');
-                goto entry;
+                result.append(url_str);
+                result.append(u8"</external>");
+                continue;
             }
             case ::pltxt2htm::NodeKind::md_link: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_md_link().get_subast(),
                                                                                   ::pltxt2htm::NodeKind::md_link, 0));
                 ++current_index;
                 result.append(u8"<external=");
-                ::pltxt2htm::details::convert_simple_pltxt_ast_to_plunity_richtext<ndebug>(
-                    node.as_md_link().get_url().get_url_ast(), result);
+                result.append(node.as_md_link().get_url().as_string());
                 result.push_back(u8'>');
                 goto entry;
             }
@@ -967,8 +963,7 @@ entry:
                 ::pltxt2htm::details::convert_simple_pltxt_ast_to_plunity_richtext<ndebug>(
                     node.as_md_image().get_subast(), result);
                 result.append(u8"](");
-                ::pltxt2htm::details::convert_simple_pltxt_ast_to_plunity_richtext<ndebug>(
-                    node.as_md_image().get_url().get_url_ast(), result);
+                result.append(node.as_md_image().get_url().as_string());
                 result.push_back(u8')');
                 continue;
             }

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -242,33 +242,6 @@ constexpr void append_html_attr_escaped(::fast_io::u8string& result, ::fast_io::
     }
 }
 
-/**
- * @brief Convert a URL AST node to a string and append to HTML output.
- * @details Asserts in debug mode that the generated URL does not contain
- *          characters requiring HTML-attribute escaping.
- * @tparam ndebug Contract checking mode.
- * @param result Output string to append to.
- * @param url_ast The URL AST to convert.
- */
-template<::pltxt2htm::Contracts ndebug>
-constexpr void append_url_attr_from_ast(::fast_io::u8string& result, ::pltxt2htm::Url<ndebug> const& url_ast) noexcept {
-    auto const url_str_offset = result.size();
-    ::pltxt2htm::details::convert_simple_pltxt_ast_to_plweb_text<ndebug>(url_ast.get_url_ast(), result);
-    // Under normal circumstances, the URL should never contain characters that could enable XSS in HTML attributes.
-    // To avoid masking upstream bugs (and to keep release-path performance), we only assert this in debug mode.
-    // Do not try to hide such errors by routing output through `append_html_attr_escaped`.
-    if constexpr (ndebug == ::pltxt2htm::Contracts::quick_enforce) {
-        auto const url_str_view =
-            ::fast_io::u8string_view{result.data() + url_str_offset, result.size() - url_str_offset};
-        ::fast_io::u8string purified_url{};
-        ::pltxt2htm::details::append_html_attr_escaped<ndebug>(purified_url, url_str_view);
-        bool const url_is_safe{purified_url == url_str_view};
-        pltxt2htm_assert(url_is_safe,
-                         u8"URL contains characters that cannot be directly used in HTML attributes. Please "
-                         u8"check the URL or use a different backend that supports escaping.");
-    }
-}
-
 enum class PlWebTextBackendMode : unsigned {
     pltxt4unittest = 0,
     fixedadv_html,
@@ -536,7 +509,9 @@ entry:
                                                                                   ::pltxt2htm::NodeKind::html_a, 0));
                 ++current_index;
                 result.append(u8"<a href=\"");
-                ::pltxt2htm::details::append_url_attr_from_ast<ndebug>(result, node.as_html_a().get_url());
+                auto const& html_a_url = node.as_html_a().get_url().as_string();
+                ::pltxt2htm::details::append_html_attr_escaped<ndebug>(
+                    result, ::fast_io::u8string_view{html_a_url.data(), html_a_url.size()});
                 if (node.as_html_a().get_internal()) {
                     result.append(u8"\" internal>");
                 }
@@ -1040,17 +1015,22 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::url: {
+                auto const& url_str = node.as_url().as_string();
+                ::fast_io::u8string escaped;
+                ::pltxt2htm::details::append_html_attr_escaped<ndebug>(
+                    escaped, ::fast_io::u8string_view{url_str.data(), url_str.size()});
                 result.append(u8"<a href=\"");
-                ::pltxt2htm::details::append_url_attr_from_ast<ndebug>(result, node.as_url());
+                result.append(escaped);
                 result.append(u8"\">");
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_url().get_url_ast(),
-                                                                                  ::pltxt2htm::NodeKind::url, 0));
-                ++current_index;
-                goto entry;
+                result.append(escaped);
+                result.append(u8"</a>");
+                continue;
             }
             case ::pltxt2htm::NodeKind::md_link: {
                 result.append(u8"<a href=\"");
-                ::pltxt2htm::details::append_url_attr_from_ast<ndebug>(result, node.as_md_link().get_url());
+                auto const& md_link_url = node.as_md_link().get_url().as_string();
+                ::pltxt2htm::details::append_html_attr_escaped<ndebug>(
+                    result, ::fast_io::u8string_view{md_link_url.data(), md_link_url.size()});
                 result.append(u8"\">");
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_md_link().get_subast(),
                                                                                   ::pltxt2htm::NodeKind::md_link, 0));
@@ -1059,7 +1039,9 @@ entry:
             }
             case ::pltxt2htm::NodeKind::pl_external: {
                 result.append(u8"<a href=\"");
-                ::pltxt2htm::details::append_url_attr_from_ast<ndebug>(result, node.as_pl_external().get_url());
+                auto const& ext_url = node.as_pl_external().get_url().as_string();
+                ::pltxt2htm::details::append_html_attr_escaped<ndebug>(
+                    result, ::fast_io::u8string_view{ext_url.data(), ext_url.size()});
                 result.append(u8"\">");
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
                     node.as_pl_external().get_subast(), ::pltxt2htm::NodeKind::pl_external, 0));
@@ -1068,7 +1050,9 @@ entry:
             }
             case ::pltxt2htm::NodeKind::md_image: {
                 result.append(u8"<img src=\"");
-                ::pltxt2htm::details::append_url_attr_from_ast<ndebug>(result, node.as_md_image().get_url());
+                auto const& img_url = node.as_md_image().get_url().as_string();
+                ::pltxt2htm::details::append_html_attr_escaped<ndebug>(
+                    result, ::fast_io::u8string_view{img_url.data(), img_url.size()});
                 result.append(u8"\" alt=\"");
                 ::pltxt2htm::details::convert_simple_pltxt_ast_to_plweb_text<ndebug>(node.as_md_image().get_subast(),
                                                                                      result);

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -1,7 +1,7 @@
 /**
  * @file for_plweb_title.hh
  * @brief HTML title backend for plweb – generates simple HTML suitable for page titles.
- * @details Provides `url_ast_to_string` and `plweb_title_backend` for converting
+ * @details Provides `plweb_title_backend` for converting
  *          a pl-text AST into a simplified HTML fragment that only supports
  *          color, bold, and italic formatting.
  */
@@ -20,149 +20,6 @@
 #include "../push_macro.hh"
 
 namespace pltxt2htm::details {
-
-/**
- * @brief Convert a URL AST to a plain URL string (all md_escape_* are unescaped).
- * @tparam ndebug Contract checking mode.
- * @param ast The URL AST to convert.
- * @param[out] out Output buffer receiving the URL string.
- */
-template<::pltxt2htm::Contracts ndebug>
-constexpr void url_ast_to_string(::pltxt2htm::Ast<ndebug> const& ast, ::fast_io::u8string& out) noexcept {
-    out.reserve(out.size() + ast.size());
-    for (auto&& node : ast) {
-        switch (node.get_node_kind()) {
-        case ::pltxt2htm::NodeKind::u8char: {
-            out.push_back(node.as_u8char().chr);
-            continue;
-        }
-        case ::pltxt2htm::NodeKind::invalid_u8char: {
-            out.append(u8"\uFFFD");
-            continue;
-        }
-        case ::pltxt2htm::NodeKind::md_escape_backslash:
-            out.push_back(u8'\\');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_exclamation:
-            out.push_back(u8'!');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_double_quote:
-            out.push_back(u8'"');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_hash:
-            out.push_back(u8'#');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_dollar:
-            out.push_back(u8'$');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_percent:
-            out.push_back(u8'%');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_ampersand:
-            out.push_back(u8'&');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_single_quote:
-            out.push_back(u8'\'');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_left_paren:
-            out.push_back(u8'(');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_right_paren:
-            out.push_back(u8')');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_asterisk:
-            out.push_back(u8'*');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_plus:
-            out.push_back(u8'+');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_comma:
-            out.push_back(u8',');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_hyphen:
-            out.push_back(u8'-');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_dot:
-            out.push_back(u8'.');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_slash:
-            out.push_back(u8'/');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_colon:
-            out.push_back(u8':');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_semicolon:
-            out.push_back(u8';');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_less_than:
-            out.push_back(u8'<');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_equals:
-            out.push_back(u8'=');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_greater_than:
-            out.push_back(u8'>');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_question:
-            out.push_back(u8'?');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_at:
-            out.push_back(u8'@');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_left_bracket:
-            out.push_back(u8'[');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_right_bracket:
-            out.push_back(u8']');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_caret:
-            out.push_back(u8'^');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_underscore:
-            out.push_back(u8'_');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_backtick:
-            out.push_back(u8'`');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_left_brace:
-            out.push_back(u8'{');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_pipe:
-            out.push_back(u8'|');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_right_brace:
-            out.push_back(u8'}');
-            continue;
-        case ::pltxt2htm::NodeKind::md_escape_tilde:
-            out.push_back(u8'~');
-            continue;
-        case ::pltxt2htm::NodeKind::ampersand:
-            out.push_back(u8'&');
-            continue;
-        case ::pltxt2htm::NodeKind::entity_reference:
-            out.push_back(u8'&');
-            out.append(node.as_entity_reference().get_value());
-            out.push_back(u8';');
-            continue;
-        case ::pltxt2htm::NodeKind::single_quote:
-            out.push_back(u8'\'');
-            continue;
-        case ::pltxt2htm::NodeKind::double_quote:
-            out.push_back(u8'"');
-            continue;
-        case ::pltxt2htm::NodeKind::less_than:
-            out.push_back(u8'<');
-            continue;
-        case ::pltxt2htm::NodeKind::greater_than:
-            out.push_back(u8'>');
-            continue;
-        default:
-            [[unlikely]] {
-                pltxt2htm_unreachable(u8"Unexpected node kind in title character rendering");
-            }
-        }
-    }
-}
 
 /**
  * @brief Translate pl-text's AST to common HTML (only supports color, b and i tags)
@@ -301,7 +158,7 @@ entry:
                                                                                   ::pltxt2htm::NodeKind::html_a, 0));
                 ++current_index;
                 result.append(u8"<a href=\"");
-                ::pltxt2htm::details::url_ast_to_string<ndebug>(node.as_html_a().get_url().get_url_ast(), result);
+                result.append(node.as_html_a().get_url().as_string());
                 if (node.as_html_a().get_internal()) {
                     result.append(u8"\" internal>");
                 }
@@ -843,7 +700,7 @@ entry:
             }
             case ::pltxt2htm::NodeKind::pl_external: {
                 result.append(u8"<a href=\"");
-                ::pltxt2htm::details::url_ast_to_string<ndebug>(node.as_pl_external().get_url().get_url_ast(), result);
+                result.append(node.as_pl_external().get_url().as_string());
                 result.append(u8"\">");
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
                     node.as_pl_external().get_subast(), ::pltxt2htm::NodeKind::pl_external, 0));
@@ -852,7 +709,7 @@ entry:
             }
             case ::pltxt2htm::NodeKind::md_link: {
                 result.append(u8"<a href=\"");
-                ::pltxt2htm::details::url_ast_to_string<ndebug>(node.as_md_link().get_url().get_url_ast(), result);
+                result.append(node.as_md_link().get_url().as_string());
                 result.append(u8"\">");
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_md_link().get_subast(),
                                                                                   ::pltxt2htm::NodeKind::md_link, 0));
@@ -860,13 +717,13 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::url: {
+                auto const& url_str = node.as_url().as_string();
                 result.append(u8"<a href=\"");
-                ::pltxt2htm::details::url_ast_to_string<ndebug>(node.as_url().get_url_ast(), result);
+                result.append(url_str);
                 result.append(u8"\">");
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_url().get_url_ast(),
-                                                                                  ::pltxt2htm::NodeKind::url, 0));
-                ++current_index;
-                goto entry;
+                result.append(url_str);
+                result.append(u8"</a>");
+                continue;
             }
             case ::pltxt2htm::NodeKind::md_image: {
                 ++current_index;

--- a/include/pltxt2htm/details/parser/frame_concext.hh
+++ b/include/pltxt2htm/details/parser/frame_concext.hh
@@ -65,7 +65,7 @@ template<::pltxt2htm::Contracts ndebug>
 class ParserFrameContextWithUrlInfo {
 public:
     ::fast_io::u8string_view pltext;
-    ::pltxt2htm::Url<ndebug> url;
+    ::pltxt2htm::Url url;
 };
 
 /**
@@ -75,7 +75,7 @@ template<::pltxt2htm::Contracts ndebug>
 class ParserFrameContextWithHtmlATagInfo {
 public:
     ::fast_io::u8string_view pltext;
-    ::pltxt2htm::Url<ndebug> url;
+    ::pltxt2htm::Url url;
     bool internal;
 };
 

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -2670,7 +2670,7 @@ constexpr auto try_parse_url_authority(::fast_io::u8string_view pltext, ::std::s
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseUrlResult {
     ::std::size_t consumed_size;
-    ::pltxt2htm::Url<ndebug> url;
+    ::pltxt2htm::Url url;
 };
 
 template<::pltxt2htm::Contracts ndebug>
@@ -2678,7 +2678,8 @@ template<::pltxt2htm::Contracts ndebug>
 constexpr auto make_try_parse_url_result(::fast_io::u8string_view const parsed_url,
                                          ::std::size_t consumed_size) noexcept
     -> ::exception::optional<::pltxt2htm::details::TryParseUrlResult<ndebug>> {
-    ::pltxt2htm::Ast<ndebug> ast{};
+    ::fast_io::u8string url_str{};
+    url_str.reserve(parsed_url.size());
     for (::std::size_t index{}; index < parsed_url.size(); ++index) {
         auto chr = ::pltxt2htm::details::u8string_view_index<ndebug>(parsed_url, index);
         if (chr == u8'&') {
@@ -2689,41 +2690,29 @@ constexpr auto make_try_parse_url_result(::fast_io::u8string_view const parsed_u
             }
         }
         switch (chr) {
-        case u8'&': {
-            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Ampersand{}));
-            break;
-        }
         case u8'\'': {
-            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::U8Char{u8'%'}));
-            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::U8Char{u8'2'}));
-            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::U8Char{u8'7'}));
+            url_str.append(u8"%27");
             break;
         }
         case u8'\"': {
-            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::U8Char{u8'%'}));
-            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::U8Char{u8'2'}));
-            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::U8Char{u8'2'}));
+            url_str.append(u8"%22");
             break;
         }
         case u8'<': {
-            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::U8Char{u8'%'}));
-            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::U8Char{u8'3'}));
-            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::U8Char{u8'C'}));
+            url_str.append(u8"%3C");
             break;
         }
         case u8'>': {
-            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::U8Char{u8'%'}));
-            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::U8Char{u8'3'}));
-            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::U8Char{u8'E'}));
+            url_str.append(u8"%3E");
             break;
         }
         default:
-            ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::U8Char{chr}));
+            url_str.push_back(chr);
             break;
         }
     }
     return ::pltxt2htm::details::TryParseUrlResult<ndebug>{.consumed_size = consumed_size,
-                                                           .url = ::pltxt2htm::Url<ndebug>{::std::move(ast)}};
+                                                           .url = ::pltxt2htm::Url{::std::move(url_str)}};
 }
 
 /**
@@ -2750,7 +2739,7 @@ constexpr auto try_parse_url_path_simple(::fast_io::u8string_view pltext, ::std:
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseHtmlATagResult {
     ::std::size_t tag_len;
-    ::pltxt2htm::Url<ndebug> url;
+    ::pltxt2htm::Url url;
     bool internal;
 };
 
@@ -2891,7 +2880,7 @@ constexpr auto try_parse_auto_url(::fast_io::u8string_view pltext, ::std::size_t
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseExternalTagResult {
     ::std::size_t tag_len;
-    ::pltxt2htm::Url<ndebug> url;
+    ::pltxt2htm::Url url;
 };
 
 template<::pltxt2htm::Contracts ndebug>
@@ -2931,7 +2920,7 @@ constexpr auto try_parse_external_tag(
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseMdUrlResult {
     ::std::size_t consumed_size;
-    ::pltxt2htm::Url<ndebug> url;
+    ::pltxt2htm::Url url;
 };
 
 template<::pltxt2htm::Contracts ndebug>
@@ -3016,7 +3005,7 @@ template<::pltxt2htm::Contracts ndebug>
 struct TryParseMdLinkResult {
     ::std::size_t advance_count;
     ::fast_io::u8string_view link_text;
-    ::pltxt2htm::Url<ndebug> link_url;
+    ::pltxt2htm::Url link_url;
 };
 
 /**
@@ -3098,7 +3087,7 @@ template<::pltxt2htm::Contracts ndebug>
 struct TryParseMdImageResult {
     ::std::size_t advance_count;
     ::pltxt2htm::Ast<ndebug> link_text;
-    ::pltxt2htm::Url<ndebug> link_url;
+    ::pltxt2htm::Url link_url;
 };
 
 /**

--- a/tests/test_ast_operator_eq.cc
+++ b/tests/test_ast_operator_eq.cc
@@ -293,18 +293,14 @@ int main() {
     {
         ::pltxt2htm::Ast<nd::quick_enforce> text_a{};
         text_a.emplace_back(::pltxt2htm::U8Char{u8'a'});
-        ::pltxt2htm::Ast<nd::quick_enforce> url_ast_a{};
-        url_ast_a.emplace_back(::pltxt2htm::U8Char{u8'x'});
 
         ::pltxt2htm::Ast<nd::quick_enforce> text_b{};
         text_b.emplace_back(::pltxt2htm::U8Char{u8'a'});
-        ::pltxt2htm::Ast<nd::quick_enforce> url_ast_b{};
-        url_ast_b.emplace_back(::pltxt2htm::U8Char{u8'x'});
 
-        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::MdLink<nd::quick_enforce>(
-            ::std::move(text_a), ::pltxt2htm::Url<nd::quick_enforce>(::std::move(url_ast_a))));
-        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::MdLink<nd::quick_enforce>(
-            ::std::move(text_b), ::pltxt2htm::Url<nd::quick_enforce>(::std::move(url_ast_b))));
+        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(
+            ::pltxt2htm::MdLink<nd::quick_enforce>(::std::move(text_a), ::pltxt2htm::Url(::fast_io::u8string{u8"x"})));
+        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(
+            ::pltxt2htm::MdLink<nd::quick_enforce>(::std::move(text_b), ::pltxt2htm::Url(::fast_io::u8string{u8"x"})));
         ::exception::assert_true<false>(a == b);
     }
 
@@ -312,18 +308,14 @@ int main() {
     {
         ::pltxt2htm::Ast<nd::quick_enforce> text_a{};
         text_a.emplace_back(::pltxt2htm::U8Char{u8'a'});
-        ::pltxt2htm::Ast<nd::quick_enforce> url_ast_a{};
-        url_ast_a.emplace_back(::pltxt2htm::U8Char{u8'x'});
 
         ::pltxt2htm::Ast<nd::quick_enforce> text_b{};
         text_b.emplace_back(::pltxt2htm::U8Char{u8'a'});
-        ::pltxt2htm::Ast<nd::quick_enforce> url_ast_b{};
-        url_ast_b.emplace_back(::pltxt2htm::U8Char{u8'y'});
 
-        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::MdLink<nd::quick_enforce>(
-            ::std::move(text_a), ::pltxt2htm::Url<nd::quick_enforce>(::std::move(url_ast_a))));
-        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::MdLink<nd::quick_enforce>(
-            ::std::move(text_b), ::pltxt2htm::Url<nd::quick_enforce>(::std::move(url_ast_b))));
+        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(
+            ::pltxt2htm::MdLink<nd::quick_enforce>(::std::move(text_a), ::pltxt2htm::Url(::fast_io::u8string{u8"x"})));
+        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(
+            ::pltxt2htm::MdLink<nd::quick_enforce>(::std::move(text_b), ::pltxt2htm::Url(::fast_io::u8string{u8"y"})));
         ::exception::assert_false<false>(a == b);
     }
 
@@ -331,18 +323,14 @@ int main() {
     {
         ::pltxt2htm::Ast<nd::quick_enforce> alt_a{};
         alt_a.emplace_back(::pltxt2htm::U8Char{u8'a'});
-        ::pltxt2htm::Ast<nd::quick_enforce> url_ast_a{};
-        url_ast_a.emplace_back(::pltxt2htm::U8Char{u8'x'});
 
         ::pltxt2htm::Ast<nd::quick_enforce> alt_b{};
         alt_b.emplace_back(::pltxt2htm::U8Char{u8'a'});
-        ::pltxt2htm::Ast<nd::quick_enforce> url_ast_b{};
-        url_ast_b.emplace_back(::pltxt2htm::U8Char{u8'x'});
 
-        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::MdImage<nd::quick_enforce>(
-            ::std::move(alt_a), ::pltxt2htm::Url<nd::quick_enforce>(::std::move(url_ast_a))));
-        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::MdImage<nd::quick_enforce>(
-            ::std::move(alt_b), ::pltxt2htm::Url<nd::quick_enforce>(::std::move(url_ast_b))));
+        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(
+            ::pltxt2htm::MdImage<nd::quick_enforce>(::std::move(alt_a), ::pltxt2htm::Url(::fast_io::u8string{u8"x"})));
+        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(
+            ::pltxt2htm::MdImage<nd::quick_enforce>(::std::move(alt_b), ::pltxt2htm::Url(::fast_io::u8string{u8"x"})));
         ::exception::assert_true<false>(a == b);
     }
 
@@ -482,17 +470,13 @@ int main() {
     // PlExternal (sub-AST + Url)
     {
         ::pltxt2htm::Ast<nd::quick_enforce> ast_a{};
-        ::pltxt2htm::Ast<nd::quick_enforce> url_ast_a{};
-        url_ast_a.emplace_back(::pltxt2htm::U8Char{u8'x'});
 
         ::pltxt2htm::Ast<nd::quick_enforce> ast_b{};
-        ::pltxt2htm::Ast<nd::quick_enforce> url_ast_b{};
-        url_ast_b.emplace_back(::pltxt2htm::U8Char{u8'x'});
 
         auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::PlExternal<nd::quick_enforce>(
-            ::std::move(ast_a), ::pltxt2htm::Url<nd::quick_enforce>(::std::move(url_ast_a))));
+            ::std::move(ast_a), ::pltxt2htm::Url(::fast_io::u8string{u8"x"})));
         auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::PlExternal<nd::quick_enforce>(
-            ::std::move(ast_b), ::pltxt2htm::Url<nd::quick_enforce>(::std::move(url_ast_b))));
+            ::std::move(ast_b), ::pltxt2htm::Url(::fast_io::u8string{u8"x"})));
         ::exception::assert_true<false>(a == b);
     }
 

--- a/tests/test_deep_copy.cc
+++ b/tests/test_deep_copy.cc
@@ -98,11 +98,8 @@ int main() {
         ::pltxt2htm::Ast<nd::quick_enforce> text_ast{};
         text_ast.emplace_back(::pltxt2htm::U8Char{u8't'});
 
-        ::pltxt2htm::Ast<nd::quick_enforce> url_ast{};
-        url_ast.emplace_back(::pltxt2htm::U8Char{u8'x'});
-
         auto const original = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::MdLink<nd::quick_enforce>(
-            ::std::move(text_ast), ::pltxt2htm::Url<nd::quick_enforce>(::std::move(url_ast))));
+            ::std::move(text_ast), ::pltxt2htm::Url(::fast_io::u8string{u8"x"})));
 
         auto const copy = original;
         ::exception::assert_true<false>(original == copy);

--- a/tests/test_html_a_tag.cc
+++ b/tests/test_html_a_tag.cc
@@ -124,8 +124,7 @@ int main() {
     {
         auto pltext = ::fast_io::u8string_view{u8"[text](https://example.com/pa'th)"};
         auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
-        auto answer = ::fast_io::u8string_view{
-            u8"<a href=\"https://example.com/pa%27th\">text</a>"};
+        auto answer = ::fast_io::u8string_view{u8"<a href=\"https://example.com/pa%27th\">text</a>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -133,15 +132,14 @@ int main() {
     {
         auto pltext = ::fast_io::u8string_view{u8"<a href=\"https://example.com/pa'th\">text</a>"};
         auto html = ::pltxt2htm_test::pltxt4htmlunittest(pltext);
-        auto answer = ::fast_io::u8string_view{
-            u8"<a href=\"https://example.com/pa%27th\">text</a>"};
+        auto answer = ::fast_io::u8string_view{u8"<a href=\"https://example.com/pa%27th\">text</a>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     // roundtrip idempotency for ' in auto-link URL
     {
-        auto pass1 = ::pltxt2htm_test::pltxt2nolatex_htmld(
-            ::fast_io::u8string_view{u8"https://example.com/path'with'quote"});
+        auto pass1 =
+            ::pltxt2htm_test::pltxt2nolatex_htmld(::fast_io::u8string_view{u8"https://example.com/path'with'quote"});
         auto pass2 = ::pltxt2htm_test::pltxt4htmlunittest(::fast_io::mnp::os_c_str(pass1));
         pltxt2htm_test_assert_equal(pass2, pass1);
     }


### PR DESCRIPTION
… parser

Url is no longer a template class — stores plain u8string instead of Ast<ndebug>. URL parser percent-encodes '`"<>` and decodes & → &. Output uses append_html_attr_escaped consistently instead of entity AST nodes. Removes `url_ast_to_string`, `append_url_attr_from_ast`, and `basic_node_def.inc` Url definitions.