### PR TITLE
feat: support Unity TextMeshPro <link="url"> link tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Quantum-Physics tags:
 | `user` | Supported |
 | `size` | Supported |
 | `external` | Supported |
+| `link` (Unity TextMeshPro link) | Supported |
 | `i` | Supported |
 | `b` | Supported |
 | `u` (Unity TextMeshPro underline) | Supported |

--- a/cxxmodule/pltxt2htm/pltxt2htm.cppm
+++ b/cxxmodule/pltxt2htm/pltxt2htm.cppm
@@ -177,6 +177,7 @@ using ::pltxt2htm::PlDiscussion;
 using ::pltxt2htm::PlUser;
 using ::pltxt2htm::PlSize;
 using ::pltxt2htm::PlExternal;
+using ::pltxt2htm::PlLink;
 using ::pltxt2htm::PlI;
 using ::pltxt2htm::PlB;
 using ::pltxt2htm::PlU;

--- a/include/pltxt2htm/ast/ast.hh
+++ b/include/pltxt2htm/ast/ast.hh
@@ -159,6 +159,7 @@ class PlTxtNode {
         ::pltxt2htm::PlDiscussion<ndebug> pl_discussion_node;
         ::pltxt2htm::PlUser<ndebug> pl_user_node;
         ::pltxt2htm::PlExternal<ndebug> pl_external_node;
+        ::pltxt2htm::PlLink<ndebug> pl_link_node;
         ::pltxt2htm::PlSize<ndebug> pl_size_node;
         ::pltxt2htm::PlI<ndebug> pl_i_node;
         ::pltxt2htm::PlB<ndebug> pl_b_node;
@@ -218,6 +219,11 @@ public:
     constexpr PlTxtNode(::pltxt2htm::PlExternal<ndebug>&& node) noexcept
         : pl_external_node(::std::move(node)),
           node_kind{::pltxt2htm::NodeKind::pl_external} {
+    }
+
+    constexpr PlTxtNode(::pltxt2htm::PlLink<ndebug>&& node) noexcept
+        : pl_link_node(::std::move(node)),
+          node_kind{::pltxt2htm::NodeKind::pl_link} {
     }
 
     constexpr PlTxtNode(::pltxt2htm::PlSize<ndebug>&& node) noexcept
@@ -863,6 +869,10 @@ public:
             new (::std::addressof(pl_external_node))::pltxt2htm::PlExternal(other.pl_external_node);
             break;
         }
+        case ::pltxt2htm::NodeKind::pl_link: {
+            new (::std::addressof(pl_link_node))::pltxt2htm::PlLink(other.pl_link_node);
+            break;
+        }
         case ::pltxt2htm::NodeKind::pl_size: {
             new (::std::addressof(pl_size_node))::pltxt2htm::PlSize(other.pl_size_node);
             break;
@@ -1419,6 +1429,10 @@ public:
         }
         case ::pltxt2htm::NodeKind::pl_external: {
             new (::std::addressof(pl_external_node))::pltxt2htm::PlExternal(::std::move(other.pl_external_node));
+            break;
+        }
+        case ::pltxt2htm::NodeKind::pl_link: {
+            new (::std::addressof(pl_link_node))::pltxt2htm::PlLink(::std::move(other.pl_link_node));
             break;
         }
         case ::pltxt2htm::NodeKind::pl_size: {
@@ -2042,6 +2056,10 @@ public:
             pl_external_node.~PlExternal();
             break;
         }
+        case ::pltxt2htm::NodeKind::pl_link: {
+            pl_link_node.~PlLink();
+            break;
+        }
         case ::pltxt2htm::NodeKind::pl_size: {
             pl_size_node.~PlSize();
             break;
@@ -2574,6 +2592,9 @@ public:
         }
         case ::pltxt2htm::NodeKind::pl_external: {
             return self.pl_external_node == other.pl_external_node;
+        }
+        case ::pltxt2htm::NodeKind::pl_link: {
+            return self.pl_link_node == other.pl_link_node;
         }
         case ::pltxt2htm::NodeKind::pl_size: {
             return self.pl_size_node == other.pl_size_node;
@@ -3773,6 +3794,13 @@ public:
         bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::pl_external};
         pltxt2htm_assert(is_type, u8"node kind mismatch");
         return ::std::forward_like<decltype(self)>(self.pl_external_node);
+    }
+
+    [[nodiscard]]
+    constexpr auto as_pl_link(this auto&& self) noexcept -> decltype(auto) {
+        bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::pl_link};
+        pltxt2htm_assert(is_type, u8"node kind mismatch");
+        return ::std::forward_like<decltype(self)>(self.pl_link_node);
     }
 
     [[nodiscard]]

