### PR TITLE
feat: Support Unity TMP `<voffset=N>` tag via a dedicated `pl_voffset` node

### DIFF
--- a/benches/include/bench_fixtures.hh
+++ b/benches/include/bench_fixtures.hh
@@ -179,7 +179,7 @@ inline auto build_html_span_ast(::std::size_t count) -> ::pltxt2htm::Ast<ndebug>
         sub.push_back(::pltxt2htm::PlTxtNode<ndebug>{::pltxt2htm::U8Char{u8't'}});
         ast.push_back(::pltxt2htm::PlTxtNode<ndebug>{::pltxt2htm::HtmlSpan<ndebug>{
             ::std::move(sub), ::fast_io::u8string{u8"color:red;font-size:16px"},
-            ::exception::optional<::pltxt2htm::ValueWithUnit>{::exception::nullopt},
+            ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>>{::exception::nullopt},
             ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>>{::exception::nullopt}}});
     }
     return ast;

--- a/benches/src/bench_micro.cc
+++ b/benches/src/bench_micro.cc
@@ -44,7 +44,7 @@ BENCHMARK_DEFINE_F(MicroFixture, NodeCreate_HtmlSpan)(benchmark::State& st) {
         sub.push_back(::pltxt2htm::PlTxtNode<ndebug>{::pltxt2htm::U8Char{u8't'}});
         ::pltxt2htm::PlTxtNode<ndebug> node{::pltxt2htm::HtmlSpan<ndebug>{
             ::std::move(sub), ::fast_io::u8string{u8"color:red;"},
-            ::exception::optional<::pltxt2htm::ValueWithUnit>{::exception::nullopt},
+            ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>>{::exception::nullopt},
             ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>>{::exception::nullopt}}};
         ::benchmark::DoNotOptimize(node);
     }

--- a/include/pltxt2htm/ast/ast.hh
+++ b/include/pltxt2htm/ast/ast.hh
@@ -164,6 +164,7 @@ class PlTxtNode {
         ::pltxt2htm::PlExternal<ndebug> pl_external_node;
         ::pltxt2htm::PlLink<ndebug> pl_link_node;
         ::pltxt2htm::PlSize<ndebug> pl_size_node;
+        ::pltxt2htm::PlVoffset<ndebug> pl_voffset_node;
         ::pltxt2htm::PlMark<ndebug> pl_mark_node;
         ::pltxt2htm::PlI<ndebug> pl_i_node;
         ::pltxt2htm::PlB<ndebug> pl_b_node;
@@ -231,6 +232,11 @@ public:
     constexpr PlTxtNode(::pltxt2htm::PlSize<ndebug>&& node) noexcept
         : pl_size_node(::std::move(node)),
           node_kind{::pltxt2htm::NodeKind::pl_size} {
+    }
+
+    constexpr PlTxtNode(::pltxt2htm::PlVoffset<ndebug>&& node) noexcept
+        : pl_voffset_node(::std::move(node)),
+          node_kind{::pltxt2htm::NodeKind::pl_voffset} {
     }
 
     constexpr PlTxtNode(::pltxt2htm::PlMark<ndebug>&& node) noexcept
@@ -889,6 +895,10 @@ public:
             new (::std::addressof(pl_size_node))::pltxt2htm::PlSize(other.pl_size_node);
             break;
         }
+        case ::pltxt2htm::NodeKind::pl_voffset: {
+            new (::std::addressof(pl_voffset_node))::pltxt2htm::PlVoffset(other.pl_voffset_node);
+            break;
+        }
         case ::pltxt2htm::NodeKind::pl_mark: {
             new (::std::addressof(pl_mark_node))::pltxt2htm::PlMark(other.pl_mark_node);
             break;
@@ -1457,6 +1467,10 @@ public:
         }
         case ::pltxt2htm::NodeKind::pl_size: {
             new (::std::addressof(pl_size_node))::pltxt2htm::PlSize(::std::move(other.pl_size_node));
+            break;
+        }
+        case ::pltxt2htm::NodeKind::pl_voffset: {
+            new (::std::addressof(pl_voffset_node))::pltxt2htm::PlVoffset(::std::move(other.pl_voffset_node));
             break;
         }
         case ::pltxt2htm::NodeKind::pl_mark: {
@@ -2095,6 +2109,10 @@ public:
             pl_size_node.~PlSize();
             break;
         }
+        case ::pltxt2htm::NodeKind::pl_voffset: {
+            pl_voffset_node.~PlVoffset();
+            break;
+        }
         case ::pltxt2htm::NodeKind::pl_mark: {
             pl_mark_node.~PlMark();
             break;
@@ -2637,6 +2655,9 @@ public:
         }
         case ::pltxt2htm::NodeKind::pl_size: {
             return self.pl_size_node == other.pl_size_node;
+        }
+        case ::pltxt2htm::NodeKind::pl_voffset: {
+            return self.pl_voffset_node == other.pl_voffset_node;
         }
         case ::pltxt2htm::NodeKind::pl_mark: {
             return self.pl_mark_node == other.pl_mark_node;
@@ -3874,6 +3895,13 @@ public:
         bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::pl_size};
         pltxt2htm_assert(is_type, u8"node kind mismatch");
         return ::std::forward_like<decltype(self)>(self.pl_size_node);
+    }
+
+    [[nodiscard]]
+    constexpr auto as_pl_voffset(this auto&& self) noexcept -> decltype(auto) {
+        bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::pl_voffset};
+        pltxt2htm_assert(is_type, u8"node kind mismatch");
+        return ::std::forward_like<decltype(self)>(self.pl_voffset_node);
     }
 
     [[nodiscard]]

