### PR TITLE
feat(ci): add clang scan-build static analysis to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,21 @@ jobs:
         run: |
           docker build -f tests/docker/x86_64-linux-gnu-msan/Dockerfile -t x86_64-linux-gnu-test-msan .
 
+  x86_64-linux-gnu-scan-build:
+    strategy:
+      fail-fast: false
+
+    name: x86_64-linux-gnu (tests/, clang scan-build)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build docker image (scan-build runs during build)
+        run: |
+          docker build -f tests/docker/x86_64-linux-gnu-scan_build/Dockerfile -t x86_64-linux-gnu-scan-build .
+
   x86_64-windows-msvc-cmd:
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ A: Memory safety is a matter of engineering practice, not language choice alone.
 * Extensive assertions in debug builds for memory and logic correctness.
 * Over 95% test coverage.
 * CI asan testing on every commit with both Clang and GCC.
+* CI clang scan-build static analysis that fails the build on any reported bug.
 * At least 6 hours of Clang fuzzing (with ASan or UBSan) before every release.
 
 > Q: Why use C++ instead of a language with VM?

--- a/tests/docker/x86_64-linux-gnu-scan_build/Dockerfile
+++ b/tests/docker/x86_64-linux-gnu-scan_build/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:26.04
+
+RUN apt update && apt install -y --no-install-recommends clang clang-tools cmake ninja-build lld perl
+
+WORKDIR /pltxt2htm
+COPY include/ /pltxt2htm/include/
+COPY tests/ /pltxt2htm/tests/
+
+RUN scan-build --status-bugs --use-cc=clang --use-c++=clang++ -o /scan-build-report \
+        cmake -S tests -B build -GNinja -DCMAKE_BUILD_TYPE=Debug \
+    && scan-build --status-bugs --use-cc=clang --use-c++=clang++ -o /scan-build-report \
+        cmake --build build -v \
+    && ctest --test-dir build -V -j $(nproc)

--- a/tests/docker/x86_64-linux-gnu-scan_build/README.md
+++ b/tests/docker/x86_64-linux-gnu-scan_build/README.md
@@ -1,0 +1,8 @@
+Build and run clang static analyzer (scan-build) on all tests in CI.
+
+Tests run during `docker build` (single RUN command with cmake + scan-build + ctest).
+
+Build:
+```
+docker build -f tests/docker/x86_64-linux-gnu-scan_build/Dockerfile -t x86_64-linux-gnu-scan-build .
+```


### PR DESCRIPTION
Add tests/docker/x86_64-linux-gnu-scan_build image that configures, builds and analyzes the test suite with clang scan-build (--status-bugs fails the build on analyzer findings) and then runs ctest. Wire it as a new x86_64-linux-gnu-scan-build job in .github/workflows/test.yml.