### PR TITLE
optimize: render rejected URL-bearing tags as one literal span

### DIFF
--- a/include/pltxt2htm/details/backend/frame_context.hh
+++ b/include/pltxt2htm/details/backend/frame_context.hh
@@ -106,9 +106,8 @@ public:
           current_index{current_index_} {
     }
 
-    constexpr BackendFrameContext(
-        ::pltxt2htm::Ast<ndebug> const& ast_, ::std::size_t current_index_,
-        ::pltxt2htm::details::BackendContextWithHtmlSpanInfo html_span_info_context) noexcept
+    constexpr BackendFrameContext(::pltxt2htm::Ast<ndebug> const& ast_, ::std::size_t current_index_,
+                                  ::pltxt2htm::details::BackendContextWithHtmlSpanInfo html_span_info_context) noexcept
         : context_data{::std::move(html_span_info_context)},
           ast(::std::addressof(ast_)),
           current_index{current_index_} {

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -800,7 +800,7 @@ entry:
                     // parsing html <a href="URL"> tag
                     if (auto a_tag = ::pltxt2htm::details::try_parse_html_a_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        a_tag.kind == ::pltxt2htm::details::TryParseTagOutcomeKind::valid) {
+                        a_tag.is_valid()) {
                         auto tag_len = a_tag.tag_len;
                         ::pltxt2htm::Url url =
                             ::std::move(a_tag.url).template value<ndebug == ::pltxt2htm::Contracts::ignore>();
@@ -815,13 +815,15 @@ entry:
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
                     }
-                    else if (a_tag.kind == ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url) {
+                    else if (a_tag.is_invalid_url()) {
                         // the <a href="..."> opening tag was recognized but its URL is invalid:
                         // consume the whole span as literal text (no auto-link / tag dispatch inside).
                         auto const tag_len = a_tag.tag_len;
                         auto span =
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index, tag_len + 2);
-                        auto&& [_, literal_ast] = ::pltxt2htm::details::simply_parse_pltext<ndebug>(span);
+                        auto&& [_, literal_ast] =
+                            ::pltxt2htm::details::simply_parse_pltext<ndebug,
+                                                                      ::pltxt2htm::details::U8LiteralString<0>{}>(span);
                         result.append_range(::std::move(literal_ast));
                         current_index += tag_len + 2;
                         continue;
@@ -1023,7 +1025,7 @@ entry:
                     }
                     if (auto external_tag = ::pltxt2htm::details::try_parse_external_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2), call_stack);
-                        external_tag.kind == ::pltxt2htm::details::TryParseTagOutcomeKind::valid) {
+                        external_tag.is_valid()) {
                         auto tag_len = external_tag.tag_len;
                         ::pltxt2htm::Url url =
                             ::std::move(external_tag.url).template value<ndebug == ::pltxt2htm::Contracts::ignore>();
@@ -1037,13 +1039,15 @@ entry:
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
                     }
-                    else if (external_tag.kind == ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url) {
+                    else if (external_tag.is_invalid_url()) {
                         // the <external=...> opening tag was recognized but its URL is invalid:
                         // consume the whole span as literal text (no auto-link / tag dispatch inside).
                         auto const tag_len = external_tag.tag_len;
                         auto span =
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index, tag_len + 3);
-                        auto&& [_, literal_ast] = ::pltxt2htm::details::simply_parse_pltext<ndebug>(span);
+                        auto&& [_, literal_ast] =
+                            ::pltxt2htm::details::simply_parse_pltext<ndebug,
+                                                                      ::pltxt2htm::details::U8LiteralString<0>{}>(span);
                         result.append_range(::std::move(literal_ast));
                         current_index += tag_len + 3;
                         continue;
@@ -1221,7 +1225,7 @@ entry:
                     }
                     if (auto link_tag = ::pltxt2htm::details::try_parse_link_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2), call_stack);
-                        link_tag.kind == ::pltxt2htm::details::TryParseTagOutcomeKind::valid) {
+                        link_tag.is_valid()) {
                         // parsing: <link="url">$1</link>
                         auto tag_len = link_tag.tag_len;
                         ::pltxt2htm::Url url =
@@ -1236,13 +1240,15 @@ entry:
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
                     }