--- a/include/pltxt2htm/ast/impl/html_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/html_node_decl.hh
@@ -609,12 +609,12 @@ template<::pltxt2htm::Contracts ndebug>
 class HtmlSpan {
     ::pltxt2htm::Ast<ndebug> subast;
     ::fast_io::u8string color;
-    ::exception::optional<::pltxt2htm::ValueWithUnit> font_size;
+    ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> font_size;
     ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>> vertical_align;
 
 public:
     constexpr HtmlSpan(::pltxt2htm::Ast<ndebug>&& subast_, ::fast_io::u8string&& color_,
-                       ::exception::optional<::pltxt2htm::ValueWithUnit> font_size_,
+                       ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> font_size_,
                        ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>> vertical_align_) noexcept;
     constexpr HtmlSpan(::pltxt2htm::HtmlSpan<ndebug> const&) noexcept;
     constexpr HtmlSpan(::pltxt2htm::HtmlSpan<ndebug>&&) noexcept;
@@ -637,7 +637,8 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto get_font_size(this auto&& self) noexcept -> ::exception::optional<::pltxt2htm::ValueWithUnit> {
+    constexpr auto get_font_size(this auto&& self) noexcept
+        -> ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> {
         return self.font_size;
     }
 

--- a/include/pltxt2htm/ast/impl/html_node_def.inc
+++ b/include/pltxt2htm/ast/impl/html_node_def.inc
@@ -605,7 +605,7 @@ constexpr auto ::pltxt2htm::HtmlColgroup<ndebug>::operator==(this ::pltxt2htm::H
 template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::HtmlSpan<ndebug>::HtmlSpan(
     ::pltxt2htm::Ast<ndebug>&& subast_, ::fast_io::u8string&& color_,
-    ::exception::optional<::pltxt2htm::ValueWithUnit> font_size_,
+    ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> font_size_,
     ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>> vertical_align_) noexcept
     : subast(::std::move(subast_)),
       color(::std::move(color_)),

--- a/include/pltxt2htm/ast/impl/physics_lab_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/physics_lab_node_decl.hh
@@ -292,6 +292,40 @@ public:
 };
 
 /**
+ * @brief Physics-Lab vertical offset tag node
+ * @details Represents &lt;voffset=value&gt;...&lt;/voffset&gt; (Unity TextMeshPro rich text)
+ *          with a signed pixel offset (negative shifts text down) and sub-AST.
+ */
+template<::pltxt2htm::Contracts ndebug>
+class PlVoffset {
+    ::pltxt2htm::Ast<ndebug> subast;
+    ::std::ptrdiff_t value;
+
+public:
+    constexpr PlVoffset(::pltxt2htm::Ast<ndebug>&& subast_, ::std::ptrdiff_t value_) noexcept;
+    constexpr PlVoffset(::pltxt2htm::PlVoffset<ndebug> const&) noexcept;
+    constexpr PlVoffset(::pltxt2htm::PlVoffset<ndebug>&&) noexcept;
+    constexpr ~PlVoffset() noexcept;
+    constexpr auto operator=(::pltxt2htm::PlVoffset<ndebug> const&) noexcept
+        -> ::pltxt2htm::PlVoffset<ndebug>& = delete;
+    constexpr auto operator=(this ::pltxt2htm::PlVoffset<ndebug>& self, ::pltxt2htm::PlVoffset<ndebug>&&) noexcept
+        -> ::pltxt2htm::PlVoffset<ndebug>&;
+
+    [[nodiscard]]
+    constexpr auto operator==(this PlVoffset const&, PlVoffset const&) noexcept -> bool;
+
+    [[nodiscard]]
+    constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.subast);
+    }
+
+    [[nodiscard]]
+    constexpr auto get_value(this auto const& self) noexcept -> ::std::ptrdiff_t {
+        return self.value;
+    }
+};
+
+/**
  * @brief Physics-Lab mark tag node
  * @details Represents &lt;mark=value&gt;...&lt;/mark&gt; (TMP rich text) with a background
  *          color string and sub-AST.

--- a/include/pltxt2htm/ast/impl/physics_lab_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/physics_lab_node_decl.hh
@@ -256,10 +256,10 @@ public:
 template<::pltxt2htm::Contracts ndebug>
 class PlSize {
     ::pltxt2htm::Ast<ndebug> subast;
-    ::pltxt2htm::ValueWithUnit font_size;
+    ::pltxt2htm::ValueWithUnit<::std::size_t> font_size;
 
 public:
-    constexpr PlSize(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::ValueWithUnit font_size_) noexcept;
+    constexpr PlSize(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::ValueWithUnit<::std::size_t> font_size_) noexcept;
     constexpr PlSize(::pltxt2htm::PlSize<ndebug> const&) noexcept;
     constexpr PlSize(::pltxt2htm::PlSize<ndebug>&&) noexcept;
     constexpr ~PlSize() noexcept;
@@ -286,7 +286,7 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto get_font_size(this auto&& self) noexcept -> ::pltxt2htm::ValueWithUnit {
+    constexpr auto get_font_size(this auto&& self) noexcept -> ::pltxt2htm::ValueWithUnit<::std::size_t> {
         return self.font_size;
     }
 };

--- a/include/pltxt2htm/ast/impl/physics_lab_node_def.inc
+++ b/include/pltxt2htm/ast/impl/physics_lab_node_def.inc
@@ -178,6 +178,29 @@ constexpr auto ::pltxt2htm::PlSize<ndebug>::operator==(this ::pltxt2htm::PlSize<
                                                        ::pltxt2htm::PlSize<ndebug> const&) noexcept -> bool = default;
 
 template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::PlVoffset<ndebug>::PlVoffset(::pltxt2htm::Ast<ndebug>&& subast_,
+                                                    ::std::ptrdiff_t value_) noexcept
+    : subast(::std::move(subast_)),
+      value(value_) {
+}
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::PlVoffset<ndebug>::PlVoffset(::pltxt2htm::PlVoffset<ndebug> const&) noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::PlVoffset<ndebug>::PlVoffset(::pltxt2htm::PlVoffset<ndebug>&&) noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::PlVoffset<ndebug>::~PlVoffset() noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr auto ::pltxt2htm::PlVoffset<ndebug>::operator=(this ::pltxt2htm::PlVoffset<ndebug>& self,
+                                                         ::pltxt2htm::PlVoffset<ndebug>&&) noexcept
+    -> ::pltxt2htm::PlVoffset<ndebug>& = default;
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr auto ::pltxt2htm::PlVoffset<ndebug>::operator==(this ::pltxt2htm::PlVoffset<ndebug> const&,
+                                                          ::pltxt2htm::PlVoffset<ndebug> const&) noexcept
+    -> bool = default;
+
+template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::PlMark<ndebug>::PlMark(::pltxt2htm::Ast<ndebug>&& subast_,
                                               ::fast_io::u8string&& background_color_) noexcept
     : subast(::std::move(subast_)),

--- a/include/pltxt2htm/ast/impl/physics_lab_node_def.inc
+++ b/include/pltxt2htm/ast/impl/physics_lab_node_def.inc
@@ -157,7 +157,7 @@ constexpr auto ::pltxt2htm::PlLink<ndebug>::operator==(this ::pltxt2htm::PlLink<
 
 template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::PlSize<ndebug>::PlSize(::pltxt2htm::Ast<ndebug>&& subast_,
-                                              ::pltxt2htm::ValueWithUnit font_size_) noexcept
+                                              ::pltxt2htm::ValueWithUnit<::std::size_t> font_size_) noexcept
     : subast(::std::move(subast_)),
       font_size(font_size_) {
 }

--- a/include/pltxt2htm/ast/node_kind.hh
+++ b/include/pltxt2htm/ast/node_kind.hh
@@ -43,6 +43,7 @@ enum class NodeKind : unsigned {
     pl_discussion, ///< Physics-Lab discussion reference: &lt;discussion=id&gt;...&lt;/discussion&gt;
     pl_user, ///< Physics-Lab user reference: &lt;user=id&gt;...&lt;/user&gt;
     pl_size, ///< Physics-Lab font size: &lt;size=value&gt;...&lt;/size&gt;
+    pl_voffset, ///< Physics-Lab vertical offset (Unity TMP rich text): &lt;voffset=value&gt;...&lt;/voffset&gt;
     pl_mark, ///< Physics-Lab mark (TMP rich text): &lt;mark=Xxx&gt;...&lt;/mark&gt;
     pl_external, ///< Physics-Lab external link: &lt;external=url&gt;...&lt;/external&gt;
     pl_link, ///< Physics-Lab link (Unity TextMeshPro rich text): &lt;link=&quot;url&quot;&gt;...&lt;/link&gt;

--- a/include/pltxt2htm/ast/value_unit.hh
+++ b/include/pltxt2htm/ast/value_unit.hh
@@ -38,4 +38,17 @@ struct ValueWithUnit {
     constexpr auto operator==(::pltxt2htm::ValueWithUnit const& other) const noexcept -> bool = default;
 };
 
+/**
+ * @brief A signed numeric value together with its unit.
+ * @details Like ::pltxt2htm::ValueWithUnit but with a signed value, used where a
+ *          negative number is meaningful (e.g. `vertical-align:-5px`).
+ */
+struct SignedValueWithUnit {
+    ::std::ptrdiff_t value; ///< Signed numeric value
+    ::pltxt2htm::Unit unit; ///< Unit of the value (px, % or em)
+
+    [[nodiscard]]
+    constexpr auto operator==(::pltxt2htm::SignedValueWithUnit const& other) const noexcept -> bool = default;
+};
+
 } // namespace pltxt2htm

