### PR TITLE
feat: support text-align style attribute on HTML table header cells (<th>)

### DIFF
--- a/include/pltxt2htm/ast/impl/html_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/html_node_decl.hh
@@ -669,7 +669,7 @@ public:
 template<::pltxt2htm::Contracts ndebug>
 class HtmlTd {
     ::pltxt2htm::Ast<ndebug> subast;
-    ::pltxt2htm::MdTableAlign align_;
+    ::pltxt2htm::MdTableAlign align;
 
 public:
     constexpr explicit HtmlTd(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::MdTableAlign align_) noexcept;
@@ -690,7 +690,7 @@ public:
 
     [[nodiscard]]
     constexpr auto get_align(this auto&& self) noexcept -> ::pltxt2htm::MdTableAlign {
-        return self.align_;
+        return self.align;
     }
 };
 
@@ -700,7 +700,7 @@ public:
 template<::pltxt2htm::Contracts ndebug>
 class HtmlTh {
     ::pltxt2htm::Ast<ndebug> subast;
-    ::pltxt2htm::MdTableAlign align_;
+    ::pltxt2htm::MdTableAlign align;
 
 public:
     constexpr explicit HtmlTh(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::MdTableAlign align_) noexcept;
@@ -721,7 +721,7 @@ public:
 
     [[nodiscard]]
     constexpr auto get_align(this auto&& self) noexcept -> ::pltxt2htm::MdTableAlign {
-        return self.align_;
+        return self.align;
     }
 };
 

--- a/include/pltxt2htm/ast/impl/html_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/html_node_decl.hh
@@ -700,9 +700,10 @@ public:
 template<::pltxt2htm::Contracts ndebug>
 class HtmlTh {
     ::pltxt2htm::Ast<ndebug> subast;
+    ::pltxt2htm::MdTableAlign align_;
 
 public:
-    constexpr explicit HtmlTh(::pltxt2htm::Ast<ndebug>&& subast_) noexcept;
+    constexpr explicit HtmlTh(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::MdTableAlign align_) noexcept;
     constexpr HtmlTh(::pltxt2htm::HtmlTh<ndebug> const&) noexcept;
     constexpr HtmlTh(::pltxt2htm::HtmlTh<ndebug>&&) noexcept;
     constexpr ~HtmlTh() noexcept;
@@ -716,6 +717,11 @@ public:
     [[nodiscard]]
     constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
         return ::std::forward_like<decltype(self)>(self.subast);
+    }
+
+    [[nodiscard]]
+    constexpr auto get_align(this auto&& self) noexcept -> ::pltxt2htm::MdTableAlign {
+        return self.align_;
     }
 };
 

--- a/include/pltxt2htm/ast/impl/html_node_def.inc
+++ b/include/pltxt2htm/ast/impl/html_node_def.inc
@@ -392,9 +392,9 @@ constexpr auto ::pltxt2htm::HtmlTr<ndebug>::operator==(this ::pltxt2htm::HtmlTr<
 
 template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::HtmlTd<ndebug>::HtmlTd(::pltxt2htm::Ast<ndebug>&& subast_,
-                                              ::pltxt2htm::MdTableAlign align) noexcept
+                                              ::pltxt2htm::MdTableAlign align_) noexcept
     : subast(::std::move(subast_)),
-      align_{align} {
+      align{align_} {
 }
 
 template<::pltxt2htm::Contracts ndebug>
@@ -414,9 +414,9 @@ constexpr auto ::pltxt2htm::HtmlTd<ndebug>::operator==(this ::pltxt2htm::HtmlTd<
 
 template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::HtmlTh<ndebug>::HtmlTh(::pltxt2htm::Ast<ndebug>&& subast_,
-                                              ::pltxt2htm::MdTableAlign align) noexcept
+                                              ::pltxt2htm::MdTableAlign align_) noexcept
     : subast(::std::move(subast_)),
-      align_{align} {
+      align{align_} {
 }
 
 template<::pltxt2htm::Contracts ndebug>

--- a/include/pltxt2htm/ast/impl/html_node_def.inc
+++ b/include/pltxt2htm/ast/impl/html_node_def.inc
@@ -413,8 +413,10 @@ constexpr auto ::pltxt2htm::HtmlTd<ndebug>::operator==(this ::pltxt2htm::HtmlTd<
                                                        ::pltxt2htm::HtmlTd<ndebug> const&) noexcept -> bool = default;
 
 template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::HtmlTh<ndebug>::HtmlTh(::pltxt2htm::Ast<ndebug>&& subast_) noexcept
-    : subast(::std::move(subast_)) {
+constexpr ::pltxt2htm::HtmlTh<ndebug>::HtmlTh(::pltxt2htm::Ast<ndebug>&& subast_,
+                                              ::pltxt2htm::MdTableAlign align) noexcept
+    : subast(::std::move(subast_)),
+      align_{align} {
 }
 
 template<::pltxt2htm::Contracts ndebug>

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -851,7 +851,15 @@ entry:
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_th().get_subast(),
                                                                                   ::pltxt2htm::NodeKind::html_th, 0));
                 ++current_index;
-                result.append(u8"<th>");
+                result.append(u8"<th");
+                auto const align = node.as_html_th().get_align();
+                if (align == ::pltxt2htm::MdTableAlign::center) {
+                    result.append(u8" style=\"text-align:center\"");
+                }
+                else if (align == ::pltxt2htm::MdTableAlign::right) {
+                    result.append(u8" style=\"text-align:right\"");
+                }
+                result.push_back(u8'>');
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_thead: {

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -929,9 +929,6 @@ entry:
                 else if (align == ::pltxt2htm::MdTableAlign::right) {
                     result.append(u8" style=\"text-align:right\"");
                 }
-                else if (align != ::pltxt2htm::MdTableAlign::left) {
-                    pltxt2htm_unreachable(u8"Invalid table header alignment value.");
-                }
                 result.push_back(u8'>');
                 goto entry;
             }

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -929,6 +929,9 @@ entry:
                 else if (align == ::pltxt2htm::MdTableAlign::right) {
                     result.append(u8" style=\"text-align:right\"");
                 }
+                else if (align != ::pltxt2htm::MdTableAlign::left) {
+                    pltxt2htm_unreachable(u8"Invalid table header alignment value.");
+                }
                 result.push_back(u8'>');
                 goto entry;
             }

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -921,7 +921,15 @@ entry:
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_th().get_subast(),
                                                                                   ::pltxt2htm::NodeKind::html_th, 0));
                 ++current_index;