-                    else if (link_tag.kind == ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url) {
+                    else if (link_tag.is_invalid_url()) {
                         // the <link="..."> opening tag was recognized but its URL is invalid:
                         // consume the whole span as literal text (no auto-link / tag dispatch inside).
                         auto const tag_len = link_tag.tag_len;
                         auto span =
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index, tag_len + 3);
-                        auto&& [_, literal_ast] = ::pltxt2htm::details::simply_parse_pltext<ndebug>(span);
+                        auto&& [_, literal_ast] =
+                            ::pltxt2htm::details::simply_parse_pltext<ndebug,
+                                                                      ::pltxt2htm::details::U8LiteralString<0>{}>(span);
                         result.append_range(::std::move(literal_ast));
                         current_index += tag_len + 3;
                         continue;

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -803,7 +803,7 @@ entry:
                         a_tag.is_valid()) {
                         auto tag_len = a_tag.tag_len;
                         ::pltxt2htm::Url url =
-                            ::std::move(a_tag.url).template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                            ::std::move(a_tag.url.template value<ndebug == ::pltxt2htm::Contracts::ignore>());
                         auto const internal = a_tag.internal;
                         current_index += tag_len + 2;
                         call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
@@ -1028,7 +1028,7 @@ entry:
                         external_tag.is_valid()) {
                         auto tag_len = external_tag.tag_len;
                         ::pltxt2htm::Url url =
-                            ::std::move(external_tag.url).template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                            ::std::move(external_tag.url.template value<ndebug == ::pltxt2htm::Contracts::ignore>());
                         current_index += tag_len + 3;
                         call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                             ::pltxt2htm::details::FrontendContextVariant<ndebug>{
@@ -1229,7 +1229,7 @@ entry:
                         // parsing: <link="url">$1</link>
                         auto tag_len = link_tag.tag_len;
                         ::pltxt2htm::Url url =
-                            ::std::move(link_tag.url).template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                            ::std::move(link_tag.url.template value<ndebug == ::pltxt2htm::Contracts::ignore>());
                         current_index += tag_len + 3;
                         call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                             ::pltxt2htm::details::FrontendContextVariant<ndebug>{

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -798,11 +798,13 @@ entry:
                         goto entry;
                     }
                     // parsing html <a href="URL"> tag
-                    if (auto opt_a_tag = ::pltxt2htm::details::try_parse_html_a_tag<ndebug>(
+                    if (auto a_tag = ::pltxt2htm::details::try_parse_html_a_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_a_tag.has_value()) {
-                        auto&& [tag_len, url, internal] =
-                            opt_a_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        a_tag.kind == ::pltxt2htm::details::TryParseTagOutcomeKind::valid) {
+                        auto tag_len = a_tag.tag_len;
+                        ::pltxt2htm::Url url =
+                            ::std::move(a_tag.url).template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        auto const internal = a_tag.internal;
                         current_index += tag_len + 2;
                         call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                             ::pltxt2htm::details::FrontendContextVariant<ndebug>{
@@ -812,6 +814,17 @@ entry:
                                     internal}}, // ::pltxt2htm::NodeKind::html_a is automatically set in ctor
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
+                    }
+                    else if (a_tag.kind == ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url) {
+                        // the <a href="..."> opening tag was recognized but its URL is invalid:
+                        // consume the whole span as literal text (no auto-link / tag dispatch inside).
+                        auto const tag_len = a_tag.tag_len;
+                        auto span =
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index, tag_len + 2);
+                        auto&& [_, literal_ast] = ::pltxt2htm::details::simply_parse_pltext<ndebug>(span);
+                        result.append_range(::std::move(literal_ast));
+                        current_index += tag_len + 2;
+                        continue;
                     }
                     result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
                     ++current_index;
@@ -1008,11 +1021,12 @@ entry:
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
                     }
-                    if (auto opt_external_tag = ::pltxt2htm::details::try_parse_external_tag<ndebug>(
+                    if (auto external_tag = ::pltxt2htm::details::try_parse_external_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2), call_stack);
-                        opt_external_tag.has_value()) {
-                        auto&& [tag_len, url] =
-                            opt_external_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        external_tag.kind == ::pltxt2htm::details::TryParseTagOutcomeKind::valid) {
+                        auto tag_len = external_tag.tag_len;
+                        ::pltxt2htm::Url url =
+                            ::std::move(external_tag.url).template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                         current_index += tag_len + 3;
                         call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                             ::pltxt2htm::details::FrontendContextVariant<ndebug>{
@@ -1022,6 +1036,17 @@ entry:
                                 ::pltxt2htm::NodeKind::pl_external},
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
+                    }
+                    else if (external_tag.kind == ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url) {
+                        // the <external=...> opening tag was recognized but its URL is invalid:
+                        // consume the whole span as literal text (no auto-link / tag dispatch inside).
+                        auto const tag_len = external_tag.tag_len;
+                        auto span =
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index, tag_len + 3);
+                        auto&& [_, literal_ast] = ::pltxt2htm::details::simply_parse_pltext<ndebug>(span);
+                        result.append_range(::std::move(literal_ast));
+                        current_index += tag_len + 3;
+                        continue;
                     }
                     if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"m">(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
@@ -1194,11 +1219,13 @@ entry:
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
                     }
-                    if (auto opt_link_tag = ::pltxt2htm::details::try_parse_link_tag<ndebug>(
+                    if (auto link_tag = ::pltxt2htm::details::try_parse_link_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2), call_stack);
-                        opt_link_tag.has_value()) {
+                        link_tag.kind == ::pltxt2htm::details::TryParseTagOutcomeKind::valid) {
                         // parsing: <link="url">$1</link>
-                        auto&& [tag_len, url] = opt_link_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        auto tag_len = link_tag.tag_len;
+                        ::pltxt2htm::Url url =
+                            ::std::move(link_tag.url).template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                         current_index += tag_len + 3;
                         call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                             ::pltxt2htm::details::FrontendContextVariant<ndebug>{
@@ -1208,6 +1235,17 @@ entry:
                                 ::pltxt2htm::NodeKind::pl_link},
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
+                    }
+                    else if (link_tag.kind == ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url) {
+                        // the <link="..."> opening tag was recognized but its URL is invalid:
+                        // consume the whole span as literal text (no auto-link / tag dispatch inside).
+                        auto const tag_len = link_tag.tag_len;
+                        auto span =
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index, tag_len + 3);
+                        auto&& [_, literal_ast] = ::pltxt2htm::details::simply_parse_pltext<ndebug>(span);
+                        result.append_range(::std::move(literal_ast));
+                        current_index += tag_len + 3;
+                        continue;
                     }
                     result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
                     ++current_index;

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -2091,7 +2091,8 @@ constexpr auto try_parse_entity_reference(::fast_io::u8string_view text) noexcep
  * @note When end_string is non-empty, the function consumes it and stops parsing immediately after.
  */
 template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::details::U8LiteralString end_string>