--- a/include/pltxt2htm/ast/value_unit.hh
+++ b/include/pltxt2htm/ast/value_unit.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <cstddef>
 
 namespace pltxt2htm {
@@ -29,26 +30,17 @@ enum class Unit : unsigned {
  * @details Pairs the numeric value with its ::pltxt2htm::Unit so the two
  *          never travel independently. This avoids carrying an invalid/undefined
  *          unit when no value is present (the value is then simply absent).
+ * @tparam T The numeric type of the value. Use ::std::size_t for non-negative
+ *           quantities (font size) and a signed type such as ::std::ptrdiff_t
+ *           where a negative value is meaningful (e.g. `vertical-align:-5px`).
  */
+template<::std::integral T>
 struct ValueWithUnit {
-    ::std::size_t value; ///< Numeric value
+    T value; ///< Numeric value
     ::pltxt2htm::Unit unit; ///< Unit of the value (px, % or em)
 
     [[nodiscard]]
-    constexpr auto operator==(::pltxt2htm::ValueWithUnit const& other) const noexcept -> bool = default;
-};
-
-/**
- * @brief A signed numeric value together with its unit.
- * @details Like ::pltxt2htm::ValueWithUnit but with a signed value, used where a
- *          negative number is meaningful (e.g. `vertical-align:-5px`).
- */
-struct SignedValueWithUnit {
-    ::std::ptrdiff_t value; ///< Signed numeric value
-    ::pltxt2htm::Unit unit; ///< Unit of the value (px, % or em)
-
-    [[nodiscard]]
-    constexpr auto operator==(::pltxt2htm::SignedValueWithUnit const& other) const noexcept -> bool = default;
+    constexpr auto operator==(::pltxt2htm::ValueWithUnit<T> const& other) const noexcept -> bool = default;
 };
 
 } // namespace pltxt2htm

--- a/include/pltxt2htm/ast/vertical_align_value.hh
+++ b/include/pltxt2htm/ast/vertical_align_value.hh
@@ -3,7 +3,8 @@
  * @brief Vertical-align value type definitions for pltxt2htm
  * @details Defines the vertical-align value used by &lt;span style="vertical-align:..."&gt;
  *          so the keyword (e.g. super/sub) or numeric length and its unit never
- *          travel independently. Percent/px lengths reuse ::pltxt2htm::ValueWithUnit.
+ *          travel independently. Percent/px lengths reuse ::pltxt2htm::ValueWithUnit
+ *          with a signed value type (::std::ptrdiff_t) so negatives are representable.
  */
 
 #pragma once
@@ -44,7 +45,7 @@ enum class VerticalAlignKind : unsigned {
  * @brief A vertical-align value.
  * @details A tagged union discriminated by `kind`: when `kind == keyword`, the
  *          active member is `keyword`; when `kind == length`, the active member
- *          is `length` (a ::pltxt2htm::ValueWithUnit). Exactly one member is
+ *          is `length` (a ::pltxt2htm::ValueWithUnit&lt;::std::ptrdiff_t&gt;). Exactly one member is
  *          active at any time. The `kind` is derived from the constructor used
  *          and needs no explicit argument. Template parameter `ndebug` selects
  *          whether the accessor contract checks are enforced at runtime.
@@ -55,7 +56,7 @@ class VerticalAlignValue {
 
     union {
         ::pltxt2htm::VerticalAlignKeyword keyword; ///< Keyword value (kind == keyword).
-        ::pltxt2htm::SignedValueWithUnit length; ///< Signed length value+unit (kind == length).
+        ::pltxt2htm::ValueWithUnit<::std::ptrdiff_t> length; ///< Signed length value+unit (kind == length).
     };
 
 public:
@@ -64,7 +65,7 @@ public:
           keyword(keyword_) {
     }
 
-    constexpr VerticalAlignValue(::pltxt2htm::SignedValueWithUnit length_) noexcept
+    constexpr VerticalAlignValue(::pltxt2htm::ValueWithUnit<::std::ptrdiff_t> length_) noexcept
         : kind(::pltxt2htm::VerticalAlignKind::length),
           length(length_) {
     }
@@ -94,7 +95,7 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto get_length(this auto&& self) noexcept -> ::pltxt2htm::SignedValueWithUnit {
+    constexpr auto get_length(this auto&& self) noexcept -> ::pltxt2htm::ValueWithUnit<::std::ptrdiff_t> {
         bool const is_length{self.kind == ::pltxt2htm::VerticalAlignKind::length};
         pltxt2htm_assert(is_length, u8"vertical-align kind mismatch");
         return self.length;

--- a/include/pltxt2htm/ast/vertical_align_value.hh
+++ b/include/pltxt2htm/ast/vertical_align_value.hh
@@ -55,7 +55,7 @@ class VerticalAlignValue {
 
     union {
         ::pltxt2htm::VerticalAlignKeyword keyword; ///< Keyword value (kind == keyword).
-        ::pltxt2htm::ValueWithUnit length; ///< Length value+unit (kind == length).
+        ::pltxt2htm::SignedValueWithUnit length; ///< Signed length value+unit (kind == length).
     };
 
 public:
@@ -64,7 +64,7 @@ public:
           keyword(keyword_) {
     }
 
-    constexpr VerticalAlignValue(::pltxt2htm::ValueWithUnit length_) noexcept
+    constexpr VerticalAlignValue(::pltxt2htm::SignedValueWithUnit length_) noexcept
         : kind(::pltxt2htm::VerticalAlignKind::length),
           length(length_) {
     }
@@ -94,7 +94,7 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto get_length(this auto&& self) noexcept -> ::pltxt2htm::ValueWithUnit {
+    constexpr auto get_length(this auto&& self) noexcept -> ::pltxt2htm::SignedValueWithUnit {
         bool const is_length{self.kind == ::pltxt2htm::VerticalAlignKind::length};
         pltxt2htm_assert(is_length, u8"vertical-align kind mismatch");
         return self.length;

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -373,6 +373,15 @@ entry:
                 result.push_back(u8'>');
                 goto entry;
             }
+            case ::pltxt2htm::NodeKind::pl_voffset: {
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                    node.as_pl_voffset().get_subast(), ::pltxt2htm::NodeKind::pl_voffset, 0));
+                ++current_index;
+                result.append(u8"<voffset=");
+                result.append(::pltxt2htm::details::ptrdiff_t2str(node.as_pl_voffset().get_value()));
+                result.push_back(u8'>');
+                goto entry;
+            }
             case ::pltxt2htm::NodeKind::html_span: {
                 auto const& span_color = node.as_html_span().get_color();
                 auto const& span_font_size = node.as_html_span().get_font_size();
@@ -413,7 +422,7 @@ entry:
                 }
                 if (has_vertical_align) {
                     result.append(u8"<voffset=");
-                    result.append(::pltxt2htm::details::size_t2str(
+                    result.append(::pltxt2htm::details::ptrdiff_t2str(
                         span_vertical_align.template value<ndebug == ::pltxt2htm::Contracts::ignore>()
                             .get_length()
                             .value));
@@ -1295,6 +1304,10 @@ entry:
             }
             case ::pltxt2htm::NodeKind::pl_size: {
                 result.append(u8"</size>");
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_voffset: {
+                result.append(u8"</voffset>");
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_double_emphasis_underscore:

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -495,6 +495,15 @@ entry:
                 }
                 goto entry;
             }
+            case ::pltxt2htm::NodeKind::pl_voffset: {
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                    node.as_pl_voffset().get_subast(), ::pltxt2htm::NodeKind::pl_voffset, 0));
+                ++current_index;
+                result.append(u8"<span style=\"vertical-align:");
+                result.append(::pltxt2htm::details::ptrdiff_t2str(node.as_pl_voffset().get_value()));
+                result.append(u8"px;\">");
+                goto entry;
+            }
             case ::pltxt2htm::NodeKind::html_span: {
                 auto const& span_color = node.as_html_span().get_color();
                 auto const& span_font_size = node.as_html_span().get_font_size();
@@ -545,7 +554,7 @@ entry:
                         result.append(::pltxt2htm::vertical_align_keyword_string<ndebug>(vertical_align.get_keyword()));
                     }
                     else {
-                        result.append(::pltxt2htm::details::size_t2str(vertical_align.get_length().value));
+                        result.append(::pltxt2htm::details::ptrdiff_t2str(vertical_align.get_length().value));
                         if (vertical_align.get_length().unit == ::pltxt2htm::Unit::percent) {
                             result.push_back(u8'%');
                         }
@@ -1400,6 +1409,10 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::pl_size: {
+                result.append(u8"</span>");
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_voffset: {
                 result.append(u8"</span>");
                 goto entry;
             }

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -446,6 +446,12 @@ entry:
                 ++current_index;
                 goto entry;
             }
+            case ::pltxt2htm::NodeKind::pl_voffset: {
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_pl_voffset().get_subast(),
+                                                                                  ::pltxt2htm::NodeKind::text, 0));
+                ++current_index;
+                goto entry;
+            }
             case ::pltxt2htm::NodeKind::html_p: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_p().get_subast(),
                                                                                   ::pltxt2htm::NodeKind::text, 0));

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -173,7 +173,7 @@ entry:
                         result.append(::pltxt2htm::vertical_align_keyword_string<ndebug>(vertical_align.get_keyword()));
                     }
                     else {
-                        result.append(::pltxt2htm::details::size_t2str(vertical_align.get_length().value));
+                        result.append(::pltxt2htm::details::ptrdiff_t2str(vertical_align.get_length().value));
                         if (vertical_align.get_length().unit == ::pltxt2htm::Unit::percent) {
                             result.push_back(u8'%');
                         }

--- a/include/pltxt2htm/details/parser/frame_context.hh
+++ b/include/pltxt2htm/details/parser/frame_context.hh
@@ -115,6 +115,15 @@ public:
 };
 
 /**
+ * @brief Context for <voffset=N> frames during parsing.
+ */
+class ParserFrameContextWithPlVoffsetTagInfo {
+public:
+    ::fast_io::u8string_view pltext;
+    ::std::ptrdiff_t value;
+};
+
+/**
  * @brief Context for pl_mark frames during parsing; stores the background color.
  */
 class ParserFrameContextWithPlMarkInfo {
@@ -209,6 +218,7 @@ public:
         html_a_tag,
         url_info,
         pl_size_tag,
+        pl_voffset_tag,
         html_span_info,
         html_code_info,
         md_block_quotes,
@@ -232,6 +242,7 @@ public:
         ::pltxt2htm::details::ParserFrameContextWithUrlInfo url_info;
         ::pltxt2htm::details::ParserFrameContextWithHtmlATagInfo html_a_tag_info;
         ::pltxt2htm::details::ParserFrameContextWithPlSizeTagInfo pl_size_tag;
+        ::pltxt2htm::details::ParserFrameContextWithPlVoffsetTagInfo pl_voffset_tag;
         ::pltxt2htm::details::ParserFrameContextWithMdBlockQuotesInfo md_block_quotes;
         ::pltxt2htm::details::ParserFrameContextWithMdListInfo<ndebug> md_list;
         ::pltxt2htm::details::ParserFrameContextWithCellInfo cell;
@@ -328,6 +339,16 @@ public:
     }
 
     constexpr FrontendContextVariant(
+        ::pltxt2htm::details::ParserFrameContextWithPlVoffsetTagInfo&& pl_voffset_tag_context,
+        ::pltxt2htm::NodeKind node_kind_) noexcept
+        : pl_voffset_tag{::std::move(pl_voffset_tag_context)},
+#ifdef PLTXT2HTM_CONTEXT_BRANCH_INSTRUMENT
+          context_branch{ContextBranch::pl_voffset_tag},
+#endif
+          kind{node_kind_} {
+    }
+
+    constexpr FrontendContextVariant(
         ::pltxt2htm::details::ParserFrameContextWithMdBlockQuotesInfo&& md_block_quotes_context,
         ::pltxt2htm::NodeKind node_kind_) noexcept
         : md_block_quotes{::std::move(md_block_quotes_context)},
@@ -411,6 +432,11 @@ public:
         case ::pltxt2htm::NodeKind::pl_size: {
             pltxt2htm_assert_context_branch(*this, ContextBranch::pl_size_tag);
             ::std::construct_at(::std::addressof(this->pl_size_tag), ::std::move(other.pl_size_tag));
+            return;
+        }
+        case ::pltxt2htm::NodeKind::pl_voffset: {
+            pltxt2htm_assert_context_branch(*this, ContextBranch::pl_voffset_tag);
+            ::std::construct_at(::std::addressof(this->pl_voffset_tag), ::std::move(other.pl_voffset_tag));
             return;
         }
         case ::pltxt2htm::NodeKind::html_span: {
@@ -729,6 +755,11 @@ public:
         case ::pltxt2htm::NodeKind::pl_size: {
             pltxt2htm_assert_context_branch(*this, ContextBranch::pl_size_tag);
             ::std::destroy_at(::std::addressof(this->pl_size_tag));
+            return;
+        }
+        case ::pltxt2htm::NodeKind::pl_voffset: {
+            pltxt2htm_assert_context_branch(*this, ContextBranch::pl_voffset_tag);
+            ::std::destroy_at(::std::addressof(this->pl_voffset_tag));
             return;
         }
         case ::pltxt2htm::NodeKind::html_span: {
@@ -1236,6 +1267,11 @@ public:
                 context_data_ref, ::pltxt2htm::details::FrontendContextVariant<ndebug>::ContextBranch::pl_size_tag);
             return context_data_ref.pl_size_tag.pltext;
         }
+        case ::pltxt2htm::NodeKind::pl_voffset: {
+            pltxt2htm_assert_context_branch(
+                context_data_ref, ::pltxt2htm::details::FrontendContextVariant<ndebug>::ContextBranch::pl_voffset_tag);
+            return context_data_ref.pl_voffset_tag.pltext;
+        }
         case ::pltxt2htm::NodeKind::html_span: {
             pltxt2htm_assert_context_branch(
                 context_data_ref, ::pltxt2htm::details::FrontendContextVariant<ndebug>::ContextBranch::html_span_info);
@@ -1402,6 +1438,14 @@ public:
         bool const is_pl_size_tag_type{context_data_ref.kind == ::pltxt2htm::NodeKind::pl_size};
         pltxt2htm_assert(is_pl_size_tag_type, u8"context kind mismatch");
         return context_data_ref.pl_size_tag.value;
+    }
+
+    [[nodiscard]]
+    constexpr auto get_pl_voffset_tag_value(this auto&& self) noexcept -> ::std::ptrdiff_t {
+        auto&& context_data_ref = self.context_data;
+        bool const is_pl_voffset_tag_type{context_data_ref.kind == ::pltxt2htm::NodeKind::pl_voffset};
+        pltxt2htm_assert(is_pl_voffset_tag_type, u8"context kind mismatch");
+        return context_data_ref.pl_voffset_tag.value;
     }
 
     [[nodiscard]]

--- a/include/pltxt2htm/details/parser/frame_context.hh
+++ b/include/pltxt2htm/details/parser/frame_context.hh
@@ -64,7 +64,7 @@ class ParserFrameContextWithHtmlSpanInfo {
 public:
     ::fast_io::u8string_view pltext;
     ::fast_io::u8string color;
-    ::exception::optional<::pltxt2htm::ValueWithUnit> font_size;
+    ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> font_size;
     ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>> vertical_align;
 };
 
@@ -111,7 +111,7 @@ public:
 class ParserFrameContextWithPlSizeTagInfo {
 public:
     ::fast_io::u8string_view pltext;
-    ::pltxt2htm::ValueWithUnit value;
+    ::pltxt2htm::ValueWithUnit<::std::size_t> value;
 };
 
 /**
@@ -1433,7 +1433,7 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto get_pl_size_tag_value(this auto&& self) noexcept -> ::pltxt2htm::ValueWithUnit {
+    constexpr auto get_pl_size_tag_value(this auto&& self) noexcept -> ::pltxt2htm::ValueWithUnit<::std::size_t> {
         auto&& context_data_ref = self.context_data;
         bool const is_pl_size_tag_type{context_data_ref.kind == ::pltxt2htm::NodeKind::pl_size};
         pltxt2htm_assert(is_pl_size_tag_type, u8"context kind mismatch");
@@ -1458,7 +1458,7 @@ public:
 
     [[nodiscard]]
     constexpr auto get_html_span_font_size(this auto&& self) noexcept
-        -> ::exception::optional<::pltxt2htm::ValueWithUnit> {
+        -> ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> {
         auto&& context_data_ref = self.context_data;
         bool const is_html_span_type{context_data_ref.kind == ::pltxt2htm::NodeKind::html_span};
         pltxt2htm_assert(is_html_span_type, u8"context kind mismatch");

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -1598,6 +1598,29 @@ entry:
                     continue;
                 }
 
+                case u8'v':
+                    [[fallthrough]];
+                case u8'V': {
+                    // parsing pl <voffset=$1>$2</voffset> tag (Unity TextMeshPro rich text)
+                    if (auto opt_voffset_tag = ::pltxt2htm::details::try_parse_voffset_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_voffset_tag.has_value()) {
+                        auto const [tag_len, value] =
+                            opt_voffset_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPlVoffsetTagInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), value},
+                                ::pltxt2htm::NodeKind::pl_voffset},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+
                 case u8'!': {
                     // parsing: <!--$1-->
                     if (::pltxt2htm::details::is_prefix_match<ndebug, u8"--">(
@@ -1831,6 +1854,25 @@ entry:
                             opt_tag_len.has_value()) {
                             ::std::size_t const staged_index{current_index};
                             ::pltxt2htm::PlSize staged_node(::std::move(result), frame.get_pl_size_tag_value());
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_voffset: {
+                        // parsing </voffset>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"voffset">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlVoffset staged_node(::std::move(result), frame.get_pl_voffset_tag_value());
                             call_stack.pop();
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
@@ -2755,6 +2797,12 @@ entry:
             case ::pltxt2htm::NodeKind::pl_size: {
                 parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
                     ::pltxt2htm::PlSize<ndebug>{::std::move(subast), frame.get_pl_size_tag_value()}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_voffset: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::PlVoffset<ndebug>{::std::move(subast), frame.get_pl_voffset_tag_value()}));
                 parent_index += staged_index;
                 goto entry;
             }

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1094,7 +1094,8 @@ constexpr auto try_parse_voffset_tag(::fast_io::u8string_view pltext) noexcept
         return ::exception::nullopt;
     }
     constexpr auto value_start = prefix_str.size() + 1;
-    auto opt_value = ::pltxt2htm::details::try_parse_ptrdiff_t_decimal_value<ndebug>(pltext, value_start);
+    auto opt_value = ::pltxt2htm::details::try_parse_ptrdiff_t_decimal_value<ndebug>(
+        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, value_start));
     if (opt_value.has_value() == false) {
         return ::exception::nullopt;
     }
@@ -1102,7 +1103,8 @@ constexpr auto try_parse_voffset_tag(::fast_io::u8string_view pltext) noexcept
     if (value.value == 0) {
         return ::exception::nullopt;
     }
-    auto opt_tag = ::pltxt2htm::details::try_parse_equal_sign_tag_suffix<ndebug>(pltext, value_start, value.end);
+    auto const value_end = value_start + value.end;
+    auto opt_tag = ::pltxt2htm::details::try_parse_equal_sign_tag_suffix<ndebug>(pltext, value_start, value_end);
     if (opt_tag.has_value() == false) {
         return ::exception::nullopt;
     }
@@ -1184,7 +1186,8 @@ template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
 constexpr auto try_parse_signed_length_value(::fast_io::u8string_view pltext, ::std::size_t const start) noexcept
     -> ::exception::optional<::pltxt2htm::details::TryParseSignedLengthValueResult> {
-    auto opt_decimal = ::pltxt2htm::details::try_parse_ptrdiff_t_decimal_value<ndebug>(pltext, start);
+    auto opt_decimal = ::pltxt2htm::details::try_parse_ptrdiff_t_decimal_value<ndebug>(
+        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, start));
     if (opt_decimal.has_value() == false) {
         return ::exception::nullopt;
     }
@@ -1192,7 +1195,7 @@ constexpr auto try_parse_signed_length_value(::fast_io::u8string_view pltext, ::
     if (decimal.value == 0) {
         return ::exception::nullopt;
     }
-    auto pos = decimal.end;
+    auto pos = start + decimal.end;
     auto unit = ::pltxt2htm::Unit::px;
     if (pos < pltext.size() && ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'p') {
         ++pos;
@@ -3953,7 +3956,8 @@ constexpr auto try_parse_md_link(::fast_io::u8string_view pltext) noexcept
     }
     ++current_index;
     return ::pltxt2htm::details::TryParseMdLinkResult{.advance_count = current_index,
-                                                      .link_text = pltext.subview(1, link_text_end - 1),
+                                                      .link_text = ::pltxt2htm::details::u8string_view_subview<ndebug>(
+                                                          pltext, 1, link_text_end - 1),
                                                       .link_url = ::std::move(md_url_result.url)};
 }
 

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1161,13 +1161,14 @@ struct TryParseFontSizeValueResult {
 
 /**
  * @brief Parse a non-zero integer optionally followed by lowercase `px`, `em` or `%`.
+ * @details `pltext` must already be subviewed so that it starts at the value, and
+ *          the returned `end` is relative to that subview.
  */
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
-constexpr auto try_parse_font_size_value(::fast_io::u8string_view pltext, ::std::size_t const start) noexcept
+constexpr auto try_parse_font_size_value(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::pltxt2htm::details::TryParseFontSizeValueResult> {
-    auto opt_decimal = ::pltxt2htm::details::try_parse_size_t_decimal_value<ndebug>(
-        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, start));
+    auto opt_decimal = ::pltxt2htm::details::try_parse_size_t_decimal_value<ndebug>(pltext);
     if (opt_decimal.has_value() == false) {
         return ::exception::nullopt;
     }
@@ -1175,7 +1176,7 @@ constexpr auto try_parse_font_size_value(::fast_io::u8string_view pltext, ::std:
     if (decimal.value == 0) {
         return ::exception::nullopt;
     }
-    auto pos = start + decimal.end;
+    auto pos = decimal.end;
     auto unit = ::pltxt2htm::Unit::px;
     if (pos < pltext.size() && ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'p') {
         ++pos;
@@ -1207,14 +1208,15 @@ struct TryParseSignedLengthValueResult {
 /**
  * @brief Parse a non-zero signed integer optionally followed by lowercase `px`, `em` or `%`.
  * @details Accepts an optional leading U+002D '-' sign, so negative lengths such as
- *          `-5px` (used by `vertical-align`) are representable.
+ *          `-5px` (used by `vertical-align`) are representable. `pltext` must already
+ *          be subviewed so that it starts at the value, and the returned `end` is
+ *          relative to that subview.
  */
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
-constexpr auto try_parse_signed_length_value(::fast_io::u8string_view pltext, ::std::size_t const start) noexcept
+constexpr auto try_parse_signed_length_value(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::pltxt2htm::details::TryParseSignedLengthValueResult> {
-    auto opt_decimal = ::pltxt2htm::details::try_parse_ptrdiff_t_decimal_value<ndebug>(
-        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, start));
+    auto opt_decimal = ::pltxt2htm::details::try_parse_ptrdiff_t_decimal_value<ndebug>(pltext);
     if (opt_decimal.has_value() == false) {
         return ::exception::nullopt;
     }
@@ -1222,7 +1224,7 @@ constexpr auto try_parse_signed_length_value(::fast_io::u8string_view pltext, ::
     if (decimal.value == 0) {
         return ::exception::nullopt;
     }
-    auto pos = start + decimal.end;
+    auto pos = decimal.end;
     auto unit = ::pltxt2htm::Unit::px;
     if (pos < pltext.size() && ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'p') {
         ++pos;
@@ -1316,12 +1318,13 @@ constexpr auto try_parse_vertical_align_value(::fast_io::u8string_view pltext, :
                 .end = start + len, .value = ::pltxt2htm::VerticalAlignValue<ndebug>{entry.keyword}};
         }
     }
-    auto opt_length = ::pltxt2htm::details::try_parse_signed_length_value<ndebug>(pltext, start);
+    auto opt_length = ::pltxt2htm::details::try_parse_signed_length_value<ndebug>(
+        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, start));
     if (opt_length.has_value() == false) {
         return ::exception::nullopt;
     }
     auto const length = opt_length.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-    return TryParseVerticalAlignValueResult<ndebug>{.end = length.end,
+    return TryParseVerticalAlignValueResult<ndebug>{.end = start + length.end,
                                                     .value = ::pltxt2htm::VerticalAlignValue<ndebug>{length.value}};
 }
 
@@ -1445,12 +1448,13 @@ constexpr auto try_parse_span_style(::fast_io::u8string_view pltext, char8_t con
             if (font_size.has_value()) {
                 return ::exception::nullopt;
             }
-            auto opt_value = ::pltxt2htm::details::try_parse_font_size_value<ndebug>(pltext, p);
+            auto opt_value = ::pltxt2htm::details::try_parse_font_size_value<ndebug>(
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, p));
             if (opt_value.has_value() == false) {
                 return ::exception::nullopt;
             }
             auto const value = opt_value.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-            p = value.end;
+            p += value.end;
             auto opt_delimiter_pos = ::pltxt2htm::details::try_parse_span_style_property_suffix<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, p), quote);
             if (opt_delimiter_pos.has_value() == false) {

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1128,12 +1128,13 @@ constexpr auto try_parse_voffset_tag(::fast_io::u8string_view pltext) noexcept
         return ::exception::nullopt;
     }
     auto const value_end = value_start + value.end;
-    auto opt_tag = ::pltxt2htm::details::try_parse_equal_sign_tag_suffix<ndebug>(pltext, value_start, value_end);
-    if (opt_tag.has_value() == false) {
+    auto opt_close = ::pltxt2htm::details::try_parse_equal_sign_tag_suffix<ndebug>(
+        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, value_end));
+    if (opt_close.has_value() == false) {
         return ::exception::nullopt;
     }
-    return ::pltxt2htm::details::TryParseVoffsetTagResult{
-        opt_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>().tag_len, value.value};
+    auto const tag_len = value_end + opt_close.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+    return ::pltxt2htm::details::TryParseVoffsetTagResult{tag_len, value.value};
 }
 
 /**
@@ -3982,10 +3983,10 @@ constexpr auto try_parse_md_link(::fast_io::u8string_view pltext) noexcept
         return ::exception::nullopt;
     }
     ++current_index;
-    return ::pltxt2htm::details::TryParseMdLinkResult{.advance_count = current_index,
-                                                      .link_text = ::pltxt2htm::details::u8string_view_subview<ndebug>(
-                                                          pltext, 1, link_text_end - 1),
-                                                      .link_url = ::std::move(md_url_result.url)};
+    return ::pltxt2htm::details::TryParseMdLinkResult{
+        .advance_count = current_index,
+        .link_text = ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, 1, link_text_end - 1),
+        .link_url = ::std::move(md_url_result.url)};
 }
 
 template<::pltxt2htm::Contracts ndebug>

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1032,7 +1032,7 @@ constexpr auto try_parse_color_tag(::fast_io::u8string_view pltext) noexcept
  */
 struct TryParseSizeTagResult {
     ::std::size_t tag_len;
-    ::pltxt2htm::ValueWithUnit value;
+    ::pltxt2htm::ValueWithUnit<::std::size_t> value;
 };
 
 /**
@@ -1117,7 +1117,8 @@ template<::pltxt2htm::Contracts ndebug>
 struct TryParseSpanTagResult {
     ::std::size_t tag_len; ///< Length of the matched tag.
     ::fast_io::u8string color; ///< Extracted color value.
-    ::exception::optional<::pltxt2htm::ValueWithUnit> font_size; ///< Extracted font-size value+unit (if present).
+    ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>>
+        font_size; ///< Extracted font-size value+unit (if present).
     ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>>
         vertical_align; ///< Extracted vertical-align value (if present).
 };
@@ -1127,7 +1128,7 @@ struct TryParseSpanTagResult {
  */
 struct TryParseFontSizeValueResult {
     ::std::size_t end;
-    ::pltxt2htm::ValueWithUnit value;
+    ::pltxt2htm::ValueWithUnit<::std::size_t> value;
 };
 
 /**
@@ -1171,7 +1172,7 @@ constexpr auto try_parse_font_size_value(::fast_io::u8string_view pltext, ::std:
  */
 struct TryParseSignedLengthValueResult {
     ::std::size_t end;
-    ::pltxt2htm::SignedValueWithUnit value;
+    ::pltxt2htm::ValueWithUnit<::std::ptrdiff_t> value;
 };
 
 /**
@@ -1329,7 +1330,8 @@ template<::pltxt2htm::Contracts ndebug>
 struct TryParseSpanStyleResult {
     ::std::size_t end; ///< Byte offset just past the closing quote, relative to the input subview.
     ::fast_io::u8string color; ///< Extracted color value, empty if none was present.
-    ::exception::optional<::pltxt2htm::ValueWithUnit> font_size; ///< Extracted font-size value+unit, if present.
+    ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>>
+        font_size; ///< Extracted font-size value+unit, if present.
     ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>>
         vertical_align; ///< Extracted vertical-align value, if present.
 };
@@ -1340,7 +1342,7 @@ constexpr auto try_parse_span_style(::fast_io::u8string_view pltext, char8_t con
     -> ::exception::optional<TryParseSpanStyleResult<ndebug>> {
     ::std::size_t p{};
     ::fast_io::u8string color{};
-    ::exception::optional<::pltxt2htm::ValueWithUnit> font_size{::exception::nullopt};
+    ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> font_size{::exception::nullopt};
     ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>> vertical_align{::exception::nullopt};
 
     while (p < pltext.size()) {
@@ -1489,7 +1491,7 @@ constexpr auto try_parse_span_tag(::fast_io::u8string_view pltext) noexcept
     ::std::size_t pos{4}; // skip past "span" (the 's' was consumed by the trie dispatch)
     bool found_style{false};
     ::fast_io::u8string color{};
-    ::exception::optional<::pltxt2htm::ValueWithUnit> font_size{::exception::nullopt};
+    ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> font_size{::exception::nullopt};
     ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>> vertical_align{::exception::nullopt};
 
     while (pos < pltext.size()) {

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1073,6 +1073,44 @@ constexpr auto try_parse_size_tag(::fast_io::u8string_view pltext) noexcept
 }
 
 /**
+ * @brief Return type of try_parse_voffset_tag: tag length and the parsed offset value.
+ */
+struct TryParseVoffsetTagResult {
+    ::std::size_t tag_len;
+    ::std::ptrdiff_t value;
+};
+
+/**
+ * @brief Parse a `<voffset=N>` opening tag.
+ * @details N is a signed non-zero decimal pixel offset (Unity TextMeshPro rich text).
+ *          A zero value is rejected so `<voffset=0>` renders as literal text.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_voffset_tag(::fast_io::u8string_view pltext) noexcept
+    -> ::exception::optional<::pltxt2htm::details::TryParseVoffsetTagResult> {
+    constexpr auto prefix_str = ::pltxt2htm::details::U8LiteralString{u8"offset"};
+    if (::pltxt2htm::details::is_equal_sign_tag_prefix<ndebug, prefix_str>(pltext) == false) {
+        return ::exception::nullopt;
+    }
+    constexpr auto value_start = prefix_str.size() + 1;
+    auto opt_value = ::pltxt2htm::details::try_parse_ptrdiff_t_decimal_value<ndebug>(pltext, value_start);
+    if (opt_value.has_value() == false) {
+        return ::exception::nullopt;
+    }
+    auto const value = opt_value.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+    if (value.value == 0) {
+        return ::exception::nullopt;
+    }
+    auto opt_tag = ::pltxt2htm::details::try_parse_equal_sign_tag_suffix<ndebug>(pltext, value_start, value.end);
+    if (opt_tag.has_value() == false) {
+        return ::exception::nullopt;
+    }
+    return ::pltxt2htm::details::TryParseVoffsetTagResult{
+        opt_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>().tag_len, value.value};
+}
+
+/**
  * @brief Return type of try_parse_span_tag: tag length, color, and optional font-size/vertical-align.
  */
 template<::pltxt2htm::Contracts ndebug>
@@ -1126,6 +1164,52 @@ constexpr auto try_parse_font_size_value(::fast_io::u8string_view pltext, ::std:
         pos += 2;
     }
     return ::pltxt2htm::details::TryParseFontSizeValueResult{pos, {decimal.value, unit}};
+}
+
+/**
+ * @brief Result of parsing a signed CSS length value.
+ */
+struct TryParseSignedLengthValueResult {
+    ::std::size_t end;
+    ::pltxt2htm::SignedValueWithUnit value;
+};
+
+/**
+ * @brief Parse a non-zero signed integer optionally followed by lowercase `px`, `em` or `%`.
+ * @details Accepts an optional leading U+002D '-' sign, so negative lengths such as
+ *          `-5px` (used by `vertical-align`) are representable.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_signed_length_value(::fast_io::u8string_view pltext, ::std::size_t const start) noexcept
+    -> ::exception::optional<::pltxt2htm::details::TryParseSignedLengthValueResult> {
+    auto opt_decimal = ::pltxt2htm::details::try_parse_ptrdiff_t_decimal_value<ndebug>(pltext, start);
+    if (opt_decimal.has_value() == false) {
+        return ::exception::nullopt;
+    }
+    auto const decimal = opt_decimal.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+    if (decimal.value == 0) {
+        return ::exception::nullopt;
+    }
+    auto pos = decimal.end;
+    auto unit = ::pltxt2htm::Unit::px;
+    if (pos < pltext.size() && ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'p') {
+        ++pos;
+        if (pos >= pltext.size() || ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'x') {
+            return ::exception::nullopt;
+        }
+        ++pos;
+    }
+    else if (pos < pltext.size() && ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'%') {
+        unit = ::pltxt2htm::Unit::percent;
+        ++pos;
+    }
+    else if (pos + 1 < pltext.size() && ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'e' &&
+             ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos + 1) == u8'm') {
+        unit = ::pltxt2htm::Unit::em;
+        pos += 2;
+    }
+    return ::pltxt2htm::details::TryParseSignedLengthValueResult{pos, {decimal.value, unit}};
 }
 
 /**
@@ -1201,7 +1285,7 @@ constexpr auto try_parse_vertical_align_value(::fast_io::u8string_view pltext, :
                 .end = start + len, .value = ::pltxt2htm::VerticalAlignValue<ndebug>{entry.keyword}};
         }
     }
-    auto opt_length = ::pltxt2htm::details::try_parse_font_size_value<ndebug>(pltext, start);
+    auto opt_length = ::pltxt2htm::details::try_parse_signed_length_value<ndebug>(pltext, start);
     if (opt_length.has_value() == false) {
         return ::exception::nullopt;
     }

--- a/include/pltxt2htm/details/utils.hh
+++ b/include/pltxt2htm/details/utils.hh
@@ -9,8 +9,8 @@
 
 #include <limits>
 #include <cstddef>
-#include <type_traits>
 #include <ranges>
+#include <type_traits>
 #include <fast_io/fast_io_dsal/stack.h>
 #include <fast_io/fast_io_dsal/vector.h>
 #include <fast_io/fast_io_dsal/string.h>
@@ -344,7 +344,7 @@ struct TryParseSizeTDecimalValueResult {
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
 constexpr auto try_parse_size_t_decimal_value(::fast_io::u8string_view str) noexcept
-    -> ::exception::optional<::pltxt2htm::details::TryParseSizeTDecimalValueResult> {
+    -> ::exception::optional<TryParseSizeTDecimalValueResult> {
     ::std::size_t parsed_value{};
     auto pos = ::std::size_t{0};
     for (; pos < str.size(); ++pos) {
@@ -361,7 +361,7 @@ constexpr auto try_parse_size_t_decimal_value(::fast_io::u8string_view str) noex
     if (pos == 0) {
         return ::exception::nullopt;
     }
-    return ::pltxt2htm::details::TryParseSizeTDecimalValueResult{.end = pos, .value = parsed_value};
+    return TryParseSizeTDecimalValueResult{.end = pos, .value = parsed_value};
 }
 
 /**
@@ -415,7 +415,7 @@ struct TryParsePtrdiffTDecimalValueResult {
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
 constexpr auto try_parse_ptrdiff_t_decimal_value(::fast_io::u8string_view str) noexcept
-    -> ::exception::optional<::pltxt2htm::details::TryParsePtrdiffTDecimalValueResult> {
+    -> ::exception::optional<TryParsePtrdiffTDecimalValueResult> {
     using unsigned_type = ::std::make_unsigned_t<::std::ptrdiff_t>;
 
     auto pos = ::std::size_t{0};
@@ -456,7 +456,7 @@ constexpr auto try_parse_ptrdiff_t_decimal_value(::fast_io::u8string_view str) n
         value = static_cast<::std::ptrdiff_t>(parsed_value);
     }
 
-    return ::pltxt2htm::details::TryParsePtrdiffTDecimalValueResult{.end = digit_pos, .value = value};
+    return TryParsePtrdiffTDecimalValueResult{.end = digit_pos, .value = value};
 }
 
 /**
@@ -473,7 +473,7 @@ template<::pltxt2htm::Contracts ndebug>
 #if __has_cpp_attribute(__gnu__::__pure__)
 [[__gnu__::__pure__]]
 #endif
-constexpr auto u8str2size_t(::fast_io::u8string_view str) noexcept -> ::exception::optional<std::size_t> {
+constexpr auto u8str2size_t(::fast_io::u8string_view str) noexcept -> ::exception::optional<::std::size_t> {
     auto result = ::pltxt2htm::details::try_parse_size_t_decimal_value<ndebug>(str);
     if (result.has_value() == false) {
         return ::exception::nullopt;

--- a/include/pltxt2htm/details/utils.hh
+++ b/include/pltxt2htm/details/utils.hh
@@ -405,17 +405,18 @@ struct TryParsePtrdiffTDecimalValueResult {
 };
 
 /**
- * @brief Parse a signed ASCII decimal value starting at a given position.
+ * @brief Parse a signed ASCII decimal value.
  * @details Accepts an optional leading U+002D '-' sign (negative values), stops at
- *          the first non-digit, and rejects empty or overflowing values.
+ *          the first non-digit, and returns nullopt for empty or overflowing values.
+ *          Callers that need to skip a prefix should pass `str` pre-subviewed.
  */
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
-constexpr auto try_parse_ptrdiff_t_decimal_value(::fast_io::u8string_view str, ::std::size_t const start) noexcept
+constexpr auto try_parse_ptrdiff_t_decimal_value(::fast_io::u8string_view str) noexcept
     -> ::exception::optional<::pltxt2htm::details::TryParsePtrdiffTDecimalValueResult> {
     using unsigned_type = ::std::make_unsigned_t<::std::ptrdiff_t>;
 
-    auto pos = start;
+    auto pos = ::std::size_t{0};
     bool const negative = pos < str.size() && ::pltxt2htm::details::u8string_view_index<ndebug>(str, pos) == u8'-';
     if (negative) {
         ++pos;

--- a/include/pltxt2htm/details/utils.hh
+++ b/include/pltxt2htm/details/utils.hh
@@ -9,6 +9,7 @@
 
 #include <limits>
 #include <cstddef>
+#include <type_traits>
 #include <ranges>
 #include <fast_io/fast_io_dsal/stack.h>
 #include <fast_io/fast_io_dsal/vector.h>
@@ -359,6 +360,100 @@ constexpr auto try_parse_size_t_decimal_value(::fast_io::u8string_view str, ::st
         return ::exception::nullopt;
     }
     return ::pltxt2htm::details::TryParseSizeTDecimalValueResult{.end = pos, .value = parsed_value};
+}
+
+/**
+ * @brief Convert a signed integer (::std::ptrdiff_t) to a UTF-8 string.
+ * @details Handles negative values with a leading U+002D '-' sign. Mirrors
+ *          ::pltxt2htm::details::size_t2str but for signed values.
+ */
+[[nodiscard]]
+#if __has_cpp_attribute(__gnu__::__pure__)
+[[__gnu__::__pure__]]
+#endif
+constexpr auto ptrdiff_t2str(::std::ptrdiff_t num) noexcept -> ::fast_io::u8string {
+    if (num == 0) {
+        return ::fast_io::u8string{u8"0"};
+    }
+
+    auto magnitude = static_cast<::std::make_unsigned_t<::std::ptrdiff_t>>(num);
+    if (num < 0) {
+        magnitude = static_cast<::std::make_unsigned_t<::std::ptrdiff_t>>(0) - magnitude;
+    }
+
+    ::fast_io::u8string result{};
+    while (magnitude > 0) {
+        char8_t const digit = (magnitude % 10) + u8'0';
+        result.push_back(digit);
+        magnitude /= 10;
+    }
+    ::std::ranges::reverse(result);
+
+    if (num < 0) {
+        result.insert(result.begin(), ::fast_io::u8string_view{u8"-"});
+    }
+
+    return result;
+}
+
+/**
+ * @brief Result of parsing a signed ASCII decimal value.
+ */
+struct TryParsePtrdiffTDecimalValueResult {
+    ::std::size_t end;
+    ::std::ptrdiff_t value;
+};
+
+/**
+ * @brief Parse a signed ASCII decimal value starting at a given position.
+ * @details Accepts an optional leading U+002D '-' sign (negative values), stops at
+ *          the first non-digit, and rejects empty or overflowing values.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_ptrdiff_t_decimal_value(::fast_io::u8string_view str, ::std::size_t const start) noexcept
+    -> ::exception::optional<::pltxt2htm::details::TryParsePtrdiffTDecimalValueResult> {
+    using unsigned_type = ::std::make_unsigned_t<::std::ptrdiff_t>;
+
+    auto pos = start;
+    bool const negative = pos < str.size() && ::pltxt2htm::details::u8string_view_index<ndebug>(str, pos) == u8'-';
+    if (negative) {
+        ++pos;
+    }
+
+    unsigned_type parsed_value{};
+    auto digit_pos = pos;
+    for (; digit_pos < str.size(); ++digit_pos) {
+        auto const chr = ::pltxt2htm::details::u8string_view_index<ndebug>(str, digit_pos);
+        if (::pltxt2htm::details::is_ascii_digit(chr) == false) {
+            break;
+        }
+        auto const digit = static_cast<unsigned_type>(chr - u8'0');
+        if (parsed_value > (::std::numeric_limits<unsigned_type>::max() - digit) / 10) {
+            return ::exception::nullopt;
+        }
+        parsed_value = parsed_value * 10 + digit;
+    }
+    if (digit_pos == pos) {
+        return ::exception::nullopt;
+    }
+
+    auto const min_magnitude = static_cast<unsigned_type>(::std::numeric_limits<::std::ptrdiff_t>::max()) + 1;
+    if (parsed_value >
+        (negative ? min_magnitude : static_cast<unsigned_type>(::std::numeric_limits<::std::ptrdiff_t>::max()))) {
+        return ::exception::nullopt;
+    }
+
+    ::std::ptrdiff_t value{};
+    if (negative) {
+        value = parsed_value == min_magnitude ? ::std::numeric_limits<::std::ptrdiff_t>::min()
+                                              : -static_cast<::std::ptrdiff_t>(parsed_value);
+    }
+    else {
+        value = static_cast<::std::ptrdiff_t>(parsed_value);
+    }
+
+    return ::pltxt2htm::details::TryParsePtrdiffTDecimalValueResult{.end = digit_pos, .value = value};
 }
 
 /**

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -45,7 +45,7 @@ public:
  */
 class OptimizerContextWithPlSizeTagInfo {
 public:
-    ::pltxt2htm::ValueWithUnit value; ///< Font size value+unit (e.g., {12, px} in size=12)
+    ::pltxt2htm::ValueWithUnit<::std::size_t> value; ///< Font size value+unit (e.g., {12, px} in size=12)
 };
 
 /**
@@ -63,7 +63,7 @@ template<::pltxt2htm::Contracts ndebug>
 class OptimizerContextWithHtmlSpanInfo {
 public:
     ::fast_io::u8string_view color{};
-    ::exception::optional<::pltxt2htm::ValueWithUnit> font_size{::exception::nullopt};
+    ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> font_size{::exception::nullopt};
     ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>> vertical_align{::exception::nullopt};
 };
 
@@ -315,7 +315,7 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto get_pl_size_tag_value(this auto&& self) noexcept -> ::pltxt2htm::ValueWithUnit {
+    constexpr auto get_pl_size_tag_value(this auto&& self) noexcept -> ::pltxt2htm::ValueWithUnit<::std::size_t> {
         auto&& context_data_ref = self.context_data;
         bool const is_pl_size_tag_type{context_data_ref.kind == ::pltxt2htm::NodeKind::pl_size};
         pltxt2htm_assert(is_pl_size_tag_type, u8"context kind mismatch");
@@ -340,7 +340,7 @@ public:
 
     [[nodiscard]]
     constexpr auto get_html_span_font_size(this auto&& self) noexcept
-        -> ::exception::optional<::pltxt2htm::ValueWithUnit> {
+        -> ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> {
         auto&& context_data_ref = self.context_data;
         bool const is_html_span_type{context_data_ref.kind == ::pltxt2htm::NodeKind::html_span};
         pltxt2htm_assert(is_html_span_type, u8"context kind mismatch");
@@ -544,7 +544,8 @@ entry:
                         auto const inner_fs = subnode.as_html_span().get_font_size();
                         auto const inner_va = subnode.as_html_span().get_vertical_align();
                         auto merged_color = ::fast_io::u8string{inner_color.empty() ? outer_color : inner_color};
-                        ::exception::optional<::pltxt2htm::ValueWithUnit> merged_fs{::exception::nullopt};
+                        ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> merged_fs{
+                            ::exception::nullopt};
                         if (inner_fs.has_value()) {
                             merged_fs = inner_fs.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                         }
@@ -569,7 +570,8 @@ entry:
                     if (subnode.get_node_kind() == ::pltxt2htm::NodeKind::pl_color) {
                         auto const outer_fs = node.as_html_span().get_font_size();
                         auto const outer_va = node.as_html_span().get_vertical_align();
-                        ::exception::optional<::pltxt2htm::ValueWithUnit> merged_fs{::exception::nullopt};
+                        ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> merged_fs{
+                            ::exception::nullopt};
                         if (outer_fs.has_value()) {
                             merged_fs = outer_fs.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                         }

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -854,26 +854,24 @@ entry:
             }
             case ::pltxt2htm::NodeKind::pl_voffset: {
                 auto&& subast = node.as_pl_voffset().get_subast();
-                {
-                    if (subast.empty()) {
-                        // <voffset=5></voffset> can be omitted
-                        ast.erase(current_iter);
-                        continue;
-                    }
-                    if (subast.size() == 1) {
-                        // <voffset=5><voffset=3>physicsLab</voffset></voffset> can be
-                        auto& subnode = ::pltxt2htm::details::vector_front<ndebug>(subast);
-                        if (subnode.get_node_kind() == ::pltxt2htm::NodeKind::pl_voffset) {
-                            // SAFETY: We must NOT write `node = ::std::move(subnode);` directly.
-                            // `subnode` is a reference into `node.get_subast()`. When the move-assignment
-                            // operator of the node runs, it first destructs the old value at `node`, which
-                            // in turn destructs `subnode` (since `subnode` lives inside that sub-AST). That means
-                            // `subnode` is destroyed *before* its contents are moved -- a use-after-free.
-                            // By moving `subnode` into a temporary first, we extract the value before the
-                            // destination is touched, breaking the aliasing.
-                            auto tmp = ::std::move(subnode);
-                            node = ::std::move(tmp);
-                        }
+                if (subast.empty()) {
+                    // <voffset=5></voffset> can be omitted
+                    ast.erase(current_iter);
+                    continue;
+                }
+                if (subast.size() == 1) {
+                    // <voffset=5><voffset=3>physicsLab</voffset></voffset> can be
+                    auto& subnode = ::pltxt2htm::details::vector_front<ndebug>(subast);
+                    if (subnode.get_node_kind() == ::pltxt2htm::NodeKind::pl_voffset) {
+                        // SAFETY: We must NOT write `node = ::std::move(subnode);` directly.
+                        // `subnode` is a reference into `node.get_subast()`. When the move-assignment
+                        // operator of the node runs, it first destructs the old value at `node`, which
+                        // in turn destructs `subnode` (since `subnode` lives inside that sub-AST). That means
+                        // `subnode` is destroyed *before* its contents are moved -- a use-after-free.
+                        // By moving `subnode` into a temporary first, we extract the value before the
+                        // destination is touched, breaking the aliasing.
+                        auto tmp = ::std::move(subnode);
+                        node = ::std::move(tmp);
                     }
                 }
                 auto&& frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -49,6 +49,14 @@ public:
 };
 
 /**
+ * @brief Context for optimizer <voffset=N> tags.
+ */
+class OptimizerContextWithPlVoffsetTagInfo {
+public:
+    ::std::ptrdiff_t value; ///< Vertical offset in pixels (e.g., 5 in voffset=5)
+};
+
+/**
  * @brief Context for optimizer html_span frames, remembers color, font-size and vertical-align.
  */
 template<::pltxt2htm::Contracts ndebug>
@@ -89,6 +97,7 @@ public:
         ::pltxt2htm::details::OptimizerContextWithoutInfo without_info;
         ::pltxt2htm::details::OptimizerContextWithEqualSignTagInfo equal_sign_tag;
         ::pltxt2htm::details::OptimizerContextWithPlSizeTagInfo pl_size_tag;
+        ::pltxt2htm::details::OptimizerContextWithPlVoffsetTagInfo pl_voffset_tag;
         ::pltxt2htm::details::OptimizerContextWithHtmlSpanInfo<ndebug> html_span_info;
         ::pltxt2htm::details::OptimizerContextWithHtmlMarkInfo<ndebug> html_mark_info;
         ::pltxt2htm::details::OptimizerContextWithPlMarkInfo<ndebug> pl_mark_info;
@@ -111,6 +120,12 @@ public:
         ::pltxt2htm::details::OptimizerContextWithPlSizeTagInfo pl_size_tag_context) noexcept
         : pl_size_tag{pl_size_tag_context},
           kind{::pltxt2htm::NodeKind::pl_size} {
+    }
+
+    constexpr OptimizerContextVariant(
+        ::pltxt2htm::details::OptimizerContextWithPlVoffsetTagInfo pl_voffset_tag_context) noexcept
+        : pl_voffset_tag{pl_voffset_tag_context},
+          kind{::pltxt2htm::NodeKind::pl_voffset} {
     }
 
     constexpr OptimizerContextVariant(
@@ -150,6 +165,10 @@ public:
             ::std::construct_at(::std::addressof(this->pl_size_tag), ::std::move(other.pl_size_tag));
             return;
         }
+        case ::pltxt2htm::NodeKind::pl_voffset: {
+            ::std::construct_at(::std::addressof(this->pl_voffset_tag), ::std::move(other.pl_voffset_tag));
+            return;
+        }
         case ::pltxt2htm::NodeKind::html_span: {
             ::std::construct_at(::std::addressof(this->html_span_info), ::std::move(other.html_span_info));
             return;
@@ -171,6 +190,7 @@ public:
     static_assert(::std::is_trivially_destructible_v<decltype(without_info)>);
     static_assert(::std::is_trivially_destructible_v<decltype(equal_sign_tag)>);
     static_assert(::std::is_trivially_destructible_v<decltype(pl_size_tag)>);
+    static_assert(::std::is_trivially_destructible_v<decltype(pl_voffset_tag)>);
     static_assert(::std::is_trivially_destructible_v<decltype(html_span_info)>);
     static_assert(::std::is_trivially_destructible_v<decltype(html_mark_info)>);
     static_assert(::std::is_trivially_destructible_v<decltype(pl_mark_info)>);
@@ -237,6 +257,14 @@ public:
 
     constexpr OptimizerFrameContext(
         ::pltxt2htm::Ast<ndebug>* ast_, Iter&& iter_,
+        ::pltxt2htm::details::OptimizerContextWithPlVoffsetTagInfo pl_voffset_tag_context_) noexcept
+        : context_data{::std::move(pl_voffset_tag_context_)},
+          ast(ast_),
+          iter{iter_} {
+    }
+
+    constexpr OptimizerFrameContext(
+        ::pltxt2htm::Ast<ndebug>* ast_, Iter&& iter_,
         ::pltxt2htm::details::OptimizerContextWithHtmlSpanInfo<ndebug>&& html_span_context_) noexcept
         : context_data{::std::move(html_span_context_)},
           ast(ast_),
@@ -292,6 +320,14 @@ public:
         bool const is_pl_size_tag_type{context_data_ref.kind == ::pltxt2htm::NodeKind::pl_size};
         pltxt2htm_assert(is_pl_size_tag_type, u8"context kind mismatch");
         return context_data_ref.pl_size_tag.value;
+    }
+
+    [[nodiscard]]
+    constexpr auto get_pl_voffset_tag_value(this auto&& self) noexcept -> ::std::ptrdiff_t {
+        auto&& context_data_ref = self.context_data;
+        bool const is_pl_voffset_tag_type{context_data_ref.kind == ::pltxt2htm::NodeKind::pl_voffset};
+        pltxt2htm_assert(is_pl_voffset_tag_type, u8"context kind mismatch");
+        return context_data_ref.pl_voffset_tag.value;
     }
 
     [[nodiscard]]
@@ -808,6 +844,45 @@ entry:
                                     typename ::pltxt2htm::Ast<ndebug>::iterator, ndebug>(
                         ::std::addressof(subast), subast.begin(),
                         ::pltxt2htm::details::OptimizerContextWithPlSizeTagInfo{node.as_pl_size().get_font_size()}));