--- a/include/pltxt2htm/ast/impl/physics_lab_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/physics_lab_node_decl.hh
@@ -217,6 +217,38 @@ public:
 };
 
 /**
+ * @brief Physics-Lab link tag node (Unity TextMeshPro rich text)
+ * @details Represents &lt;link=&quot;url&quot;&gt;...&lt;/link&gt; with a URL.
+ */
+template<::pltxt2htm::Contracts ndebug>
+class PlLink {
+    ::pltxt2htm::Ast<ndebug> subast;
+    ::pltxt2htm::Url url;
+
+public:
+    constexpr PlLink(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::Url&& url_) noexcept;
+    constexpr PlLink(::pltxt2htm::PlLink<ndebug> const&) noexcept;
+    constexpr PlLink(::pltxt2htm::PlLink<ndebug>&&) noexcept;
+    constexpr ~PlLink() noexcept;
+    constexpr auto operator=(::pltxt2htm::PlLink<ndebug> const&) noexcept -> ::pltxt2htm::PlLink<ndebug>& = delete;
+    constexpr auto operator=(this ::pltxt2htm::PlLink<ndebug>& self, ::pltxt2htm::PlLink<ndebug>&&) noexcept
+        -> ::pltxt2htm::PlLink<ndebug>&;
+
+    [[nodiscard]]
+    constexpr auto operator==(this PlLink const&, PlLink const&) noexcept -> bool;
+
+    [[nodiscard]]
+    constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.subast);
+    }
+
+    [[nodiscard]]
+    constexpr auto get_url(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.url);
+    }
+};
+
+/**
  * @brief Physics-Lab font size tag node
  * @details Represents &lt;size=value&gt;...&lt;/size&gt; or &lt;size=value%&gt;...&lt;/size&gt;
  *          (TMP_Text rich text) with a font size value and its unit.

--- a/include/pltxt2htm/ast/impl/physics_lab_node_def.inc
+++ b/include/pltxt2htm/ast/impl/physics_lab_node_def.inc
@@ -135,6 +135,27 @@ constexpr auto ::pltxt2htm::PlExternal<ndebug>::operator==(this ::pltxt2htm::PlE
     -> bool = default;
 
 template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::PlLink<ndebug>::PlLink(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::Url&& url_) noexcept
+    : subast(::std::move(subast_)),
+      url(::std::move(url_)) {
+}
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::PlLink<ndebug>::PlLink(::pltxt2htm::PlLink<ndebug> const&) noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::PlLink<ndebug>::PlLink(::pltxt2htm::PlLink<ndebug>&&) noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::PlLink<ndebug>::~PlLink() noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr auto ::pltxt2htm::PlLink<ndebug>::operator=(this ::pltxt2htm::PlLink<ndebug>& self,
+                                                      ::pltxt2htm::PlLink<ndebug>&&) noexcept
+    -> ::pltxt2htm::PlLink<ndebug>& = default;
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr auto ::pltxt2htm::PlLink<ndebug>::operator==(this ::pltxt2htm::PlLink<ndebug> const&,
+                                                       ::pltxt2htm::PlLink<ndebug> const&) noexcept -> bool = default;
+
+template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::PlSize<ndebug>::PlSize(::pltxt2htm::Ast<ndebug>&& subast_,
                                               ::pltxt2htm::FontSizeValue value_) noexcept
     : subast(::std::move(subast_)),

--- a/include/pltxt2htm/ast/node_kind.hh
+++ b/include/pltxt2htm/ast/node_kind.hh
@@ -225,6 +225,17 @@ constexpr auto is_md_list_ul_or_ol_type(::pltxt2htm::NodeKind const node_type) n
     return node_type == ::pltxt2htm::NodeKind::md_ul || node_type == ::pltxt2htm::NodeKind::md_ol;
 }
 
+/**
+ * @brief Whether the node kind is a URL-link container tag.
+ * @details Auto-detected bare URLs inside these tags are suppressed to avoid
+ *          nested anchors (e.g. an `<a>` inside `<link="url">...</link>`).
+ */
+[[nodiscard]]
+constexpr auto is_url_link_tag_type(::pltxt2htm::NodeKind const node_type) noexcept -> bool {
+    return node_type == ::pltxt2htm::NodeKind::pl_link || node_type == ::pltxt2htm::NodeKind::pl_external ||
+           node_type == ::pltxt2htm::NodeKind::md_link || node_type == ::pltxt2htm::NodeKind::html_a;
+}
+
 [[nodiscard]]
 constexpr auto is_plain_pltext_type(::pltxt2htm::NodeKind const node_type) noexcept -> bool {
     return !(::pltxt2htm::details::is_equal_sign_tag_type(node_type) ||

--- a/include/pltxt2htm/ast/node_kind.hh
+++ b/include/pltxt2htm/ast/node_kind.hh
@@ -44,6 +44,7 @@ enum class NodeKind : unsigned {
     pl_user, ///< Physics-Lab user reference: &lt;user=id&gt;...&lt;/user&gt;
     pl_size, ///< Physics-Lab font size: &lt;size=value&gt;...&lt;/size&gt;
     pl_external, ///< Physics-Lab external link: &lt;external=url&gt;...&lt;/external&gt;
+    pl_link, ///< Physics-Lab link (Unity TextMeshPro rich text): &lt;link=&quot;url&quot;&gt;...&lt;/link&gt;
 
     // Text formatting (shared across Physics-Lab, HTML, and Markdown)
     pl_b, ///< Bold text: &lt;b&gt;...&lt;/b&gt;, Markdown double emphasis, &lt;strong&gt; in HTML
@@ -227,10 +228,11 @@ constexpr auto is_md_list_ul_or_ol_type(::pltxt2htm::NodeKind const node_type) n
 [[nodiscard]]
 constexpr auto is_plain_pltext_type(::pltxt2htm::NodeKind const node_type) noexcept -> bool {
     return !(::pltxt2htm::details::is_equal_sign_tag_type(node_type) ||
-             node_type == ::pltxt2htm::NodeKind::pl_external || node_type == ::pltxt2htm::NodeKind::pl_size ||
-             node_type == ::pltxt2htm::NodeKind::md_block_quotes || node_type == ::pltxt2htm::NodeKind::md_link ||
-             node_type == ::pltxt2htm::NodeKind::html_span || node_type == ::pltxt2htm::NodeKind::html_a ||
-             node_type == ::pltxt2htm::NodeKind::html_td || ::pltxt2htm::details::is_md_list_ul_or_ol_type(node_type));
+             node_type == ::pltxt2htm::NodeKind::pl_external || node_type == ::pltxt2htm::NodeKind::pl_link ||
+             node_type == ::pltxt2htm::NodeKind::pl_size || node_type == ::pltxt2htm::NodeKind::md_block_quotes ||
+             node_type == ::pltxt2htm::NodeKind::md_link || node_type == ::pltxt2htm::NodeKind::html_span ||
+             node_type == ::pltxt2htm::NodeKind::html_a || node_type == ::pltxt2htm::NodeKind::html_td ||
+             ::pltxt2htm::details::is_md_list_ul_or_ol_type(node_type));
 }
 
 } // namespace details

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -338,6 +338,15 @@ entry:
                 result.push_back(u8'>');
                 goto entry;
             }