-[[nodiscard]] constexpr auto simply_parse_pltext(::fast_io::u8string_view pltext) noexcept
+[[nodiscard]]
+constexpr auto simply_parse_pltext(::fast_io::u8string_view pltext) noexcept
     -> ::pltxt2htm::details::SimplyParsePLtextResult<ndebug> {
     ::pltxt2htm::Ast<ndebug> ast{};
     ::std::size_t current_index{};

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -2080,18 +2080,19 @@ constexpr auto try_parse_entity_reference(::fast_io::u8string_view text) noexcep
  * encounters the specified termination string.
  *
  * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
- * @tparam end_string The exact string that marks the end of parsing.
+ * @tparam end_string The exact string that marks the end of parsing. When empty (the default),
+ *                    the whole input view is parsed.
  * @param[in] pltext The input text to parse.
  * @return A structure containing the parsed AST and the index to continue parsing from.
  * @note Special characters such as newline, space, ampersand, quotes,
  *       greater-than, and tab are converted to specific AST nodes.
  * @note Backslash escape sequences are processed and converted to their escaped equivalents.
  * @note UTF-8 multi-byte characters are properly handled and converted to U8Char nodes.
- * @note The function consumes the termination string and stops parsing immediately after it.
+ * @note When end_string is non-empty, the function consumes it and stops parsing immediately after.
  */
-template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::details::U8LiteralString end_string>
-[[nodiscard]]
-constexpr auto simply_parse_pltext(::fast_io::u8string_view pltext) noexcept
+template<::pltxt2htm::Contracts ndebug,
+         ::pltxt2htm::details::U8LiteralString end_string = ::pltxt2htm::details::U8LiteralString<0>{}>
+[[nodiscard]] constexpr auto simply_parse_pltext(::fast_io::u8string_view pltext) noexcept
     -> ::pltxt2htm::details::SimplyParsePLtextResult<ndebug> {
     ::pltxt2htm::Ast<ndebug> ast{};
     ::std::size_t current_index{};
@@ -2100,10 +2101,12 @@ constexpr auto simply_parse_pltext(::fast_io::u8string_view pltext) noexcept
     while (current_index < pltext.size()) {
         char8_t const chr{::pltxt2htm::details::u8string_view_index<ndebug>(pltext, current_index)};
 
-        if (::pltxt2htm::details::is_prefix_match<ndebug, end_string>(
-                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index))) {
-            current_index += end_size;
-            break;
+        if constexpr (end_size != 0) {
+            if (::pltxt2htm::details::is_prefix_match<ndebug, end_string>(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index))) {
+                current_index += end_size;
+                break;
+            }
         }
 
         if (chr == u8'\n') {
@@ -2903,28 +2906,40 @@ constexpr auto try_parse_url_path_unicode(::fast_io::u8string_view pltext, ::std
     return start_index;
 }
 
+/**
+ * @brief Discriminator shared by URL-bearing tag parse results.
+ * @details `not_a_tag` keeps the char-by-char fallback; `invalid_url` means the opening tag
+ *          was recognized but its URL failed validation, so the caller consumes the whole
+ *          span as literal text (via simply_parse_pltext) instead of re-interpreting it.
+ */
+enum class TryParseTagOutcomeKind : unsigned {
+    not_a_tag,
+    invalid_url,
+    valid,
+};
+
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseHtmlATagResult {
-    ::std::size_t tag_len;
-    ::pltxt2htm::Url url;
-    bool internal;
+    ::pltxt2htm::details::TryParseTagOutcomeKind kind{::pltxt2htm::details::TryParseTagOutcomeKind::not_a_tag};
+    ::std::size_t tag_len{}; ///< Opening-tag length in the input view (valid for valid/invalid_url).
+    ::exception::optional<::pltxt2htm::Url> url{::exception::nullopt}; ///< Extracted URL; engaged only when valid.
+    bool internal{};
 };
 
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
-constexpr auto try_parse_html_a_tag(::fast_io::u8string_view pltext) noexcept
-    -> ::exception::optional<TryParseHtmlATagResult<ndebug>> {
+constexpr auto try_parse_html_a_tag(::fast_io::u8string_view pltext) noexcept -> TryParseHtmlATagResult<ndebug> {
     ::std::size_t pos{};
     while (pos < pltext.size() && (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
                                    ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
         ++pos;
     }
     if (pos >= pltext.size()) {
-        return ::exception::nullopt;
+        return {};
     }
     if (::pltxt2htm::details::is_prefix_match<ndebug, ::pltxt2htm::details::U8LiteralString{u8"href"}>(
             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, pos)) == false) {
-        return ::exception::nullopt;
+        return {};
     }
     pos += 4;
     while (pos < pltext.size() && (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
@@ -2932,7 +2947,7 @@ constexpr auto try_parse_html_a_tag(::fast_io::u8string_view pltext) noexcept
         ++pos;
     }
     if (pos >= pltext.size() || ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'=') {
-        return ::exception::nullopt;
+        return {};
     }
     ++pos;
     while (pos < pltext.size() && (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
@@ -2940,11 +2955,11 @@ constexpr auto try_parse_html_a_tag(::fast_io::u8string_view pltext) noexcept
         ++pos;
     }
     if (pos >= pltext.size()) {
-        return ::exception::nullopt;
+        return {};
     }
     char8_t const quote{::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos)};
     if (quote != u8'"' && quote != u8'\'') {
-        return ::exception::nullopt;
+        return {};
     }
     ++pos;
     ::std::size_t const val_start{pos};
@@ -2952,7 +2967,7 @@ constexpr auto try_parse_html_a_tag(::fast_io::u8string_view pltext) noexcept
         ++pos;
     }
     if (pos >= pltext.size()) {
-        return ::exception::nullopt;
+        return {};
     }
     ::fast_io::u8string_view const attr_val{pltext.data() + val_start, pos - val_start};
     ++pos;
@@ -2966,7 +2981,7 @@ constexpr auto try_parse_html_a_tag(::fast_io::u8string_view pltext) noexcept
         constexpr auto internal_literal = ::pltxt2htm::details::U8LiteralString{u8"internal"};
         if (::pltxt2htm::details::is_prefix_match<ndebug, internal_literal>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, pos)) == false) {
-            return ::exception::nullopt;
+            return {};
         }
         internal = true;
         pos += internal_literal.size();
@@ -2976,24 +2991,26 @@ constexpr auto try_parse_html_a_tag(::fast_io::u8string_view pltext) noexcept
         }
     }
     if (pos >= pltext.size() || ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'>') {
-        return ::exception::nullopt;
+        return {};
     }
     auto opt_auth_end = ::pltxt2htm::details::try_parse_url_authority<ndebug>(
         attr_val, ::pltxt2htm::details::try_parse_url_scheme<ndebug>(attr_val).value_or(::std::size_t{}));
     if (opt_auth_end.has_value() == false) {
-        return ::exception::nullopt;
+        return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url, .tag_len = pos + 1};
     }
     auto auth_end = opt_auth_end.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
     auto path_end = ::pltxt2htm::details::try_parse_url_path_unicode<ndebug>(attr_val, auth_end);
     if (path_end != attr_val.size()) {
-        return ::exception::nullopt;
+        return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url, .tag_len = pos + 1};
     }
     auto opt_url_result = ::pltxt2htm::details::make_try_parse_url_result<ndebug>(attr_val, path_end);
     if (opt_url_result.has_value() == false) {
-        return ::exception::nullopt;
+        return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url, .tag_len = pos + 1};
     }
