### PR TITLE
ci(msan): split Docker build and test phases to fix seccomp issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,9 +109,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Build docker image (tests run during build)
+      - name: Build docker image
         run: |
-          docker build -f tests/docker/x86_64-linux-gnu-msan/Dockerfile -t x86_64-linux-gnu-test-msan .
+          docker build -f tests/docker/x86_64-linux-gnu-msan/Dockerfile -t x86_64-linux-gnu-tests-msan .
+
+      - name: Run tests
+        run: |
+          docker run --rm --security-opt seccomp=unconfined x86_64-linux-gnu-tests-msan
 
   x86_64-linux-gnu-scan-build:
     strategy:

--- a/tests/docker/x86_64-linux-gnu-msan/Dockerfile
+++ b/tests/docker/x86_64-linux-gnu-msan/Dockerfile
@@ -7,5 +7,9 @@ COPY include/ /pltxt2htm/include/
 COPY tests/ /pltxt2htm/tests/
 
 RUN cmake -S tests -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DPLTXT2HTM_SANITIZER=memory -DCMAKE_CXX_COMPILER=clang++ \
-    && cmake --build build -v \
-    && ctest --test-dir build -V -j $(nproc)
+    && cmake --build build -v
+
+# Tests run via `docker run --security-opt seccomp=unconfined` because MSan needs
+# personality(ADDR_NO_RANDOMIZE) to disable ASLR, which Docker's default seccomp
+# profile blocks (see README.md).
+CMD ["/bin/sh", "-c", "ctest --test-dir build -V -j $(nproc)"]

--- a/tests/docker/x86_64-linux-gnu-msan/README.md
+++ b/tests/docker/x86_64-linux-gnu-msan/README.md
@@ -1,35 +1,30 @@
 MemorySanitizer test image
 
-Tests run during `docker build` (single RUN command with cmake + ctest).
+Build (compiles the tests with `-fsanitize=memory`):
 
-Build:
 ```
-docker build -t pltxt2htm-msan .
+docker build -f tests/docker/x86_64-linux-gnu-msan/Dockerfile -t x86_64-linux-gnu-tests-msan .
+```
+
+Run (executes ctest inside the image):
+
+```
+docker run --rm --security-opt seccomp=unconfined x86_64-linux-gnu-tests-msan
 ```
 
 ## Seccomp issue
 
-Docker's default seccomp profile only allows `personality()` with arguments
-`PER_LINUX(0)`, `PER_LINUX32(1024)`, or `PER_MASK(0xFFFFFFFF)`.
-MSan calls `personality(ADDR_NO_RANDOMIZE=0x40000)` at startup to disable ASLR,
-which is blocked by the default profile, causing a CHECK failure during build:
+MSan calls `personality(ADDR_NO_RANDOMIZE)` at startup to disable ASLR. Docker's
+default seccomp profile only allows `personality()` with arguments `PER_LINUX(0)`,
+`PER_LINUX32(1024)`, or `PER_MASK(0xFFFFFFFF)`, so this call is blocked and MSan
+aborts during startup:
 
 ```
 MemorySanitizer: CHECK failed: msan_linux.cpp:193
   "((personality(old_personality | ADDR_NO_RANDOMIZE))) != ((-1))"
 ```
 
-This only affects Docker Desktop (Windows/macOS) and environments with strict
-seccomp profiles. GitHub Actions runners are unaffected.
-
-## Workarounds
-
-Since tests run at build time, runtime `--security-opt` flags do not apply.
-Options:
-
-1. **Split build and test** — move `ctest` to `CMD`, then `docker run --security-opt seccomp=unconfined`
-2. **BuildKit `--security=insecure`** — requires `# syntax=docker/dockerfile:1` and
-   `DOCKER_BUILDKIT=1`:
-   ```dockerfile
-   RUN --security=insecure cmake ... && cmake --build build -v && ctest ...
-   ```
+Tests therefore do not run during `docker build`; they run via
+`docker run --security-opt seccomp=unconfined`. This affects Docker Desktop
+(Windows/macOS) and environments with strict seccomp profiles. GitHub Actions
+runners are unaffected, but the `--security-opt` flag is harmless there.


### PR DESCRIPTION
MSan calls personality(ADDR_NO_RANDOMIZE) at startup to disable ASLR. Docker's default seccomp profile blocks this syscall, causing a CHECK failure when tests run during `docker build`.

Move `ctest` from a RUN step to CMD so tests execute at `docker run` time, where `--security-opt seccomp=unconfined` can be applied. Update the GitHub Actions workflow and README accordingly.