-                result.append(u8"<th>");
+                result.append(u8"<th");
+                auto const align = node.as_html_th().get_align();
+                if (align == ::pltxt2htm::MdTableAlign::center) {
+                    result.append(u8" style=\"text-align:center\"");
+                }
+                else if (align == ::pltxt2htm::MdTableAlign::right) {
+                    result.append(u8" style=\"text-align:right\"");
+                }
+                result.push_back(u8'>');
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_thead: {

--- a/include/pltxt2htm/details/parser/frame_concext.hh
+++ b/include/pltxt2htm/details/parser/frame_concext.hh
@@ -1283,6 +1283,7 @@ public:
     constexpr auto get_md_cell_align(this auto&& self) noexcept -> ::pltxt2htm::MdTableAlign {
         auto&& context_data_ref = self.context_data;
         pltxt2htm_assert(context_data_ref.kind == ::pltxt2htm::NodeKind::html_td ||
+                             context_data_ref.kind == ::pltxt2htm::NodeKind::html_th ||
                              context_data_ref.kind == ::pltxt2htm::NodeKind::md_th ||
                              context_data_ref.kind == ::pltxt2htm::NodeKind::md_td,
                          u8"context kind mismatch");

--- a/include/pltxt2htm/details/parser/frame_concext.hh
+++ b/include/pltxt2htm/details/parser/frame_concext.hh
@@ -353,8 +353,6 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_tr:
             [[fallthrough]];
-        case ::pltxt2htm::NodeKind::html_th:
-            [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_thead:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_tbody:
@@ -395,6 +393,8 @@ public:
             ::std::construct_at(::std::addressof(this->pltext), ::std::move(other.pltext));
             return;
         }
+        case ::pltxt2htm::NodeKind::html_th:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_td:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_th:

--- a/include/pltxt2htm/details/parser/frame_concext.hh
+++ b/include/pltxt2htm/details/parser/frame_concext.hh
@@ -114,7 +114,7 @@ public:
 /**
  * @brief Context for an individual table cell during parsing.
  *
- * Stores the cell text content and its alignment for md_th / md_td nodes.
+ * Stores the cell text content and its alignment for md_th / md_td / html_th / html_td nodes.
  */
 class ParserFrameContextWithMdCellInfo {
 public:
@@ -635,8 +635,6 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_tr:
             [[fallthrough]];
-        case ::pltxt2htm::NodeKind::html_th:
-            [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_thead:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_tbody:
@@ -677,6 +675,8 @@ public:
             ::std::destroy_at(::std::addressof(this->pltext));
             return;
         }
+        case ::pltxt2htm::NodeKind::html_th:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_td:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_th:
@@ -950,8 +950,6 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_tr:
             [[fallthrough]];
-        case ::pltxt2htm::NodeKind::html_th:
-            [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_thead:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_tbody:
@@ -1049,6 +1047,8 @@ public:
         case ::pltxt2htm::NodeKind::md_link: {
             return context_data_ref.url_info.pltext;
         }
+        case ::pltxt2htm::NodeKind::html_th:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_td:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_th:

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -1374,15 +1374,16 @@ entry:
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
                     }
-                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_th_tag<ndebug>(
+                    if (auto opt_th_tag = ::pltxt2htm::details::try_parse_th_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
                             ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
-                        opt_tag_len.has_value()) {
-                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        opt_th_tag.has_value()) {
+                        auto&& [tag_len, align] = opt_th_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 3;
                         call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                             ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::details::ParserFrameContextWithMdCellInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), align},
                                 ::pltxt2htm::NodeKind::html_th},
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
@@ -2091,7 +2092,8 @@ entry:
                             opt_tag_len.has_value()) {
                             // parsing end tag </th> successed
                             ::std::size_t const staged_index{current_index};
-                            ::pltxt2htm::HtmlTh staged_node(::std::move(result));
+                            auto align = frame.get_md_cell_align();
+                            ::pltxt2htm::HtmlTh staged_node(::std::move(result), align);
                             call_stack.pop();
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(
@@ -2637,7 +2639,9 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_th: {
-                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlTh<ndebug>{::std::move(subast)}));
+                auto align = frame.get_md_cell_align();
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlTh<ndebug>{::std::move(subast), align}));
                 parent_index += staged_index;
                 goto entry;
             }

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -506,28 +506,6 @@ constexpr auto try_parse_tr_tag(::fast_io::u8string_view pltext, ::pltxt2htm::No
 }
 
 /**
- * @brief Parse &lt;th&gt; and validate parent container type.
- * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
- * @param[in] pltext The input text to parse, starting after `<t`.
- * @param[in] nested_tag_type Current parent tag type from parsing context.
- * @return Matched tag length when valid under &lt;tr&gt;; otherwise nullopt.
- */
-template<::pltxt2htm::Contracts ndebug>
-[[nodiscard]]
-constexpr auto try_parse_th_tag(::fast_io::u8string_view pltext, ::pltxt2htm::NodeKind const nested_tag_type) noexcept
-    -> ::exception::optional<::std::size_t> {
-    auto opt_tag_len =
-        ::pltxt2htm::details::try_parse_bare_tag<ndebug, ::pltxt2htm::details::U8LiteralString{u8"h"}>(pltext);
-    if (opt_tag_len.has_value() == false) {
-        return ::exception::nullopt_t{};
-    }
-    if (nested_tag_type != ::pltxt2htm::NodeKind::html_tr) {
-        return ::exception::nullopt_t{};
-    }
-    return opt_tag_len;
-}
-
-/**
  * @brief Parse a CSS text-align value to a MdTableAlign.
  * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled.
  * @param[in] value The text-align value string (e.g. "center", "CENTER").
@@ -550,12 +528,157 @@ constexpr auto parse_text_align_value(::fast_io::u8string_view value) noexcept
 }
 
 /**
- * @brief Return type of try_parse_td_tag: tag length and cell alignment.
+ * @brief Return type of try_parse_th_tag and try_parse_td_tag: tag length and cell alignment.
  */
 struct TryParseTdTagResult {
     ::std::size_t tag_len; ///< Length of the matched tag up to the closing `>`.
     ::pltxt2htm::MdTableAlign align; ///< Cell alignment parsed from `style="text-align:..."`.
 };