+            case ::pltxt2htm::NodeKind::pl_link: {
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_pl_link().get_subast(),
+                                                                                  ::pltxt2htm::NodeKind::pl_link, 0));
+                ++current_index;
+                result.append(u8"<link=\"");
+                result.append(node.as_pl_link().get_url().as_string());
+                result.append(u8"\">");
+                goto entry;
+            }
             case ::pltxt2htm::NodeKind::pl_user: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_pl_user().get_subast(),
                                                                                   ::pltxt2htm::NodeKind::pl_user, 0));
@@ -1205,6 +1214,10 @@ entry:
             }
             case ::pltxt2htm::NodeKind::pl_external: {
                 result.append(u8"</external>");
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_link: {
+                result.append(u8"</link>");
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::pl_user: {

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * @file for_plweb_text.hh
  * @brief Advanced HTML backend for pltxt2htm
  * @details Generates full-featured HTML output with comprehensive support for
@@ -1108,6 +1108,17 @@ entry:
                 ++current_index;
                 goto entry;
             }
+            case ::pltxt2htm::NodeKind::pl_link: {
+                result.append(u8"<a href=\"");
+                auto const& link_url = node.as_pl_link().get_url().as_string();
+                ::pltxt2htm::details::append_html_attr_escaped<ndebug>(
+                    result, ::fast_io::u8string_view{link_url.data(), link_url.size()});
+                result.append(u8"\">");
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_pl_link().get_subast(),
+                                                                                  ::pltxt2htm::NodeKind::pl_link, 0));
+                ++current_index;
+                goto entry;
+            }
             case ::pltxt2htm::NodeKind::md_image: {
                 result.append(u8"<img src=\"");
                 auto const& img_url = node.as_md_image().get_url().as_string();
@@ -1516,6 +1527,8 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::pl_external:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::pl_link:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::md_link:
                 [[fallthrough]];

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -738,6 +738,15 @@ entry:
                 ++current_index;
                 goto entry;
             }