-    return TryParseHtmlATagResult<ndebug>{
-        pos + 1, ::std::move(opt_url_result.template value<ndebug == ::pltxt2htm::Contracts::ignore>().url), internal};
+    return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::valid,
+            .tag_len = pos + 1,
+            .url = ::std::move(opt_url_result.template value<ndebug == ::pltxt2htm::Contracts::ignore>().url),
+            .internal = internal};
 }
 
 /**
@@ -3045,12 +3062,14 @@ constexpr auto try_parse_auto_url(::fast_io::u8string_view pltext, ::std::size_t
  * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
  * @param[in] pltext The input text starting at the `external` tag payload.
  * @param[in] call_stack Active parser frames used to reject invalid nested contexts.
- * @return Parsed tag length and extracted URL on success; nullopt if invalid or disallowed nesting.
+ * @return `valid` with tag length + URL on success; `invalid_url` with the tag length when the
+ *         opening tag was recognized but its URL failed validation; `not_a_tag` otherwise.
  */
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseExternalTagResult {
-    ::std::size_t tag_len;
-    ::pltxt2htm::Url url;
+    ::pltxt2htm::details::TryParseTagOutcomeKind kind{::pltxt2htm::details::TryParseTagOutcomeKind::not_a_tag};
+    ::std::size_t tag_len{}; ///< Opening-tag length in the input view (valid for valid/invalid_url).
+    ::exception::optional<::pltxt2htm::Url> url{::exception::nullopt}; ///< Extracted URL; engaged only when valid.
 };
 
 template<::pltxt2htm::Contracts ndebug>
@@ -3058,34 +3077,35 @@ template<::pltxt2htm::Contracts ndebug>
 constexpr auto try_parse_external_tag(
     ::fast_io::u8string_view pltext,
     ::fast_io::stack<::pltxt2htm::details::ParserFrameContext<ndebug>> const& call_stack) noexcept
-    -> ::exception::optional<::pltxt2htm::details::TryParseExternalTagResult<ndebug>> {
+    -> TryParseExternalTagResult<ndebug> {
     auto result = ::pltxt2htm::details::try_parse_non_nestable_equal_sign_tag<ndebug, u8"xternal",
                                                                               ::pltxt2htm::details::is_url_value_char>(
         pltext, call_stack);
     if (result.has_value() == false) {
-        return ::exception::nullopt;
+        return {};
     }
+    auto const tag_len = result.template value<ndebug == ::pltxt2htm::Contracts::ignore>().tag_len;
 
     auto&& [_, url_str] = result.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
     auto url_vw = ::fast_io::u8string_view{url_str.data(), url_str.size()};
     auto opt_auth_end = ::pltxt2htm::details::try_parse_url_authority<ndebug>(
         url_vw, ::pltxt2htm::details::try_parse_url_scheme<ndebug>(url_vw).value_or(::std::size_t{}));
     if (opt_auth_end.has_value() == false) {
-        return ::exception::nullopt;
+        return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url, .tag_len = tag_len};
     }
     auto auth_end = opt_auth_end.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
     auto path_end = ::pltxt2htm::details::try_parse_url_path_unicode<ndebug>(url_vw, auth_end);
     if (path_end != url_vw.size()) {
-        return ::exception::nullopt;
+        return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url, .tag_len = tag_len};
     }
     auto opt_url = ::pltxt2htm::details::make_try_parse_url_result<ndebug>(url_vw, url_vw.size());
     if (opt_url.has_value() == false) {
-        return ::exception::nullopt;
+        return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url, .tag_len = tag_len};
     }
 
-    return ::pltxt2htm::details::TryParseExternalTagResult<ndebug>{
-        result.template value<ndebug == ::pltxt2htm::Contracts::ignore>().tag_len,
-        ::std::move(opt_url.template value<ndebug == ::pltxt2htm::Contracts::ignore>().url)};
+    return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::valid,
+            .tag_len = tag_len,
+            .url = ::std::move(opt_url.template value<ndebug == ::pltxt2htm::Contracts::ignore>().url)};
 }
 
 /**
@@ -3093,14 +3113,16 @@ constexpr auto try_parse_external_tag(
  * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
  * @param[in] pltext The input text starting at the `link` tag payload.
  * @param[in] call_stack Active parser frames used to reject invalid nested contexts.
- * @return Parsed tag length and extracted URL on success; nullopt if invalid or disallowed nesting.
+ * @return `valid` with tag length + URL on success; `invalid_url` with the tag length when the
+ *         opening tag was recognized but its URL failed validation; `not_a_tag` otherwise.
  * @note The Unity TextMeshPro link tag uses a quoted value: &lt;link=&quot;url&quot;&gt;. A value
  *       without surrounding double quotes is rejected so that unquoted `<link=url>` stays plain text.
  */
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseLinkTagResult {
-    ::std::size_t tag_len;
-    ::pltxt2htm::Url url;
+    ::pltxt2htm::details::TryParseTagOutcomeKind kind{::pltxt2htm::details::TryParseTagOutcomeKind::not_a_tag};
+    ::std::size_t tag_len{}; ///< Opening-tag length in the input view (valid for valid/invalid_url).
+    ::exception::optional<::pltxt2htm::Url> url{::exception::nullopt}; ///< Extracted URL; engaged only when valid.
 };
 
 template<::pltxt2htm::Contracts ndebug>
@@ -3108,38 +3130,40 @@ template<::pltxt2htm::Contracts ndebug>
 constexpr auto try_parse_link_tag(
     ::fast_io::u8string_view pltext,
     ::fast_io::stack<::pltxt2htm::details::ParserFrameContext<ndebug>> const& call_stack) noexcept