+                    goto entry;
+                }
+                node = ::pltxt2htm::PlTxtNode<ndebug>{::pltxt2htm::Text<ndebug>{::std::move(subast)}};
+                ++current_iter;
+                continue;
+            }
+            case ::pltxt2htm::NodeKind::pl_voffset: {
+                auto&& subast = node.as_pl_voffset().get_subast();
+                {
+                    if (subast.empty()) {
+                        // <voffset=5></voffset> can be omitted
+                        ast.erase(current_iter);
+                        continue;
+                    }
+                    if (subast.size() == 1) {
+                        // <voffset=5><voffset=3>physicsLab</voffset></voffset> can be
+                        auto& subnode = ::pltxt2htm::details::vector_front<ndebug>(subast);
+                        if (subnode.get_node_kind() == ::pltxt2htm::NodeKind::pl_voffset) {
+                            // SAFETY: We must NOT write `node = ::std::move(subnode);` directly.
+                            // `subnode` is a reference into `node.get_subast()`. When the move-assignment
+                            // operator of the node runs, it first destructs the old value at `node`, which
+                            // in turn destructs `subnode` (since `subnode` lives inside that sub-AST). That means
+                            // `subnode` is destroyed *before* its contents are moved -- a use-after-free.
+                            // By moving `subnode` into a temporary first, we extract the value before the
+                            // destination is touched, breaking the aliasing.
+                            auto tmp = ::std::move(subnode);
+                            node = ::std::move(tmp);
+                        }
+                    }
+                }
+                auto&& frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                // Optimization: If the offset is the same as the parent node, ignore the nested tag.
+                bool const is_different_tag = frame.get_nested_tag_type() != ::pltxt2htm::NodeKind::pl_voffset ||
+                                              node.as_pl_voffset().get_value() != frame.get_pl_voffset_tag_value();
+                if (is_different_tag) {
+                    call_stack.push(::pltxt2htm::details::OptimizerFrameContext<
+                                    typename ::pltxt2htm::Ast<ndebug>::iterator, ndebug>(
+                        ::std::addressof(subast), subast.begin(),
+                        ::pltxt2htm::details::OptimizerContextWithPlVoffsetTagInfo{node.as_pl_voffset().get_value()}));
                     goto entry;
                 }
                 node = ::pltxt2htm::PlTxtNode<ndebug>{::pltxt2htm::Text<ndebug>{::std::move(subast)}};

--- a/tests/test_ast_operator_eq.cc
+++ b/tests/test_ast_operator_eq.cc
@@ -451,9 +451,9 @@ int main() {
         ::pltxt2htm::Ast<nd::quick_enforce> ast_b{};
 
         auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::PlSize<nd::quick_enforce>(
-            ::std::move(ast_a), ::pltxt2htm::ValueWithUnit{.value = 14, .unit = ::pltxt2htm::Unit::px}));
+            ::std::move(ast_a), ::pltxt2htm::ValueWithUnit<::std::size_t>{.value = 14, .unit = ::pltxt2htm::Unit::px}));
         auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::PlSize<nd::quick_enforce>(
-            ::std::move(ast_b), ::pltxt2htm::ValueWithUnit{.value = 14, .unit = ::pltxt2htm::Unit::px}));
+            ::std::move(ast_b), ::pltxt2htm::ValueWithUnit<::std::size_t>{.value = 14, .unit = ::pltxt2htm::Unit::px}));
         ::exception::assert_true<false>(a == b);
     }
     {
@@ -461,9 +461,9 @@ int main() {
         ::pltxt2htm::Ast<nd::quick_enforce> ast_b{};
 
         auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::PlSize<nd::quick_enforce>(
-            ::std::move(ast_a), ::pltxt2htm::ValueWithUnit{.value = 14, .unit = ::pltxt2htm::Unit::px}));
+            ::std::move(ast_a), ::pltxt2htm::ValueWithUnit<::std::size_t>{.value = 14, .unit = ::pltxt2htm::Unit::px}));
         auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::PlSize<nd::quick_enforce>(
-            ::std::move(ast_b), ::pltxt2htm::ValueWithUnit{.value = 16, .unit = ::pltxt2htm::Unit::px}));
+            ::std::move(ast_b), ::pltxt2htm::ValueWithUnit<::std::size_t>{.value = 16, .unit = ::pltxt2htm::Unit::px}));
         ::exception::assert_false<false>(a == b);
     }
     {
@@ -471,9 +471,10 @@ int main() {
         ::pltxt2htm::Ast<nd::quick_enforce> ast_b{};
 
         auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::PlSize<nd::quick_enforce>(
-            ::std::move(ast_a), ::pltxt2htm::ValueWithUnit{.value = 14, .unit = ::pltxt2htm::Unit::px}));
+            ::std::move(ast_a), ::pltxt2htm::ValueWithUnit<::std::size_t>{.value = 14, .unit = ::pltxt2htm::Unit::px}));
         auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::PlSize<nd::quick_enforce>(
-            ::std::move(ast_b), ::pltxt2htm::ValueWithUnit{.value = 14, .unit = ::pltxt2htm::Unit::percent}));
+            ::std::move(ast_b),
+            ::pltxt2htm::ValueWithUnit<::std::size_t>{.value = 14, .unit = ::pltxt2htm::Unit::percent}));
         ::exception::assert_false<false>(a == b);
     }
 