+
+/**
+ * @brief Parse &lt;th&gt; (optionally with `style="text-align:..."`) and validate parent container type.
+ * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
+ * @param[in] pltext The input text to parse, starting after `<t`.
+ * @param[in] nested_tag_type Current parent tag type from parsing context.
+ * @return Parsed tag length and alignment when valid under &lt;tr&gt;; otherwise nullopt.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_th_tag(::fast_io::u8string_view pltext, ::pltxt2htm::NodeKind const nested_tag_type) noexcept
+    -> ::exception::optional<TryParseTdTagResult> {
+    if (::pltxt2htm::details::is_prefix_match<ndebug, ::pltxt2htm::details::U8LiteralString{u8"h"}>(pltext) == false) {
+        return ::exception::nullopt_t{};
+    }
+    if (nested_tag_type != ::pltxt2htm::NodeKind::html_tr) {
+        return ::exception::nullopt_t{};
+    }
+
+    ::std::size_t pos{1}; // skip past "h"
+    ::pltxt2htm::MdTableAlign align{::pltxt2htm::MdTableAlign::left};
+
+    while (pos < pltext.size()) {
+        // skip whitespace
+        while (pos < pltext.size() && (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
+                                       ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
+            ++pos;
+        }
+        if (pos >= pltext.size()) {
+            return ::exception::nullopt_t{};
+        }
+        if (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'>') {
+            return TryParseTdTagResult{pos, align};
+        }
+
+        // parse attribute name
+        ::std::size_t const attr_start{pos};
+        while (pos < pltext.size() && ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'=' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'>' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8' ' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'\t' &&
+               ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'/') {
+            ++pos;
+        }
+        ::fast_io::u8string_view const attr_name{pltext.data() + attr_start, pos - attr_start};
+
+        // skip whitespace before '='
+        while (pos < pltext.size() && (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
+                                       ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
+            ++pos;
+        }
+        if (pos >= pltext.size() || ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'=') {
+            return ::exception::nullopt_t{};
+        }
+        ++pos; // skip '='
+
+        // skip whitespace after '='
+        while (pos < pltext.size() && (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
+                                       ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
+            ++pos;
+        }
+        if (pos >= pltext.size()) {
+            return ::exception::nullopt_t{};
+        }
+
+        // parse quoted attribute value
+        char8_t const quote{::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos)};
+        if (quote != u8'"' && quote != u8'\'') {
+            return ::exception::nullopt_t{};
+        }
+        ++pos; // skip opening quote
+        ::std::size_t const val_start{pos};
+        while (pos < pltext.size() && ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != quote) {
+            ++pos;
+        }
+        if (pos >= pltext.size()) {
+            return ::exception::nullopt_t{};
+        }
+        ::fast_io::u8string_view const attr_val{pltext.data() + val_start, pos - val_start};
+        ++pos; // skip closing quote
+
+        // only lowercase "style" attribute is checked for text-align
+        if (::pltxt2htm::details::is_prefix_match<ndebug, ::pltxt2htm::details::U8LiteralString{u8"style"}>(
+                attr_name) &&
+            attr_name.size() == 5) {
+            // parse CSS property:value pairs from the style value
+            ::std::size_t css_pos{};
+            while (css_pos < attr_val.size()) {
+                // skip leading whitespace
+                while (css_pos < attr_val.size() &&
+                       (::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) == u8' ' ||
+                        ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) == u8'\t')) {
+                    ++css_pos;
+                }
+                if (css_pos >= attr_val.size()) {
+                    break;
+                }
+
+                // parse CSS property name (text-align)
+                ::std::size_t const css_prop_start{css_pos};
+                while (css_pos < attr_val.size() &&
+                       ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) != u8':') {
+                    ++css_pos;
+                }
+                if (css_pos >= attr_val.size()) {
+                    break;
+                }
+                ::fast_io::u8string_view const css_prop{attr_val.data() + css_prop_start,
+                                                        css_pos - css_prop_start};
+                ++css_pos; // skip ':'
+
+                // skip whitespace before value
+                while (css_pos < attr_val.size() &&
+                       (::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) == u8' ' ||
+                        ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) == u8'\t')) {
+                    ++css_pos;
+                }
+
+                // parse CSS value
+                ::std::size_t const css_val_start{css_pos};
+                while (css_pos < attr_val.size() &&
+                       ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) != u8';') {
+                    ++css_pos;
+                }
+                ::fast_io::u8string_view const css_val{attr_val.data() + css_val_start,
+                                                       css_pos - css_val_start};
+                if (css_pos < attr_val.size()) {
+                    ++css_pos; // skip ';'
+                }
+
+                // check text-align property
+                static constexpr ::pltxt2htm::details::U8LiteralString text_align{u8"text-align"};
+                if (css_prop.size() == text_align.size() &&
+                    ::pltxt2htm::details::is_prefix_match<ndebug, text_align>(css_prop)) {
+                    auto opt_align = ::pltxt2htm::details::parse_text_align_value(css_val);
+                    if (opt_align.has_value()) {
+                        align = opt_align.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    }
+                }
+            }
+        }
+    }
+
+    return ::exception::nullopt_t{};
+}
 
 /**
  * @brief Parse &lt;td&gt; (optionally with `style="text-align:..."`) and validate parent container type.

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -601,7 +601,7 @@ constexpr auto try_parse_th_tag(::fast_io::u8string_view pltext, ::pltxt2htm::No
 
         // parse quoted attribute value
         char8_t const quote{::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos)};
-        if (quote != u8'"' && quote != u8'\'') {
+        if (quote != u8'\"' && quote != u8'\'') {
             return ::exception::nullopt_t{};
         }
         ++pos; // skip opening quote
@@ -616,64 +616,63 @@ constexpr auto try_parse_th_tag(::fast_io::u8string_view pltext, ::pltxt2htm::No
         ++pos; // skip closing quote
 
         // only lowercase "style" attribute is checked for text-align
-        if (::pltxt2htm::details::is_prefix_match<ndebug, ::pltxt2htm::details::U8LiteralString{u8"style"}>(
-                attr_name) &&
-            attr_name.size() == 5) {
-            // parse CSS property:value pairs from the style value
-            ::std::size_t css_pos{};
-            while (css_pos < attr_val.size()) {
-                // skip leading whitespace
-                while (css_pos < attr_val.size() &&
-                       (::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) == u8' ' ||
-                        ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) == u8'\t')) {
-                    ++css_pos;
-                }
-                if (css_pos >= attr_val.size()) {
-                    break;
-                }
-
-                // parse CSS property name (text-align)
-                ::std::size_t const css_prop_start{css_pos};
-                while (css_pos < attr_val.size() &&
-                       ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) != u8':') {
-                    ++css_pos;
-                }
-                if (css_pos >= attr_val.size()) {
-                    break;
-                }
-                ::fast_io::u8string_view const css_prop{attr_val.data() + css_prop_start,
-                                                        css_pos - css_prop_start};
-                ++css_pos; // skip ':'
-
-                // skip whitespace before value
-                while (css_pos < attr_val.size() &&
-                       (::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) == u8' ' ||
-                        ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) == u8'\t')) {
-                    ++css_pos;
-                }
-
-                // parse CSS value
-                ::std::size_t const css_val_start{css_pos};
-                while (css_pos < attr_val.size() &&
-                       ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) != u8';') {
-                    ++css_pos;
-                }
-                ::fast_io::u8string_view const css_val{attr_val.data() + css_val_start,
-                                                       css_pos - css_val_start};
-                if (css_pos < attr_val.size()) {
-                    ++css_pos; // skip ';'
-                }
-
-                // check text-align property
-                static constexpr ::pltxt2htm::details::U8LiteralString text_align{u8"text-align"};
-                if (css_prop.size() == text_align.size() &&
-                    ::pltxt2htm::details::is_prefix_match<ndebug, text_align>(css_prop)) {
-                    auto opt_align = ::pltxt2htm::details::parse_text_align_value(css_val);
-                    if (opt_align.has_value()) {
-                        align = opt_align.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-                    }
-                }
+        if (attr_name != u8"style") {
+            return ::exception::nullopt_t{};
+        }
+        // parse CSS property:value pairs from the style value
+        ::std::size_t css_pos{};
+        while (css_pos < attr_val.size()) {
+            // skip leading whitespace
+            while (css_pos < attr_val.size() &&
+                    (::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) == u8' ' ||
+                    ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) == u8'\t')) {
+                ++css_pos;
             }
+            if (css_pos >= attr_val.size()) {
+                break;
+            }
+
+            // parse CSS property name (text-align)
+            ::std::size_t const css_prop_start{css_pos};
+            while (css_pos < attr_val.size() &&
+                    ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) != u8':') {
+                ++css_pos;
+            }
+            if (css_pos >= attr_val.size()) {
+                break;
+            }
+            ::fast_io::u8string_view const css_prop{attr_val.data() + css_prop_start,
+                                                    css_pos - css_prop_start};
+            ++css_pos; // skip ':'
+
+            // skip whitespace before value
+            while (css_pos < attr_val.size() &&
+                    (::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) == u8' ' ||
+                    ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) == u8'\t')) {
+                ++css_pos;
+            }
+
+            // parse CSS value
+            ::std::size_t const css_val_start{css_pos};
+            while (css_pos < attr_val.size() &&
+                    ::pltxt2htm::details::u8string_view_index<ndebug>(attr_val, css_pos) != u8';') {
+                ++css_pos;
+            }
+            ::fast_io::u8string_view const css_val{attr_val.data() + css_val_start,
+                                                    css_pos - css_val_start};
+            if (css_pos < attr_val.size()) {
+                ++css_pos; // skip ';'
+            }
+
+            // check text-align property
+            if (css_prop != u8"text-align") {
+                return ::exception::nullopt_t{};
+            }
+            auto opt_align = ::pltxt2htm::details::parse_text_align_value(css_val);
+            if (opt_align.has_value() == false) {
+                return ::exception::nullopt_t{};
+            }
+            align = opt_align.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
         }
     }
 

--- a/include/pltxt2htm/experimental/html_parser.hh
+++ b/include/pltxt2htm/experimental/html_parser.hh
@@ -528,15 +528,16 @@ entry:
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
                     }
-                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_th_tag<ndebug>(
+                    if (auto opt_th_tag = ::pltxt2htm::details::try_parse_th_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
                             ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
-                        opt_tag_len.has_value()) {
-                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        opt_th_tag.has_value()) {
+                        auto&& [tag_len, align] = opt_th_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 3;
                         call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                             ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::details::ParserFrameContextWithMdCellInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), align},
                                 ::pltxt2htm::NodeKind::html_th},
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
@@ -1023,7 +1024,8 @@ entry:
                                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                             opt_tag_len.has_value()) {
                             ::std::size_t const staged_index{current_index};
-                            ::pltxt2htm::HtmlTh staged_node(::std::move(result));
+                            auto align = frame.get_md_cell_align();
+                            ::pltxt2htm::HtmlTh staged_node(::std::move(result), align);
                             call_stack.pop();
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(
@@ -1261,7 +1263,9 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_th: {
-                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlTh<ndebug>{::std::move(subast)}));
+                auto align = frame.get_md_cell_align();
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlTh<ndebug>{::std::move(subast), align}));
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_thead: {

--- a/tests/test_html_table.cc
+++ b/tests/test_html_table.cc
@@ -309,16 +309,116 @@ int main() {
     }
 
     {
-        // <td style="text-align:CENTER"> → uppercase → rejected
-        auto html =
-            ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td style=\"text-align:CENTER\">cell</td></tr></table>");
-        auto answer = ::fast_io::u8string_view{
-            u8"<table><tr>&lt;td&nbsp;style=&quot;text-align:CENTER&quot;&gt;cell&lt;/td&gt;</tr></table>"};
+        // <th> without style → no style attribute
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><th>header</th></tr></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><tr><th>header</th></tr></table>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
-        // <td style="text-align:Right"> → mixed case → rejected
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<table><tr><th style=\"text-align:center\">header</th></tr></table>");
+        auto answer =
+            ::fast_io::u8string_view{u8"<table><tr><th style=\"text-align:center\">header</th></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <th style="text-align:right">
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<table><tr><th style=\"text-align:right\">header</th></tr></table>");
+        auto answer =
+            ::fast_io::u8string_view{u8"<table><tr><th style=\"text-align:right\">header</th></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <th style="text-align:left"> → accepted, default align → no style attr
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<table><tr><th style=\"text-align:left\">header</th></tr></table>");
+        auto answer = ::fast_io::u8string_view{u8"<table><tr><th>header</th></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <th> with multiple attributes — unknown ones (class, id) → tag rejected, escaped
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<table><tr><th class=\"foo\" style=\"text-align:center\" id=\"bar\">header</th></tr></table>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<table><tr>&lt;th&nbsp;class=&quot;foo&quot;&nbsp;style=&quot;text-align:center&quot;&nbsp;id=&quot;bar&"
+            u8"quot;&gt;header&lt;/th&gt;</tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <th style="color:red;text-align:center"> → unknown CSS → tag rejected, escaped
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<table><tr><th style=\"color:red;text-align:center\">header</th></tr></table>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<table><tr>&lt;th&nbsp;style=&quot;color:red;text-align:center&quot;&gt;header&lt;/th&gt;</tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <th style="text-align:center;color:red"> → unknown CSS → tag rejected, escaped
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<table><tr><th style=\"text-align:center;color:red\">header</th></tr></table>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<table><tr>&lt;th&nbsp;style=&quot;text-align:center;color:red&quot;&gt;header&lt;/th&gt;</tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    // ── <th> uppercase text-align values rejected ──
+
+    {
+        // <th style="text-align:LEFT"> → uppercase → rejected
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<table><tr><th style=\"text-align:LEFT\">header</th></tr></table>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<table><tr>&lt;th&nbsp;style=&quot;text-align:LEFT&quot;&gt;header&lt;/th&gt;</tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <th style="text-align:Left"> → mixed case → rejected
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<table><tr><th style=\"text-align:Left\">header</th></tr></table>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<table><tr>&lt;th&nbsp;style=&quot;text-align:Left&quot;&gt;header&lt;/th&gt;</tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <th style="text-align:CENTER"> → uppercase → rejected
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<table><tr><th style=\"text-align:CENTER\">header</th></tr></table>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<table><tr>&lt;th&nbsp;style=&quot;text-align:CENTER&quot;&gt;header&lt;/th&gt;</tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <th style="text-align:Right"> → mixed case → rejected
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<table><tr><th style=\"text-align:Right\">header</th></tr></table>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<table><tr>&lt;th&nbsp;style=&quot;text-align:Right&quot;&gt;header&lt;/th&gt;</tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    // ── <th> and <td> mixed styles ──
+
+    {
+        // <th> and <td> with different alignments in same row
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<table><tr><th style=\"text-align:center\">h</th><td style=\"text-align:right\">d</td></tr></table>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<table><tr><th style=\"text-align:center\">h</th><td style=\"text-align:right\">d</td></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // <td style="text-align:CENTER"> → uppercase → rejected
         auto html =
             ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td style=\"text-align:Right\">cell</td></tr></table>");
         auto answer = ::fast_io::u8string_view{

--- a/tests/test_html_table.cc
+++ b/tests/test_html_table.cc
@@ -88,63 +88,63 @@ int main() {
     // ── Rejection of table-internal tags outside their valid context ──
 
     {
-        // <tr> at top level → literal text
+        // <tr> at top level -> literal text
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<tr>");
         auto answer = ::fast_io::u8string_view{u8"&lt;tr&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
-        // <td> at top level → literal text
+        // <td> at top level -> literal text
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<td>");
         auto answer = ::fast_io::u8string_view{u8"&lt;td&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
-        // <th> at top level → literal text
+        // <th> at top level -> literal text
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<th>");
         auto answer = ::fast_io::u8string_view{u8"&lt;th&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
-        // <thead> at top level → literal text
+        // <thead> at top level -> literal text
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<thead>");
         auto answer = ::fast_io::u8string_view{u8"&lt;thead&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
-        // <tbody> at top level → literal text
+        // <tbody> at top level -> literal text
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<tbody>");
         auto answer = ::fast_io::u8string_view{u8"&lt;tbody&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
-        // <tfoot> at top level → literal text
+        // <tfoot> at top level -> literal text
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<tfoot>");
         auto answer = ::fast_io::u8string_view{u8"&lt;tfoot&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
-        // <caption> at top level → literal text
+        // <caption> at top level -> literal text
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<caption>");
         auto answer = ::fast_io::u8string_view{u8"&lt;caption&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
-        // <colgroup> at top level → literal text
+        // <colgroup> at top level -> literal text
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<colgroup>");
         auto answer = ::fast_io::u8string_view{u8"&lt;colgroup&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
-        // uppercase <TR> at top level → literal text
+        // uppercase <TR> at top level -> literal text
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<TR>");
         auto answer = ::fast_io::u8string_view{u8"&lt;TR&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
@@ -221,7 +221,7 @@ int main() {
     }
 
     {
-        // <tr> inside <caption> → <tr> is rejected (wrong context)
+        // <tr> inside <caption> -> <tr> is rejected (wrong context)
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><caption><tr>x</tr></caption></table>");
         auto answer = ::fast_io::u8string_view{u8"<table><caption>&lt;tr&gt;x&lt;/tr&gt;</caption></table>"};
         pltxt2htm_test_assert_equal(html, answer);
@@ -230,7 +230,7 @@ int main() {
     // ── <td style="text-align:..."> ──
 
     {
-        // <td> without style → no style attribute
+        // <td> without style -> no style attribute
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td>cell</td></tr></table>");
         auto answer = ::fast_io::u8string_view{u8"<table><tr><td>cell</td></tr></table>"};
         pltxt2htm_test_assert_equal(html, answer);
@@ -253,7 +253,7 @@ int main() {
     }
 
     {
-        // <td style="text-align:left"> → accepted (valid), default align → no style attr
+        // <td style="text-align:left"> -> accepted (valid), default align -> no style attr
         auto html =
             ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td style=\"text-align:left\">cell</td></tr></table>");
         auto answer = ::fast_io::u8string_view{u8"<table><tr><td>cell</td></tr></table>"};
@@ -261,7 +261,7 @@ int main() {
     }
 
     {
-        // <td> with multiple attributes — unknown attributes (class, id) → tag rejected, escaped
+        // <td> with multiple attributes — unknown attributes (class, id) -> tag rejected, escaped
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"<table><tr><td class=\"foo\" style=\"text-align:center\" id=\"bar\">cell</td></tr></table>");
         auto answer = ::fast_io::u8string_view{
@@ -271,7 +271,7 @@ int main() {
     }
 
     {
-        // <td style="color:red;text-align:center"> → unknown CSS → tag rejected, escaped
+        // <td style="color:red;text-align:center"> -> unknown CSS -> tag rejected, escaped
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"<table><tr><td style=\"color:red;text-align:center\">cell</td></tr></table>");
         auto answer = ::fast_io::u8string_view{
@@ -280,7 +280,7 @@ int main() {
     }
 
     {
-        // <td style="text-align:center;color:red"> → unknown CSS → tag rejected, escaped
+        // <td style="text-align:center;color:red"> -> unknown CSS -> tag rejected, escaped
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"<table><tr><td style=\"text-align:center;color:red\">cell</td></tr></table>");
         auto answer = ::fast_io::u8string_view{
@@ -291,7 +291,7 @@ int main() {
     // ── uppercase text-align values rejected ──
 
     {
-        // <td style="text-align:LEFT"> → uppercase → rejected
+        // <td style="text-align:LEFT"> -> uppercase -> rejected
         auto html =
             ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td style=\"text-align:LEFT\">cell</td></tr></table>");
         auto answer = ::fast_io::u8string_view{
@@ -300,7 +300,7 @@ int main() {
     }
 
     {
-        // <td style="text-align:Left"> → mixed case → rejected
+        // <td style="text-align:Left"> -> mixed case -> rejected
         auto html =
             ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td style=\"text-align:Left\">cell</td></tr></table>");
         auto answer = ::fast_io::u8string_view{
@@ -309,7 +309,7 @@ int main() {
     }
 
     {
-        // <th> without style → no style attribute
+        // <th> without style -> no style attribute
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><th>header</th></tr></table>");
         auto answer = ::fast_io::u8string_view{u8"<table><tr><th>header</th></tr></table>"};
         pltxt2htm_test_assert_equal(html, answer);
@@ -333,7 +333,7 @@ int main() {
     }
 
     {
-        // <th style="text-align:left"> → accepted, default align → no style attr
+        // <th style="text-align:left"> -> accepted, default align -> no style attr
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"<table><tr><th style=\"text-align:left\">header</th></tr></table>");
         auto answer = ::fast_io::u8string_view{u8"<table><tr><th>header</th></tr></table>"};
@@ -341,7 +341,7 @@ int main() {
     }
 
     {
-        // <th> with multiple attributes — unknown ones (class, id) → tag rejected, escaped
+        // <th> with multiple attributes — unknown ones (class, id) -> tag rejected, escaped
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"<table><tr><th class=\"foo\" style=\"text-align:center\" id=\"bar\">header</th></tr></table>");
         auto answer = ::fast_io::u8string_view{
@@ -351,7 +351,7 @@ int main() {
     }
 
     {
-        // <th style="color:red;text-align:center"> → unknown CSS → tag rejected, escaped
+        // <th style="color:red;text-align:center"> -> unknown CSS -> tag rejected, escaped
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"<table><tr><th style=\"color:red;text-align:center\">header</th></tr></table>");
         auto answer = ::fast_io::u8string_view{
@@ -360,7 +360,7 @@ int main() {
     }
 
     {
-        // <th style="text-align:center;color:red"> → unknown CSS → tag rejected, escaped
+        // <th style="text-align:center;color:red"> -> unknown CSS -> tag rejected, escaped
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"<table><tr><th style=\"text-align:center;color:red\">header</th></tr></table>");
         auto answer = ::fast_io::u8string_view{
@@ -371,7 +371,7 @@ int main() {
     // ── <th> uppercase text-align values rejected ──
 
     {
-        // <th style="text-align:LEFT"> → uppercase → rejected
+        // <th style="text-align:LEFT"> -> uppercase -> rejected
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"<table><tr><th style=\"text-align:LEFT\">header</th></tr></table>");
         auto answer = ::fast_io::u8string_view{
@@ -380,7 +380,7 @@ int main() {
     }
 
     {
-        // <th style="text-align:Left"> → mixed case → rejected
+        // <th style="text-align:Left"> -> mixed case -> rejected
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"<table><tr><th style=\"text-align:Left\">header</th></tr></table>");
         auto answer = ::fast_io::u8string_view{
@@ -389,7 +389,7 @@ int main() {
     }
 
     {
-        // <th style="text-align:CENTER"> → uppercase → rejected
+        // <th style="text-align:CENTER"> -> uppercase -> rejected
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"<table><tr><th style=\"text-align:CENTER\">header</th></tr></table>");
         auto answer = ::fast_io::u8string_view{
@@ -398,7 +398,7 @@ int main() {
     }
 
     {
-        // <th style="text-align:Right"> → mixed case → rejected
+        // <th style="text-align:Right"> -> mixed case -> rejected
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"<table><tr><th style=\"text-align:Right\">header</th></tr></table>");
         auto answer = ::fast_io::u8string_view{
@@ -418,7 +418,7 @@ int main() {
     }
 
     {
-        // <td style="text-align:CENTER"> → uppercase → rejected
+        // <td style="text-align:CENTER"> -> uppercase -> rejected
         auto html =
             ::pltxt2htm_test::pltxt4unittest(u8"<table><tr><td style=\"text-align:Right\">cell</td></tr></table>");
         auto answer = ::fast_io::u8string_view{

--- a/tests/test_html_table.cc
+++ b/tests/test_html_table.cc
@@ -333,6 +333,15 @@ int main() {
     }
 
     {
+        // <th style="text-align: center"> -> whitespace after colon accepted and normalized
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<table><tr><th style=\"text-align: center\">header</th></tr></table>");
+        auto answer =
+            ::fast_io::u8string_view{u8"<table><tr><th style=\"text-align:center\">header</th></tr></table>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
         // <th style="text-align:left"> -> accepted, default align -> no style attr
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"<table><tr><th style=\"text-align:left\">header</th></tr></table>");


### PR DESCRIPTION
## Summary

Extend the HTML table parser so that `<th>` accepts and preserves the `style="text-align:..."` attribute, matching the existing behavior for `<td>`.

## Changes

- **AST**: `HtmlTh` now stores a `MdTableAlign align_` member and exposes `get_align()`.
- **Parser**: `try_parse_th_tag` returns `{tag_len, align}` and parses `style="text-align:left|center|right"`.
- **Frame context**: `html_th` frames now carry `ParserFrameContextWithMdCellInfo` (same as `html_td/md_th/md_td`) so the alignment is available when the end tag is reached.
- **Backends**: both `for_plweb_text` and `for_plunity_text` emit `<th style="text-align:center">` / `<th style="text-align:right">` as appropriate; the default `left` produces no attribute.
- **Experimental HTML parser**: mirrored the same `html_th` alignment handling.
- **Tests**: added comprehensive cases in `tests/test_html_table.cc` covering `center`/`right`/`left`, unknown attributes, unknown CSS properties, uppercase/mixed-case values, and mixed `<th>`/`<td>` rows.

## Fixes applied during review

- `FrontendContextVariant` destructor and `get_pltext()` were updated so `html_th` is treated as an `md_cell` member, avoiding undefined behavior from accessing the wrong union variant.
- `try_parse_th_tag` now trims whitespace around CSS property/value pairs (e.g. `text-align: center`), keeping it consistent with `try_parse_td_tag`.
- Removed an inconsistent `pltxt2htm_unreachable` branch for `html_th` in `for_plweb_text`.

## Test result

```text
100% tests passed, 0 tests failed out of 68
```