-    -> ::exception::optional<::pltxt2htm::details::TryParseLinkTagResult<ndebug>> {
+    -> TryParseLinkTagResult<ndebug> {
     auto result = ::pltxt2htm::details::try_parse_non_nestable_equal_sign_tag<ndebug, u8"ink",
                                                                               ::pltxt2htm::details::is_url_value_char>(
         pltext, call_stack);
     if (result.has_value() == false) {
-        return ::exception::nullopt;
+        return {};
     }
+    auto const tag_len = result.template value<ndebug == ::pltxt2htm::Contracts::ignore>().tag_len;
 
     auto&& [_, raw_value] = result.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
     if (raw_value.size() < 2 || ::pltxt2htm::details::u8string_view_index<ndebug>(raw_value, 0) != u8'"' ||
         ::pltxt2htm::details::u8string_view_index<ndebug>(raw_value, raw_value.size() - 1) != u8'"') {
-        return ::exception::nullopt;
+        // unquoted value is not a Unity TextMeshPro link tag: keep the char-by-char fallback
+        return {};
     }
     auto url_vw = ::pltxt2htm::details::u8string_view_subview<ndebug>(raw_value, 1, raw_value.size() - 2);
     auto opt_auth_end = ::pltxt2htm::details::try_parse_url_authority<ndebug>(
         url_vw, ::pltxt2htm::details::try_parse_url_scheme<ndebug>(url_vw).value_or(::std::size_t{}));
     if (opt_auth_end.has_value() == false) {
-        return ::exception::nullopt;
+        return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url, .tag_len = tag_len};
     }
     auto auth_end = opt_auth_end.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
     auto path_end = ::pltxt2htm::details::try_parse_url_path_unicode<ndebug>(url_vw, auth_end);
     if (path_end != url_vw.size()) {
-        return ::exception::nullopt;
+        return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url, .tag_len = tag_len};
     }
     auto opt_url = ::pltxt2htm::details::make_try_parse_url_result<ndebug>(url_vw, url_vw.size());
     if (opt_url.has_value() == false) {
-        return ::exception::nullopt;
+        return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url, .tag_len = tag_len};
     }
 
-    return ::pltxt2htm::details::TryParseLinkTagResult<ndebug>{
-        result.template value<ndebug == ::pltxt2htm::Contracts::ignore>().tag_len,
-        ::std::move(opt_url.template value<ndebug == ::pltxt2htm::Contracts::ignore>().url)};
+    return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::valid,
+            .tag_len = tag_len,
+            .url = ::std::move(opt_url.template value<ndebug == ::pltxt2htm::Contracts::ignore>().url)};
 }
 
 template<::pltxt2htm::Contracts ndebug>

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -2080,8 +2080,8 @@ constexpr auto try_parse_entity_reference(::fast_io::u8string_view text) noexcep
  * encounters the specified termination string.
  *
  * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
- * @tparam end_string The exact string that marks the end of parsing. When empty (the default),
- *                    the whole input view is parsed.
+ * @tparam end_string The exact string that marks the end of parsing. When empty, the whole
+ *                    input view is parsed.
  * @param[in] pltext The input text to parse.
  * @return A structure containing the parsed AST and the index to continue parsing from.
  * @note Special characters such as newline, space, ampersand, quotes,
@@ -2090,8 +2090,7 @@ constexpr auto try_parse_entity_reference(::fast_io::u8string_view text) noexcep
  * @note UTF-8 multi-byte characters are properly handled and converted to U8Char nodes.
  * @note When end_string is non-empty, the function consumes it and stops parsing immediately after.
  */
-template<::pltxt2htm::Contracts ndebug,
-         ::pltxt2htm::details::U8LiteralString end_string = ::pltxt2htm::details::U8LiteralString<0>{}>
+template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::details::U8LiteralString end_string>
 [[nodiscard]] constexpr auto simply_parse_pltext(::fast_io::u8string_view pltext) noexcept
     -> ::pltxt2htm::details::SimplyParsePLtextResult<ndebug> {
     ::pltxt2htm::Ast<ndebug> ast{};
@@ -2906,24 +2905,46 @@ constexpr auto try_parse_url_path_unicode(::fast_io::u8string_view pltext, ::std
     return start_index;
 }
 
-/**
- * @brief Discriminator shared by URL-bearing tag parse results.
- * @details `not_a_tag` keeps the char-by-char fallback; `invalid_url` means the opening tag
- *          was recognized but its URL failed validation, so the caller consumes the whole
- *          span as literal text (via simply_parse_pltext) instead of re-interpreting it.
- */
-enum class TryParseTagOutcomeKind : unsigned {
-    not_a_tag,
-    invalid_url,
-    valid,
-};
-
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseHtmlATagResult {
-    ::pltxt2htm::details::TryParseTagOutcomeKind kind{::pltxt2htm::details::TryParseTagOutcomeKind::not_a_tag};
-    ::std::size_t tag_len{}; ///< Opening-tag length in the input view (valid for valid/invalid_url).
-    ::exception::optional<::pltxt2htm::Url> url{::exception::nullopt}; ///< Extracted URL; engaged only when valid.
-    bool internal{};
+    ::std::size_t tag_len; ///< Opening-tag length in the input view (valid for valid/invalid_url).
+    ::exception::optional<::pltxt2htm::Url> url; ///< Extracted URL; engaged only when valid.
+    bool internal;
+
+    constexpr TryParseHtmlATagResult() noexcept
+        : tag_len{},
+          url{::exception::nullopt},
+          internal{} {
+    }
+
+    constexpr TryParseHtmlATagResult(::std::size_t tag_len_) noexcept
+        : tag_len{tag_len_},
+          url{::exception::nullopt},
+          internal{} {
+    }
+
+    constexpr TryParseHtmlATagResult(::std::size_t tag_len_, ::pltxt2htm::Url&& url_, bool internal_) noexcept
+        : tag_len{tag_len_},
+          url(::std::move(url_)),
+          internal{internal_} {
+    }
+
+    /// State is derived from the payload: engaged url means valid; otherwise a non-zero
+    /// tag_len means the URL failed validation; a zero tag_len means not a tag.
+    [[nodiscard]]
+    constexpr auto is_valid(this auto const& self) noexcept -> bool {
+        return self.url.has_value();
+    }
+
+    [[nodiscard]]
+    constexpr auto is_invalid_url(this auto const& self) noexcept -> bool {
+        return self.url.has_value() == false && self.tag_len != 0;
+    }
+
+    [[nodiscard]]
+    constexpr auto is_not_a_tag(this auto const& self) noexcept -> bool {
+        return self.tag_len == 0;
+    }
 };
 
 template<::pltxt2htm::Contracts ndebug>
@@ -2996,21 +3017,19 @@ constexpr auto try_parse_html_a_tag(::fast_io::u8string_view pltext) noexcept ->
     auto opt_auth_end = ::pltxt2htm::details::try_parse_url_authority<ndebug>(
         attr_val, ::pltxt2htm::details::try_parse_url_scheme<ndebug>(attr_val).value_or(::std::size_t{}));
     if (opt_auth_end.has_value() == false) {
-        return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url, .tag_len = pos + 1};
+        return TryParseHtmlATagResult<ndebug>{pos + 1};
     }
     auto auth_end = opt_auth_end.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
     auto path_end = ::pltxt2htm::details::try_parse_url_path_unicode<ndebug>(attr_val, auth_end);
     if (path_end != attr_val.size()) {
-        return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url, .tag_len = pos + 1};
+        return TryParseHtmlATagResult<ndebug>{pos + 1};
     }
     auto opt_url_result = ::pltxt2htm::details::make_try_parse_url_result<ndebug>(attr_val, path_end);
     if (opt_url_result.has_value() == false) {
-        return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url, .tag_len = pos + 1};
+        return TryParseHtmlATagResult<ndebug>{pos + 1};
     }