+            case ::pltxt2htm::NodeKind::pl_link: {
+                result.append(u8"<a href=\"");
+                result.append(node.as_pl_link().get_url().as_string());
+                result.append(u8"\">");
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_pl_link().get_subast(),
+                                                                                  ::pltxt2htm::NodeKind::pl_link, 0));
+                ++current_index;
+                goto entry;
+            }
             case ::pltxt2htm::NodeKind::md_link: {
                 result.append(u8"<a href=\"");
                 result.append(node.as_md_link().get_url().as_string());
@@ -811,6 +820,8 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::pl_external:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::pl_link:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::md_link:
                 [[fallthrough]];

--- a/include/pltxt2htm/details/parser/frame_context.hh
+++ b/include/pltxt2htm/details/parser/frame_context.hh
@@ -359,6 +359,8 @@ public:
         }
         case ::pltxt2htm::NodeKind::pl_external:
             [[fallthrough]];
+        case ::pltxt2htm::NodeKind::pl_link:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_link: {
             pltxt2htm_assert_context_branch(*this, ContextBranch::url_info);
             ::std::construct_at(::std::addressof(this->url_info), ::std::move(other.url_info));
@@ -664,6 +666,8 @@ public:
             return;
         }
         case ::pltxt2htm::NodeKind::pl_external:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::pl_link:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_link: {
             pltxt2htm_assert_context_branch(*this, ContextBranch::url_info);
@@ -1160,6 +1164,11 @@ public:
                 context_data_ref, ::pltxt2htm::details::FrontendContextVariant<ndebug>::ContextBranch::url_info);
             return context_data_ref.url_info.pltext;
         }
+        case ::pltxt2htm::NodeKind::pl_link: {
+            pltxt2htm_assert_context_branch(
+                context_data_ref, ::pltxt2htm::details::FrontendContextVariant<ndebug>::ContextBranch::url_info);
+            return context_data_ref.url_info.pltext;
+        }
         case ::pltxt2htm::NodeKind::pl_size: {
             pltxt2htm_assert_context_branch(
                 context_data_ref, ::pltxt2htm::details::FrontendContextVariant<ndebug>::ContextBranch::pl_size_tag);
@@ -1304,6 +1313,14 @@ public:
         auto&& context_data_ref = self.context_data;
         bool const is_external_tag_type{context_data_ref.kind == ::pltxt2htm::NodeKind::pl_external};
         pltxt2htm_assert(is_external_tag_type, u8"context kind mismatch");
+        return ::std::forward_like<decltype(self)>(context_data_ref.url_info.url);
+    }
+
+    [[nodiscard]]
+    constexpr auto get_link_tag_url(this auto&& self) noexcept -> decltype(auto) {
+        auto&& context_data_ref = self.context_data;
+        bool const is_link_tag_type{context_data_ref.kind == ::pltxt2htm::NodeKind::pl_link};
+        pltxt2htm_assert(is_link_tag_type, u8"context kind mismatch");
         return ::std::forward_like<decltype(self)>(context_data_ref.url_info.url);
     }
 

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -741,10 +741,23 @@ entry:
             }
             if (auto opt_url = ::pltxt2htm::details::try_parse_auto_url<ndebug>(pltext, current_index);
                 opt_url.has_value()) {
-                auto&& [consumed_size, url_obj] = opt_url.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-                result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(url_obj)));
-                current_index += consumed_size;
-                continue;
+                // Suppress auto-link when inside a URL-link container frame (pl_link,
+                // pl_external, md_link, html_a): a bare URL there would otherwise nest
+                // an <a> inside another <a>.  The URL then falls through to literal text.
+                bool in_url_link_frame{false};
+                for (auto const& v : call_stack.container) {
+                    if (::pltxt2htm::details::is_url_link_tag_type(v.get_nested_tag_type())) {
+                        in_url_link_frame = true;
+                        break;
+                    }
+                }
+                if (in_url_link_frame == false) {
+                    auto&& [consumed_size, url_obj] =
+                        opt_url.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(url_obj)));
+                    current_index += consumed_size;
+                    continue;
+                }
             }
             if (auto opt_md_image = ::pltxt2htm::details::try_parse_md_image<ndebug>(
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -1181,6 +1181,21 @@ entry:
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
                     }
+                    if (auto opt_link_tag = ::pltxt2htm::details::try_parse_link_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2), call_stack);
+                        opt_link_tag.has_value()) {
+                        // parsing: <link="url">$1</link>
+                        auto&& [tag_len, url] = opt_link_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithUrlInfo<ndebug>{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                                    ::std::move(url)},
+                                ::pltxt2htm::NodeKind::pl_link},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
                     result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
                     ++current_index;
                     continue;
