### PR TITLE
fix: use roundtrip backend mode for fixedadv fuzzer

### DIFF
--- a/fuzzing/src/fixedadv_roundtrip.cc
+++ b/fuzzing/src/fixedadv_roundtrip.cc
@@ -28,8 +28,8 @@ extern "C" int LLVMFuzzerTestOneInput(::std::uint8_t const* const data, ::std::s
     auto html1_ast = ::pltxt2htm::parse_pltxt<::pltxt2htm::Contracts::quick_enforce>(::fast_io::mnp::os_c_str(str));
     ::pltxt2htm::optimize_ast<::pltxt2htm::Contracts::quick_enforce>(html1_ast);
     auto const html1 = ::pltxt2htm::details::plweb_text_backend<::pltxt2htm::Contracts::quick_enforce,
-                                                                ::pltxt2htm::details::PlWebTextBackendMode::no_latex>(
-        html1_ast, u8"_", u8"_", u8"_", u8"_", u8"_");
+                                                                ::pltxt2htm::details::PlWebTextBackendMode::roundtrip>(
+        html1_ast, u8"https://plweb.turtlesim.com", u8"_", u8"_", u8"_", u8"_");
 
     auto const html2_ast = ::pltxt2htm::experimental::parse_pltxt_html<::pltxt2htm::Contracts::quick_enforce>(
         ::fast_io::mnp::os_c_str(html1));

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * @file for_plweb_text.hh
  * @brief Advanced HTML backend for pltxt2htm
  * @details Generates full-featured HTML output with comprehensive support for
@@ -245,7 +245,7 @@ constexpr void append_html_attr_escaped(::fast_io::u8string& result, ::fast_io::
 enum class PlWebTextBackendMode : unsigned {
     pltxt4unittest = 0,
     fixedadv_html,
-    no_latex,
+    roundtrip,
 };
 
 /**
@@ -442,28 +442,36 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::pl_user: {
-                call_stack.template push<ndebug>(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                    node.as_pl_user().get_subast(), ::pltxt2htm::NodeKind::pl_user, 0));
                 ++current_index;
-                result.append(u8"<span class='RUser' data-user='");
-                auto const& user_id = node.as_pl_user().get_id();
-                // Under normal circumstances, `user_id` should never contain characters that could enable XSS in HTML
-                // attributes. To avoid masking upstream bugs (and to keep release-path performance), we only assert
-                // this in debug mode. Do not try to hide such errors by routing output through
-                // `append_html_attr_escaped`.
-                if constexpr (ndebug == ::pltxt2htm::Contracts::quick_enforce) {
-                    ::fast_io::u8string purified_user_id{};
-                    ::pltxt2htm::details::append_html_attr_escaped<ndebug>(
-                        purified_user_id, ::fast_io::u8string_view{user_id.data(), user_id.size()});
-                    bool const is_valid_user_id{purified_user_id == user_id};
-                    pltxt2htm_assert(is_valid_user_id,
-                                     u8"User ID contains characters that cannot be directly used in HTML attributes. "
-                                     u8"Please check the "
-                                     u8"user ID or use a different backend that supports escaping.");
+                if constexpr (mode == PlWebTextBackendMode::roundtrip) {
+                    call_stack.template push<ndebug>(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                        node.as_pl_user().get_subast(), ::pltxt2htm::NodeKind::text, 0));
+                    goto entry;
                 }
-                result.append(user_id);
-                result.append(u8"'>");
-                goto entry;
+                else {
+                    call_stack.template push<ndebug>(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                        node.as_pl_user().get_subast(), ::pltxt2htm::NodeKind::pl_user, 0));
+                    result.append(u8"<span class='RUser' data-user='");
+                    auto const& user_id = node.as_pl_user().get_id();
+                    // Under normal circumstances, `user_id` should never contain characters that could enable XSS in
+                    // HTML attributes. To avoid masking upstream bugs (and to keep release-path performance), we only
+                    // assert this in debug mode. Do not try to hide such errors by routing output through
+                    // `append_html_attr_escaped`.
+                    if constexpr (ndebug == ::pltxt2htm::Contracts::quick_enforce) {
+                        ::fast_io::u8string purified_user_id{};
+                        ::pltxt2htm::details::append_html_attr_escaped<ndebug>(
+                            purified_user_id, ::fast_io::u8string_view{user_id.data(), user_id.size()});
+                        bool const is_valid_user_id{purified_user_id == user_id};
+                        pltxt2htm_assert(
+                            is_valid_user_id,
+                            u8"User ID contains characters that cannot be directly used in HTML attributes. Please "
+                            u8"check the "
+                            u8"user ID or use a different backend that supports escaping.");
+                    }
+                    result.append(user_id);
+                    result.append(u8"'>");
+                    goto entry;
+                }
             }
             case ::pltxt2htm::NodeKind::pl_size: {
                 call_stack.template push<ndebug>(::pltxt2htm::details::BackendFrameContext<ndebug>(
@@ -802,7 +810,7 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_latex_inline: {
-                if constexpr (mode == PlWebTextBackendMode::no_latex) {
+                if constexpr (mode == PlWebTextBackendMode::roundtrip) {
                     continue;
                 }
                 else {
@@ -814,7 +822,7 @@ entry:
                 }
             }
             case ::pltxt2htm::NodeKind::md_latex_block: {
-                if constexpr (mode == PlWebTextBackendMode::no_latex) {
+                if constexpr (mode == PlWebTextBackendMode::roundtrip) {
                     continue;
                 }
                 else {
@@ -1374,14 +1382,14 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_latex_inline: {
-                pltxt2htm_assert(mode != PlWebTextBackendMode::no_latex,
-                                 u8"Unexpected md_latex_inline node in no_latex mode");
+                pltxt2htm_assert(mode != PlWebTextBackendMode::roundtrip,
+                                 u8"Unexpected md_latex_inline node in roundtrip mode");
                 result.push_back(u8'$');
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_latex_block: {
-                pltxt2htm_assert(mode != PlWebTextBackendMode::no_latex,
-                                 u8"Unexpected md_latex_block node in no_latex mode");
+                pltxt2htm_assert(mode != PlWebTextBackendMode::roundtrip,
+                                 u8"Unexpected md_latex_block node in roundtrip mode");
                 result.append(u8"$$");
                 goto entry;
             }

--- a/tests/precompile.cpp
+++ b/tests/precompile.cpp
@@ -75,11 +75,12 @@ PLTXT2HTM_VISIBILITY_DEFAULT auto pltxt4htmlunittest(::fast_io::u8string_view pl
 #if __has_cpp_attribute(__gnu__::__pure__)
 [[__gnu__::__pure__]]
 #endif
-PLTXT2HTM_VISIBILITY_DEFAULT auto pltxt2nolatex_htmld(::fast_io::u8string_view pltext) noexcept -> ::fast_io::u8string {
+PLTXT2HTM_VISIBILITY_DEFAULT auto pltxt2roundtrip_htmld(::fast_io::u8string_view pltext) noexcept
+    -> ::fast_io::u8string {
     auto ast = ::pltxt2htm::parse_pltxt<::pltxt2htm::Contracts::quick_enforce>(pltext);
     ::pltxt2htm::optimize_ast<::pltxt2htm::Contracts::quick_enforce>(ast);
     return ::pltxt2htm::details::plweb_text_backend<::pltxt2htm::Contracts::quick_enforce,
-                                                    ::pltxt2htm::details::PlWebTextBackendMode::no_latex>(
+                                                    ::pltxt2htm::details::PlWebTextBackendMode::roundtrip>(
         ast, u8"_", u8"_", u8"_", u8"_", u8"_");
 }
 

--- a/tests/precompile.hh
+++ b/tests/precompile.hh
@@ -64,7 +64,7 @@ auto pltxt2fixedadv_htmld(::fast_io::u8string_view pltext, ::fast_io::u8string_v
 #if __has_cpp_attribute(__gnu__::__pure__)
 [[__gnu__::__pure__]]
 #endif
-auto pltxt2nolatex_htmld(::fast_io::u8string_view) noexcept -> ::fast_io::u8string;
+auto pltxt2roundtrip_htmld(::fast_io::u8string_view) noexcept -> ::fast_io::u8string;
 
 void assert_true_impl(::fast_io::u8string_view file, ::std::size_t line, ::fast_io::u8string_view expr,
                       bool cond) noexcept;

--- a/tests/test_html_a_tag.cc
+++ b/tests/test_html_a_tag.cc
@@ -147,7 +147,7 @@ int main() {
     // roundtrip idempotency for ' in auto-link URL
     {
         auto pass1 =
-            ::pltxt2htm_test::pltxt2nolatex_htmld(::fast_io::u8string_view{u8"https://example.com/path'with'quote"});
+            ::pltxt2htm_test::pltxt2roundtrip_htmld(::fast_io::u8string_view{u8"https://example.com/path'with'quote"});
         auto pass2 = ::pltxt2htm_test::pltxt4htmlunittest(::fast_io::mnp::os_c_str(pass1));
         pltxt2htm_test_assert_equal(pass2, pass1);
     }

--- a/tests/test_latex.cc
+++ b/tests/test_latex.cc
@@ -62,18 +62,18 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
     }
 
-    // no_latex mode must not double-skip nodes after $...$
+    // roundtrip mode must not double-skip nodes after $...$
     // regression test for roundtrip fuzzer finding
     {
         auto pltext = ::fast_io::u8string_view{u8"$a$b"};
-        auto html = ::pltxt2htm_test::pltxt2nolatex_htmld(pltext);
+        auto html = ::pltxt2htm_test::pltxt2roundtrip_htmld(pltext);
         auto answer = ::fast_io::u8string_view{u8"b"};
         pltxt2htm_test_assert_equal(html, answer);
     }
     // same for md_latex_block
     {
         auto pltext = ::fast_io::u8string_view{u8"$$a$$b"};
-        auto html = ::pltxt2htm_test::pltxt2nolatex_htmld(pltext);
+        auto html = ::pltxt2htm_test::pltxt2roundtrip_htmld(pltext);
         auto answer = ::fast_io::u8string_view{u8"b"};
         pltxt2htm_test_assert_equal(html, answer);
     }

--- a/tests/test_pl_size_tag.cc
+++ b/tests/test_pl_size_tag.cc
@@ -26,13 +26,13 @@ int main() {
     }
 
     {
-        auto html = ::pltxt2htm_test::pltxt2nolatex_htmld(u8"<size=1>hello</size>");
+        auto html = ::pltxt2htm_test::pltxt2roundtrip_htmld(u8"<size=1>hello</size>");
         auto reparsed_html = ::pltxt2htm_test::pltxt4htmlunittest(::fast_io::u8string_view{html.data(), html.size()});
         pltxt2htm_test_assert_equal(reparsed_html, html);
     }
 
     {
-        auto html = ::pltxt2htm_test::pltxt2nolatex_htmld(u8"<size=00>hello</size>");
+        auto html = ::pltxt2htm_test::pltxt2roundtrip_htmld(u8"<size=00>hello</size>");
         auto reparsed_html = ::pltxt2htm_test::pltxt4htmlunittest(::fast_io::u8string_view{html.data(), html.size()});
         pltxt2htm_test_assert_equal(reparsed_html, html);
     }

--- a/tests/test_pl_user_tag.cc
+++ b/tests/test_pl_user_tag.cc
@@ -99,5 +99,11 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
     }
 
+    {
+        auto html = ::pltxt2htm_test::pltxt2roundtrip_htmld(u8"<user=xxx><i>test</i></user>");
+        auto answer = ::fast_io::u8string_view{u8"<em>test</em>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
     return 0;
 }


### PR DESCRIPTION
Rename the no-latex backend mode to roundtrip and use it for the fixedadv-roundtrip fuzzer. In this mode, omit backend-private output that the HTML parser should not be expected to understand, including LaTeX nodes and PL user wrappers.

Also use a valid host in the roundtrip fuzzer so generated internal links can be parsed back as anchors.