-    return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::valid,
-            .tag_len = pos + 1,
-            .url = ::std::move(opt_url_result.template value<ndebug == ::pltxt2htm::Contracts::ignore>().url),
-            .internal = internal};
+    return TryParseHtmlATagResult<ndebug>{
+        pos + 1, ::std::move(opt_url_result.template value<ndebug == ::pltxt2htm::Contracts::ignore>().url), internal};
 }
 
 /**
@@ -3067,9 +3086,40 @@ constexpr auto try_parse_auto_url(::fast_io::u8string_view pltext, ::std::size_t
  */
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseExternalTagResult {
-    ::pltxt2htm::details::TryParseTagOutcomeKind kind{::pltxt2htm::details::TryParseTagOutcomeKind::not_a_tag};
-    ::std::size_t tag_len{}; ///< Opening-tag length in the input view (valid for valid/invalid_url).
-    ::exception::optional<::pltxt2htm::Url> url{::exception::nullopt}; ///< Extracted URL; engaged only when valid.
+    ::std::size_t tag_len; ///< Opening-tag length in the input view (valid for valid/invalid_url).
+    ::exception::optional<::pltxt2htm::Url> url; ///< Extracted URL; engaged only when valid.
+
+    constexpr TryParseExternalTagResult() noexcept
+        : tag_len{},
+          url{::exception::nullopt} {
+    }
+
+    constexpr TryParseExternalTagResult(::std::size_t tag_len_) noexcept
+        : tag_len{tag_len_},
+          url{::exception::nullopt} {
+    }
+
+    constexpr TryParseExternalTagResult(::std::size_t tag_len_, ::pltxt2htm::Url&& url_) noexcept
+        : tag_len{tag_len_},
+          url(::std::move(url_)) {
+    }
+
+    /// State is derived from the payload: engaged url means valid; otherwise a non-zero
+    /// tag_len means the URL failed validation; a zero tag_len means not a tag.
+    [[nodiscard]]
+    constexpr auto is_valid(this auto const& self) noexcept -> bool {
+        return self.url.has_value();
+    }
+
+    [[nodiscard]]
+    constexpr auto is_invalid_url(this auto const& self) noexcept -> bool {
+        return self.url.has_value() == false && self.tag_len != 0;
+    }
+
+    [[nodiscard]]
+    constexpr auto is_not_a_tag(this auto const& self) noexcept -> bool {
+        return self.tag_len == 0;
+    }
 };
 
 template<::pltxt2htm::Contracts ndebug>
@@ -3091,21 +3141,20 @@ constexpr auto try_parse_external_tag(
     auto opt_auth_end = ::pltxt2htm::details::try_parse_url_authority<ndebug>(
         url_vw, ::pltxt2htm::details::try_parse_url_scheme<ndebug>(url_vw).value_or(::std::size_t{}));
     if (opt_auth_end.has_value() == false) {
-        return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url, .tag_len = tag_len};
+        return TryParseExternalTagResult<ndebug>{tag_len};
     }
     auto auth_end = opt_auth_end.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
     auto path_end = ::pltxt2htm::details::try_parse_url_path_unicode<ndebug>(url_vw, auth_end);
     if (path_end != url_vw.size()) {
-        return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url, .tag_len = tag_len};
+        return TryParseExternalTagResult<ndebug>{tag_len};
     }
     auto opt_url = ::pltxt2htm::details::make_try_parse_url_result<ndebug>(url_vw, url_vw.size());
     if (opt_url.has_value() == false) {
-        return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url, .tag_len = tag_len};
+        return TryParseExternalTagResult<ndebug>{tag_len};
     }
 