@@ -1669,6 +1684,26 @@ entry:
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
                                 ::pltxt2htm::PlExternal<ndebug>{::std::move(staged_node)}));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_link: {
+                        // parsing </link>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"link">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlLink staged_node(::std::move(result), ::std::move(frame.get_link_tag_url()));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(
+                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlLink<ndebug>{::std::move(staged_node)}));
                             parent_frame.current_index +=
                                 staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
                                 3;
@@ -2608,6 +2643,13 @@ entry:
                 auto&& url = frame.get_external_tag_url();
                 parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
                     ::pltxt2htm::PlExternal<ndebug>{::std::move(subast), ::std::move(url)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_link: {
+                auto&& url = frame.get_link_tag_url();
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlLink<ndebug>{::std::move(subast), ::std::move(url)}));
                 parent_index += staged_index;
                 goto entry;
             }

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -950,7 +950,8 @@ constexpr auto try_parse_non_nestable_equal_sign_tag(
         auto const nested_tag_type = v.get_nested_tag_type();
         if (nested_tag_type == ::pltxt2htm::NodeKind::pl_experiment ||
             nested_tag_type == ::pltxt2htm::NodeKind::pl_discussion ||
-            nested_tag_type == ::pltxt2htm::NodeKind::pl_external) {
+            nested_tag_type == ::pltxt2htm::NodeKind::pl_external ||
+            nested_tag_type == ::pltxt2htm::NodeKind::pl_link) {
             return ::exception::nullopt;
         }
     }
@@ -3044,6 +3045,60 @@ constexpr auto try_parse_external_tag(
     }
 
     return ::pltxt2htm::details::TryParseExternalTagResult<ndebug>{
+        result.template value<ndebug == ::pltxt2htm::Contracts::ignore>().tag_len,
+        ::std::move(opt_url.template value<ndebug == ::pltxt2htm::Contracts::ignore>().url)};
+}
+
+/**
+ * @brief Parse `<link="...">` tag (Unity TextMeshPro rich text) and validate its URL payload.
+ * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
+ * @param[in] pltext The input text starting at the `link` tag payload.
+ * @param[in] call_stack Active parser frames used to reject invalid nested contexts.
+ * @return Parsed tag length and extracted URL on success; nullopt if invalid or disallowed nesting.
+ * @note The Unity TextMeshPro link tag uses a quoted value: &lt;link=&quot;url&quot;&gt;. A value
+ *       without surrounding double quotes is rejected so that unquoted `<link=url>` stays plain text.
+ */
+template<::pltxt2htm::Contracts ndebug>
+struct TryParseLinkTagResult {
+    ::std::size_t tag_len;
+    ::pltxt2htm::Url url;
+};
+
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_link_tag(
+    ::fast_io::u8string_view pltext,
+    ::fast_io::stack<::pltxt2htm::details::ParserFrameContext<ndebug>> const& call_stack) noexcept
+    -> ::exception::optional<::pltxt2htm::details::TryParseLinkTagResult<ndebug>> {
+    auto result = ::pltxt2htm::details::try_parse_non_nestable_equal_sign_tag<ndebug, u8"ink",
+                                                                              ::pltxt2htm::details::is_ascii_graphic>(
+        pltext, call_stack);
+    if (result.has_value() == false) {
+        return ::exception::nullopt;
+    }
+
+    auto&& [_, raw_value] = result.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+    if (raw_value.size() < 2 || ::pltxt2htm::details::u8string_view_index<ndebug>(raw_value, 0) != u8'"' ||
+        ::pltxt2htm::details::u8string_view_index<ndebug>(raw_value, raw_value.size() - 1) != u8'"') {
+        return ::exception::nullopt;
+    }
+    auto url_vw = ::pltxt2htm::details::u8string_view_subview<ndebug>(raw_value, 1, raw_value.size() - 2);
+    auto opt_auth_end = ::pltxt2htm::details::try_parse_url_authority<ndebug>(
+        url_vw, ::pltxt2htm::details::try_parse_url_scheme<ndebug>(url_vw).value_or(::std::size_t{}));
+    if (opt_auth_end.has_value() == false) {
+        return ::exception::nullopt;
+    }
+    auto auth_end = opt_auth_end.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+    auto path_end = ::pltxt2htm::details::try_parse_url_path_simple<ndebug>(url_vw, auth_end);
+    if (path_end != url_vw.size()) {
+        return ::exception::nullopt;
+    }
+    auto opt_url = ::pltxt2htm::details::make_try_parse_url_result<ndebug>(url_vw, url_vw.size());
+    if (opt_url.has_value() == false) {
+        return ::exception::nullopt;
+    }
+
+    return ::pltxt2htm::details::TryParseLinkTagResult<ndebug>{
         result.template value<ndebug == ::pltxt2htm::Contracts::ignore>().tag_len,
         ::std::move(opt_url.template value<ndebug == ::pltxt2htm::Contracts::ignore>().url)};
 }

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -658,6 +658,18 @@ entry:
                         ::std::addressof(subast), ::pltxt2htm::NodeKind::pl_external, subast.begin()));
                 goto entry;
             }