--- a/tests/test_html_span_tag.cc
+++ b/tests/test_html_span_tag.cc
@@ -527,10 +527,9 @@ int main() {
     }
 
     {
-        // negative length rejected
+        // negative length supported (vertical-align: -5px)
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<span style=\"vertical-align:-5px\">text</span>");
-        auto answer =
-            ::fast_io::u8string_view{u8"&lt;span&nbsp;style=&quot;vertical-align:-5px&quot;&gt;text&lt;/span&gt;"};
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"vertical-align:-5px;\">text</span>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_pl_voffset_tag.cc
+++ b/tests/test_pl_voffset_tag.cc
@@ -1,0 +1,165 @@
+#include "precompile.hh"
+
+int main() {
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<voffset=5>hello</voffset>");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"vertical-align:5px;\">hello</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<voffset=-5>hello</voffset>");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"vertical-align:-5px;\">hello</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<voffset=0>hello</voffset>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;voffset=0&gt;hello&lt;/voffset&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<voffset=00>hello</voffset>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;voffset=00&gt;hello&lt;/voffset&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<voffset=-0>hello</voffset>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;voffset=-0&gt;hello&lt;/voffset&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt2roundtrip_htmld(u8"<voffset=5>hello</voffset>");
+        auto reparsed_html = ::pltxt2htm_test::pltxt4htmlunittest(::fast_io::u8string_view{html.data(), html.size()});
+        pltxt2htm_test_assert_equal(reparsed_html, html);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt2roundtrip_htmld(u8"<voffset=-5>hello</voffset>");
+        auto reparsed_html = ::pltxt2htm_test::pltxt4htmlunittest(::fast_io::u8string_view{html.data(), html.size()});
+        pltxt2htm_test_assert_equal(reparsed_html, html);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<Voffset=5>hello</voffset>");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"vertical-align:5px;\">hello</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<voffset=5   >hello</voffset  >");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"vertical-align:5px;\">hello</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<voffset=5>hello");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"vertical-align:5px;\">hello</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"hello<voffset=5>");
+        auto answer = ::fast_io::u8string_view{u8"hello"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"hello<voffset=3><voffset=5>world");
+        auto answer = ::fast_io::u8string_view{u8"hello<span style=\"vertical-align:5px;\">world</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<voffset=3>hello<voffset=5>world</voffset></voffset>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<span style=\"vertical-align:3px;\">hello<span style=\"vertical-align:5px;\">world</span></span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<voffset=5>hello<voffset=5>world</voffset></voffset>");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"vertical-align:5px;\">helloworld</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<voffset=-5>hello<voffset=-5>world</voffset></voffset>");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"vertical-align:-5px;\">helloworld</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"t<voffset=5></voffset>t");
+        auto answer = ::fast_io::u8string_view{u8"tt"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<voffset=5></voffset");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"vertical-align:5px;\">&lt;/voffset</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<voffset=5><i>test</i></voffset>");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"vertical-align:5px;\"><em>test</em></span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<voffset=>text");
+        auto answer = ::fast_io::u8string_view{u8"&lt;voffset=&gt;text"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<voffset= >text");
+        auto answer = ::fast_io::u8string_view{u8"&lt;voffset=&nbsp;&gt;text"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    if constexpr (sizeof(::std::ptrdiff_t) <= 8) {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<voffset=999999999999999999999999>hello</voffset>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;voffset=999999999999999999999999&gt;hello&lt;/voffset&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // negative overflow rejected (min - 1)
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<voffset=-999999999999999999999999>hello</voffset>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;voffset=-999999999999999999999999&gt;hello&lt;/voffset&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<voffset=5>text</voffset>");
+        auto answer = ::fast_io::u8string_view{u8"<voffset=5>text</voffset>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<voffset=-5>text</voffset>");
+        auto answer = ::fast_io::u8string_view{u8"<voffset=-5>text</voffset>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // HTML roundtrip: <span style="vertical-align:Npx;"> maps back to <voffset=N>
+        auto html = ::pltxt2htm_test::pltxt4htmlunittest(u8"<span style=\"vertical-align:5px\">x</span>");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"vertical-align:5px;\">x</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // tag content can contain HTML which is not interpreted
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<voffset=5><b>test</b></voffset>");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"vertical-align:5px;\"><strong>test</strong></span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    return 0;
+}


### PR DESCRIPTION

## Summary

Adds support for the Unity TextMeshPro `<voffset=N>` tag so that vertical offset
information survives the pltext -> HTML -> pltext roundtrip instead of being
dropped on the floor.

## Motivation

In the previous implementation, `vertical-align` was only representable through
the HTML `<span style="vertical-align:...">` path. When converting a pltext
document that contains a TMP `<voffset>` tag to HTML and then back to pltext,
the offset information was lost. This PR makes the offset a first-class AST
node so it can be emitted, optimized, and roundtripped reliably.

## Changes

### Feature: `pl_voffset` node (3bc5ca7)

- Add `pl_voffset` to `node_kind.hh` and a new `PlVoffset` AST class
  (`physics_lab_node_decl.hh` / `physics_lab_node_def.inc`), wired into the
  `Node` union (constructor, copy/move/dtor/`==` switches, `as_pl_voffset()`).
- Store the offset as `::std::ptrdiff_t`, so negative values such as
  `<voffset=-5>` are valid.
- Parser (`parser.hh`, `try_parse.hh`, `frame_context.hh`):
  - `pl_voffset` tag info added to the frame context and its variant switches.
  - Tag parsing accepts an optional sign, requires a nonzero value, and is
    case-insensitive with optional trailing whitespace.
  - `0`, `00`, and `-0` are rejected and emitted as literal escaped text.
- Optimizer (`optimizer.hh`): `pl_voffset` tag info merged like other tags;
  adjacent/nested `pl_voffset` ranges are collapsed into a single offset.
- Backends:
  - Web: emits `<span style="vertical-align:Npx;">...</span>`.
  - Unity: roundtrips back to `<voffset=N>...</voffset>`.
  - Title: keeps the `vertical-align` value in the generated style.
- New test suite `tests/test_pl_voffset_tag.cc` covering positive/negative
  values, rejected `0`/`00`/`-0`, case-insensitivity, whitespace, nesting/merge,
  Unity passthrough, and HTML roundtrip.

### Refactor: template `ValueWithUnit` (625d057)

- Turn `ValueWithUnit` into `template<::std::integral T> struct ValueWithUnit`.
- All font-size usages now explicitly spell `ValueWithUnit<::std::size_t>`.
- `VerticalAlignValue` length is explicitly `ValueWithUnit<::std::ptrdiff_t>`
  so negative `vertical-align` lengths (e.g. from `<voffset=-5>`) parse back
  correctly; `for_plweb_title.hh` prints signed lengths with `ptrdiff_t2str`.
- Remove the temporary `SignedValueWithUnit` helper.
- Update the CTAD test sites in `tests/test_ast_operator_eq.cc`.

## Behavior details

| pltext input | web output | unity output |
| --- | --- | --- |
| `<voffset=5>hi</voffset>` | `<span style="vertical-align:5px;">hi</span>` | `<voffset=5>hi</voffset>` |
| `<voffset=-5>hi</voffset>` | `<span style="vertical-align:-5px;">hi</span>` | `<voffset=-5>hi</voffset>` |
| `<voffset=0>hi</voffset>` | `&lt;voffset=0&gt;hi&lt;/voffset&gt;` (literal) | `&lt;voffset=0&gt;...` |

## Testing

- All 75 tests pass (`ctest`), including the new `test_pl_voffset_tag` suite.
- `clang-format` applied to the modified sources.