-    return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::valid,
-            .tag_len = tag_len,
-            .url = ::std::move(opt_url.template value<ndebug == ::pltxt2htm::Contracts::ignore>().url)};
+    return TryParseExternalTagResult<ndebug>{
+        tag_len, ::std::move(opt_url.template value<ndebug == ::pltxt2htm::Contracts::ignore>().url)};
 }
 
 /**
@@ -3120,9 +3169,40 @@ constexpr auto try_parse_external_tag(
  */
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseLinkTagResult {
-    ::pltxt2htm::details::TryParseTagOutcomeKind kind{::pltxt2htm::details::TryParseTagOutcomeKind::not_a_tag};
-    ::std::size_t tag_len{}; ///< Opening-tag length in the input view (valid for valid/invalid_url).
-    ::exception::optional<::pltxt2htm::Url> url{::exception::nullopt}; ///< Extracted URL; engaged only when valid.
+    ::std::size_t tag_len; ///< Opening-tag length in the input view (valid for valid/invalid_url).
+    ::exception::optional<::pltxt2htm::Url> url; ///< Extracted URL; engaged only when valid.
+
+    constexpr TryParseLinkTagResult() noexcept
+        : tag_len{},
+          url{::exception::nullopt} {
+    }
+
+    constexpr TryParseLinkTagResult(::std::size_t tag_len_) noexcept
+        : tag_len{tag_len_},
+          url{::exception::nullopt} {
+    }
+
+    constexpr TryParseLinkTagResult(::std::size_t tag_len_, ::pltxt2htm::Url&& url_) noexcept
+        : tag_len{tag_len_},
+          url(::std::move(url_)) {
+    }
+
+    /// State is derived from the payload: engaged url means valid; otherwise a non-zero
+    /// tag_len means the URL failed validation; a zero tag_len means not a tag.
+    [[nodiscard]]
+    constexpr auto is_valid(this auto const& self) noexcept -> bool {
+        return self.url.has_value();
+    }
+
+    [[nodiscard]]
+    constexpr auto is_invalid_url(this auto const& self) noexcept -> bool {
+        return self.url.has_value() == false && self.tag_len != 0;
+    }
+
+    [[nodiscard]]
+    constexpr auto is_not_a_tag(this auto const& self) noexcept -> bool {
+        return self.tag_len == 0;
+    }
 };
 
 template<::pltxt2htm::Contracts ndebug>
@@ -3149,21 +3229,20 @@ constexpr auto try_parse_link_tag(
     auto opt_auth_end = ::pltxt2htm::details::try_parse_url_authority<ndebug>(
         url_vw, ::pltxt2htm::details::try_parse_url_scheme<ndebug>(url_vw).value_or(::std::size_t{}));
     if (opt_auth_end.has_value() == false) {
-        return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url, .tag_len = tag_len};
+        return TryParseLinkTagResult<ndebug>{tag_len};
     }
     auto auth_end = opt_auth_end.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
     auto path_end = ::pltxt2htm::details::try_parse_url_path_unicode<ndebug>(url_vw, auth_end);
     if (path_end != url_vw.size()) {
-        return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url, .tag_len = tag_len};
+        return TryParseLinkTagResult<ndebug>{tag_len};
     }
     auto opt_url = ::pltxt2htm::details::make_try_parse_url_result<ndebug>(url_vw, url_vw.size());
     if (opt_url.has_value() == false) {
-        return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::invalid_url, .tag_len = tag_len};
+        return TryParseLinkTagResult<ndebug>{tag_len};
     }
 
-    return {.kind = ::pltxt2htm::details::TryParseTagOutcomeKind::valid,
-            .tag_len = tag_len,
-            .url = ::std::move(opt_url.template value<ndebug == ::pltxt2htm::Contracts::ignore>().url)};
+    return TryParseLinkTagResult<ndebug>{
+        tag_len, ::std::move(opt_url.template value<ndebug == ::pltxt2htm::Contracts::ignore>().url)};
 }
 
 template<::pltxt2htm::Contracts ndebug>