+            case ::pltxt2htm::NodeKind::pl_link: {
+                auto&& subast = node.as_pl_link().get_subast();
+                if (subast.empty()) {
+                    // <link="url"></link> can be omitted
+                    ast.erase(current_iter);
+                    continue;
+                }
+                call_stack.push(
+                    ::pltxt2htm::details::OptimizerFrameContext<typename ::pltxt2htm::Ast<ndebug>::iterator, ndebug>(
+                        ::std::addressof(subast), ::pltxt2htm::NodeKind::pl_link, subast.begin()));
+                goto entry;
+            }
             case ::pltxt2htm::NodeKind::pl_size: {
                 auto&& subast = node.as_pl_size().get_subast();
                 {

--- a/tests/test_pl_link_tag.cc
+++ b/tests/test_pl_link_tag.cc
@@ -26,11 +26,31 @@ int main() {
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"<Link=\"https://main.com\"><link=\"https://nested.com\">physicslab</link></Link>");
-        // The rejected nested tag becomes literal text, and its quoted URL is auto-linked
-        // (unlike pl_external, where the '=' guard suppresses auto-link).
+        // The rejected nested tag becomes literal text; auto-link is suppressed because the
+        // URL is inside a URL-link frame (pl_link), matching pl_external's behavior.
         auto answer = ::fast_io::u8string_view{
-            u8"<a href=\"https://main.com\">&lt;link=&quot;<a href=\"https://nested.com\">https://nested.com</a>"
-            u8"&quot;&gt;physicslab</a>&lt;/Link&gt;"};
+            u8"<a href=\"https://main.com\">&lt;link=&quot;https://nested.com&quot;&gt;physicslab</a>&lt;/Link&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // A bare URL in a link tag's text is not auto-linked (no nested <a> inside <a>).
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<link=\"https://a.com\">visit https://b.com here</link>");
+        auto answer = ::fast_io::u8string_view{u8"<a href=\"https://a.com\">visit&nbsp;https://b.com&nbsp;here</a>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // Same suppression applies inside pl_external.
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<external=https://a.com>see https://b.com</external>");
+        auto answer = ::fast_io::u8string_view{u8"<a href=\"https://a.com\">see&nbsp;https://b.com</a>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // Control: outside any URL-link frame auto-link still works.
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"x https://a.com y");
+        auto answer = ::fast_io::u8string_view{u8"x&nbsp;<a href=\"https://a.com\">https://a.com</a>&nbsp;y"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -38,8 +58,8 @@ int main() {
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"ab<Link=\"https://first.com\">te<link=\"https://second.com\">physicslab</link>st</Link>cd");
         auto answer = ::fast_io::u8string_view{
-            u8"ab<a href=\"https://first.com\">te&lt;link=&quot;<a href=\"https://second.com\">https://second.com</a>"
-            u8"&quot;&gt;physicslab</a>st&lt;/Link&gt;cd"};
+            u8"ab<a href=\"https://first.com\">te&lt;link=&quot;https://second.com&quot;&gt;physicslab</a>st&lt;/"
+            u8"Link&gt;cd"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -73,8 +93,8 @@ int main() {
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"<link=\"https://example.com\">text<link=\"https://another-example.com\">text</link></link>");
         auto answer = ::fast_io::u8string_view{
-            u8"<a href=\"https://example.com\">text&lt;link=&quot;<a href=\"https://another-example.com\">https://"
-            u8"another-example.com</a>&quot;&gt;text</a>&lt;/link&gt;"};
+            u8"<a href=\"https://example.com\">text&lt;link=&quot;https://another-example.com&quot;&gt;text</a>&lt;/"
+            u8"link&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -82,8 +102,8 @@ int main() {
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"<link=\"https://example.com\">physics<link=\"https://another-site.org\">L</link>ab</link>");
         auto answer = ::fast_io::u8string_view{
-            u8"<a href=\"https://example.com\">physics&lt;link=&quot;<a href=\"https://another-site.org\">https://"
-            u8"another-site.org</a>&quot;&gt;L</a>ab&lt;/link&gt;"};
+            u8"<a href=\"https://example.com\">physics&lt;link=&quot;https://another-site.org&quot;&gt;L</a>ab&lt;/"
+            u8"link&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -115,8 +135,7 @@ int main() {
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"<link=\"https://main.com\"><i><link=\"https://nested.com\">c</link></i></link>");
         auto answer = ::fast_io::u8string_view{
-            u8"<a href=\"https://main.com\"><em>&lt;link=&quot;<a href=\"https://nested.com\">https://nested.com</a>"
-            u8"&quot;&gt;c&lt;/link&gt;</em></a>"};
+            u8"<a href=\"https://main.com\"><em>&lt;link=&quot;https://nested.com&quot;&gt;c&lt;/link&gt;</em></a>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -127,6 +146,8 @@ int main() {
     }
 
     {
+        // At the root there is no URL-link outer frame, so the URL inside this rejected
+        // tag is still auto-linked.
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<link=\"https://a.com\"onclick=\"alert(1)\">x</link>");
         auto answer = ::fast_io::u8string_view{
             u8"&lt;link=&quot;<a href=\"https://a.com\">https://a.com</a>&quot;onclick=&quot;alert(1)&quot;&gt;x&lt;/"
@@ -151,6 +172,7 @@ int main() {
     }
 
     {
+        // Same as above: rejected at the root, so the URL is auto-linked.
         auto html = ::pltxt2htm_test::pltxt4unittest(
             u8"<link=\"https://main.com\" onmouseover=\"alert('XSS')\">content</link>");
         auto answer = ::fast_io::u8string_view{

--- a/tests/test_pl_link_tag.cc
+++ b/tests/test_pl_link_tag.cc
@@ -1,0 +1,183 @@
+#include "precompile.hh"
+
+int main() {
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<link=\"https://example.com/discussion\">physicslab</link>");
+        auto answer = ::fast_io::u8string_view{u8"<a href=\"https://example.com/discussion\">physicslab</a>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<lInK=\"https://another-example.org/path\">physicslab</LINK>");
+        auto answer = ::fast_io::u8string_view{u8"<a href=\"https://another-example.org/path\">physicslab</a>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8R"(
+<LINK="https://site.com/item"      >te
+ xt</link      >
+)");
+        auto answer = ::fast_io::u8string_view{u8"<br><a href=\"https://site.com/item\">te<br>&nbsp;xt</a><br>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<Link=\"https://main.com\"><link=\"https://nested.com\">physicslab</link></Link>");
+        // The rejected nested tag becomes literal text, and its quoted URL is auto-linked
+        // (unlike pl_external, where the '=' guard suppresses auto-link).
+        auto answer = ::fast_io::u8string_view{
+            u8"<a href=\"https://main.com\">&lt;link=&quot;<a href=\"https://nested.com\">https://nested.com</a>"
+            u8"&quot;&gt;physicslab</a>&lt;/Link&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"ab<Link=\"https://first.com\">te<link=\"https://second.com\">physicslab</link>st</Link>cd");
+        auto answer = ::fast_io::u8string_view{
+            u8"ab<a href=\"https://first.com\">te&lt;link=&quot;<a href=\"https://second.com\">https://second.com</a>"
+            u8"&quot;&gt;physicslab</a>st&lt;/Link&gt;cd"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"test<lInK=\"https://example.com\">");
+        auto answer = ::fast_io::u8string_view{u8"test"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"te<lInK=\"https://example.com\"></link>st");
+        auto answer = ::fast_io::u8string_view{u8"test"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // test invalid tag
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"test<link=");
+        auto answer = ::fast_io::u8string_view{u8"test&lt;link="};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // unquoted value is not a Unity TextMeshPro link tag, so it stays plain text
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<link=https://example.com>text</link>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;link=https://example.com&gt;text&lt;/link&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<link=\"https://example.com\">text<link=\"https://another-example.com\">text</link></link>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<a href=\"https://example.com\">text&lt;link=&quot;<a href=\"https://another-example.com\">https://"
+            u8"another-example.com</a>&quot;&gt;text</a>&lt;/link&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<link=\"https://example.com\">physics<link=\"https://another-site.org\">L</link>ab</link>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<a href=\"https://example.com\">physics&lt;link=&quot;<a href=\"https://another-site.org\">https://"
+            u8"another-site.org</a>&quot;&gt;L</a>ab&lt;/link&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<link=\"https://example.com\">physicslab");
+        auto answer = ::fast_io::u8string_view{u8"<a href=\"https://example.com\">physicslab</a>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"t<link=\"https://example.com\"></link>t");
+        auto answer = ::fast_io::u8string_view{u8"tt"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<link=\"\">t");
+        auto answer = ::fast_io::u8string_view{u8"&lt;link=&quot;&quot;&gt;t"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<link=\"https://example.com\"></link");
+        auto answer = ::fast_io::u8string_view{u8"<a href=\"https://example.com\">&lt;/link</a>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<link=\"https://main.com\"><i><link=\"https://nested.com\">c</link></i></link>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<a href=\"https://main.com\"><em>&lt;link=&quot;<a href=\"https://nested.com\">https://nested.com</a>"
+            u8"&quot;&gt;c&lt;/link&gt;</em></a>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<link=\"javascript:alert(1)\">x</link>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;link=&quot;javascript:alert(1)&quot;&gt;x&lt;/link&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<link=\"https://a.com\"onclick=\"alert(1)\">x</link>");
+        auto answer = ::fast_io::u8string_view{
+            u8"&lt;link=&quot;<a href=\"https://a.com\">https://a.com</a>&quot;onclick=&quot;alert(1)&quot;&gt;x&lt;/"
+            u8"link&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html =
+            ::pltxt2htm_test::pltxt4unittest(u8"<link=\"https://main.com\"><i><experiment=a>c</experiment></i></link>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<a href=\"https://main.com\"><em>&lt;experiment=a&gt;c&lt;/experiment&gt;</em></a>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html =
+            ::pltxt2htm_test::pltxt4unittest(u8"<link=\"https://main.com\"><i><discussion=a>c</discussion></i></link>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<a href=\"https://main.com\"><em>&lt;discussion=a&gt;c&lt;/discussion&gt;</em></a>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(
+            u8"<link=\"https://main.com\" onmouseover=\"alert('XSS')\">content</link>");
+        auto answer = ::fast_io::u8string_view{
+            u8"&lt;link=&quot;<a "
+            u8"href=\"https://main.com\">https://main.com</a>&quot;&nbsp;onmouseover=&quot;alert(&apos;"
+            u8"XSS&apos;)&quot;&gt;content&lt;/link&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<link=\"javascript:alert('XSS')\">clickme</link>");
+        auto answer = ::fast_io::u8string_view{
+            u8"&lt;link=&quot;javascript:alert(&apos;XSS&apos;)&quot;&gt;clickme&lt;/link&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<link=\"example.com\">text</link>");
+        auto answer = ::fast_io::u8string_view{u8"<a href=\"example.com\">text</a>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"ab<link=\"https://example.com\">example</link>cd");
+        auto answer = ::fast_io::u8string_view{u8"ab<link=\"https://example.com\">example</link>cd"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Add a pl_link AST node (NodeKind::pl_link, Physics-Lab category) that mirrors pl_external, so the Unity TextMeshPro rich-text link tag <link="url">...</link> parses, optimizes and renders in every backend.

- Parser: try_parse_link_tag accepts the quoted TMP form -- the value must be wrapped in double quotes, which are stripped before running the same URL validation as pl_external. pl_link joins the non-nestable tag family (experiment/discussion/external), so nested instances are rejected and rendered as literal text.
- AST: new PlLink node (sub-AST + Url) wired through the PlTxtNode tagged union (copy/move/dtor/operator==/as_pl_link) and exported from the C++20 module.
- Backends: plweb text/title render <a href="url">...</a> (href is attribute-escaped in the text backend); the PLUnity backend emits <link="url">...</link> so the tag round-trips through the parser.
- Optimizer: empty <link="url"></link> is dropped, like pl_external.
- Docs/tests: README lists the link tag; tests/test_pl_link_tag.cc covers basic conversion, case-insensitive tags, nesting rejection, unquoted/empty/invalid payloads, XSS payloads and the PLUnity round-trip.