--- a/include/pltxt2htm/experimental/html_parser.hh
+++ b/include/pltxt2htm/experimental/html_parser.hh
@@ -89,11 +89,13 @@ entry:
                 case u8'a':
                     [[fallthrough]];
                 case u8'A': {
-                    if (auto opt_a_tag = ::pltxt2htm::details::try_parse_html_a_tag<ndebug>(
+                    if (auto a_tag = ::pltxt2htm::details::try_parse_html_a_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_a_tag.has_value()) {
-                        auto&& [tag_len, url, internal] =
-                            opt_a_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        a_tag.kind == ::pltxt2htm::details::TryParseTagOutcomeKind::valid) {
+                        auto tag_len = a_tag.tag_len;
+                        ::pltxt2htm::Url url =
+                            ::std::move(a_tag.url).template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        auto const internal = a_tag.internal;
                         current_index += tag_len + 2;
                         call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                             ::pltxt2htm::details::FrontendContextVariant<ndebug>{

--- a/include/pltxt2htm/experimental/html_parser.hh
+++ b/include/pltxt2htm/experimental/html_parser.hh
@@ -91,7 +91,7 @@ entry:
                 case u8'A': {
                     if (auto a_tag = ::pltxt2htm::details::try_parse_html_a_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        a_tag.kind == ::pltxt2htm::details::TryParseTagOutcomeKind::valid) {
+                        a_tag.is_valid()) {
                         auto tag_len = a_tag.tag_len;
                         ::pltxt2htm::Url url =
                             ::std::move(a_tag.url).template value<ndebug == ::pltxt2htm::Contracts::ignore>();

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -78,9 +78,8 @@ public:
           kind{kind_} {
     }
 
-    constexpr OptimizerContextVariant(
-        ::pltxt2htm::details::OptimizerContextWithEqualSignTagInfo equal_sign_tag_context,
-        ::pltxt2htm::NodeKind const kind_) noexcept
+    constexpr OptimizerContextVariant(::pltxt2htm::details::OptimizerContextWithEqualSignTagInfo equal_sign_tag_context,
+                                      ::pltxt2htm::NodeKind const kind_) noexcept
         : equal_sign_tag{equal_sign_tag_context},
           kind{kind_} {
     }

--- a/tests/test_html_a_tag.cc
+++ b/tests/test_html_a_tag.cc
@@ -83,10 +83,11 @@ int main() {
     }
 
     {
+        // The opening tag is recognized but its URL fails validation, so the whole span
+        // becomes literal text (no auto-link inside).
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<a href=\"https://example.com@evil.invalid/path\">click</a>");
         auto answer = ::fast_io::u8string_view{
-            u8"&lt;a&nbsp;href=&quot;<a href=\"https://example.com\">https://example.com</a>@evil.invalid/"
-            u8"path&quot;&gt;click&lt;/a&gt;"};
+            u8"&lt;a&nbsp;href=&quot;https://example.com@evil.invalid/path&quot;&gt;click&lt;/a&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -152,6 +153,30 @@ int main() {
         pltxt2htm_test_assert_equal(pass2, pass1);
     }
 
+    // --- rejected <a href="..."> tags (recognized structure, invalid URL) become one literal span ---
+
+    {
+        // a '>' inside the quoted value: the span ends at the real closing '>' found
+        // by the parser, not the first '>'
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<a href=\"https://x.com/a>b\">click</a>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;a&nbsp;href=&quot;https://x.com/a&gt;b&quot;&gt;click&lt;/a&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // single-quoted href value
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<a href='javascript:x'>click</a>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;a&nbsp;href=&apos;javascript:x&apos;&gt;click&lt;/a&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // a newline inside the rejected span becomes a line break; no block re-scan
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<a href=\"https://x\n.com\">click</a>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;a&nbsp;href=&quot;https://x<br>.com&quot;&gt;click&lt;/a&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
     {
         // non-ASCII (CJK) in the path is accepted and percent-encoded
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<a href=\"https://x.com/中文\">click</a>");
@@ -160,10 +185,27 @@ int main() {
     }
 
     {
-        // non-ASCII in the authority (domain) is still rejected; the tag stays literal
+        // non-ASCII in the authority (domain) is still rejected; the span stays literal
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<a href=\"https://中文.com/path\">click</a>");
         auto answer =
             ::fast_io::u8string_view{u8"&lt;a&nbsp;href=&quot;https://中文.com/path&quot;&gt;click&lt;/a&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // a valid tag right after the rejected span still parses normally
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<a href=\"https://example.com@evil.invalid/path\"><i>ok</i>");
+        auto answer = ::fast_io::u8string_view{
+            u8"&lt;a&nbsp;href=&quot;https://example.com@evil.invalid/path&quot;&gt;<em>ok</em>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // the boolean "internal" attribute is part of the span when the URL is invalid
+        auto html =
+            ::pltxt2htm_test::pltxt4unittest(u8"<a href=\"https://example.com@evil.invalid/path\" internal>click</a>");
+        auto answer = ::fast_io::u8string_view{
+            u8"&lt;a&nbsp;href=&quot;https://example.com@evil.invalid/path&quot;&nbsp;internal&gt;click&lt;/a&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_pl_link_tag.cc
+++ b/tests/test_pl_link_tag.cc
@@ -146,12 +146,11 @@ int main() {
     }
 
     {
-        // At the root there is no URL-link outer frame, so the URL inside this rejected
-        // tag is still auto-linked.
+        // The opening tag is recognized but its URL fails validation, so the whole span
+        // becomes literal text (no auto-link inside).
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<link=\"https://a.com\"onclick=\"alert(1)\">x</link>");
         auto answer = ::fast_io::u8string_view{
-            u8"&lt;link=&quot;<a href=\"https://a.com\">https://a.com</a>&quot;onclick=&quot;alert(1)&quot;&gt;x&lt;/"
-            u8"link&gt;"};
+            u8"&lt;link=&quot;https://a.com&quot;onclick=&quot;alert(1)&quot;&gt;x&lt;/link&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -198,6 +197,53 @@ int main() {
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"ab<link=\"https://example.com\">example</link>cd");
         auto answer = ::fast_io::u8string_view{u8"ab<link=\"https://example.com\">example</link>cd"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    // --- rejected <link="..."> tags (recognized structure, invalid URL) become one literal span ---
+
+    {
+        // a '<' inside the rejected value no longer dispatches as a real tag
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<link=\"a<b\">x</link>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;link=&quot;a&lt;b&quot;&gt;x&lt;/link&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // '&amp;' inside the rejected span stays an entity (no double escaping)
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<link=\"javascript:alert(&amp;x)\">x</link>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;link=&quot;javascript:alert(&amp;x)&quot;&gt;x&lt;/link&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // macros inside the rejected span are not expanded
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<link=\"javascript:alert({Project})\">x</link>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;link=&quot;javascript:alert({Project})&quot;&gt;x&lt;/link&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // backslash escapes are still processed inside the rejected span
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<link=\"javascript:\\*\">x</link>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;link=&quot;javascript:*&quot;&gt;x&lt;/link&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // markdown link syntax inside the rejected span is not interpreted
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<link=\"javascript:[a](https://x.com)\">x</link>");
+        auto answer =
+            ::fast_io::u8string_view{u8"&lt;link=&quot;javascript:[a](https://x.com)&quot;&gt;x&lt;/link&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // the PLUnity backend escapes the rejected span's angle brackets as full-width chars
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<link=\"javascript:x\">x</link>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<size=20>\uff1c</size>link=\"javascript:x\"<size=20>\uff1e</size>x<size=20>\uff1c</size>/link<size=20>"
+            u8"\uff1e</size>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 


### PR DESCRIPTION
When an opening tag of a URL-bearing kind (html_a <a href="...">,
pl_external <external=...>, pl_link <link="...">) is structurally
recognized but its URL fails validation, the tag was previously re-parsed
character by character. That re-parse re-interpreted the tag's own text:
a valid-looking URL inside it was auto-linked (even at the root), and a
nested '<', markdown link, macro, LaTeX or escape inside the value could
be parsed as real syntax.

Introduce a tagged outcome protocol for the three tag parsers and consume
the whole invalid opening tag as one literal span instead:

- try_parse_html_a_tag / try_parse_external_tag / try_parse_link_tag now
    return a result discriminated by TryParseTagOutcomeKind
    (not_a_tag / invalid_url / valid) carrying the tag length, with the URL
    held in an optional engaged only on success.
- The parser call sites feed invalid_url spans to simply_parse_pltext,
    which now supports an empty end-string (parse the whole view). Escaping
    (&amp; entities, backslash escapes, quotes, spaces, tabs, newlines,
    multi-byte UTF-8) stays byte-faithful, while auto-link, tag dispatch,
    markdown links, macros and LaTeX inside the rejected tag are no longer
    interpreted.
- Experimental html_parser.hh adapted to the new result type (behavior
    unchanged).

Tests: rejected <a href="..."> / <link="..."> tags no longer auto-link
their inner URL (updated expectations), plus corner cases for nested '<',
'>' inside a quoted value, single-quoted href, entities, escapes, macros,
markdown link syntax, newlines, non-ASCII text, a valid tag following the
rejected span, and the "internal" attribute with an invalid URL.