### PR TITLE
feat(parser): restrict <p> tag parsing to block-level contexts

### DIFF
--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -162,21 +162,46 @@ constexpr auto find_next_block_after_line_break(
             return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{
                 .advance_count = current_index + advance_count, .new_frame_been_pushed_into_call_stack = true};
         }
+        // Check for HTML <p> tag at line start
+        if (auto opt_p_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<p">(
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+            opt_p_tag_len.has_value()) {
+            current_index += opt_p_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
+            call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                    ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                    ::pltxt2htm::NodeKind::html_p},
+                ::pltxt2htm::Ast<ndebug>{}));
+            return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{
+                .advance_count = current_index, .new_frame_been_pushed_into_call_stack = true};
+        }
         return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{.advance_count = current_index,
                                                                        .new_frame_been_pushed_into_call_stack = false};
     }
 }
 
 /**
+ * @brief Return type of parse_pltxt.
+ * @tparam ndebug Contract checking mode.
+ */
+template<::pltxt2htm::Contracts ndebug>
+struct ParsePlTxtResult {
+    ::pltxt2htm::Ast<ndebug> subast; ///< Parsed AST for the bottom frame.
+    ///< Bytes consumed from the bottom frame's pltext (the caller uses it to advance past html_p blocks).
+    ::std::size_t consumed_bytes{};
+};
+
+/**
  * @brief Parse pl-text to nodes.
  * @tparam ndebug Contract checking mode; `::pltxt2htm::Contracts::ignore` disables checks.
  * @param call_stack: use `call_stack` + `goto entry` to avoid stack overflow.
- * @return Quantum-Physics text's ast.
+ * @return The parsed ast and how many bytes of the bottom frame's pltext were consumed.
  */
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
 constexpr auto parse_pltxt(::fast_io::stack<::pltxt2htm::details::ParserFrameContext<ndebug>>& call_stack) noexcept
-    -> ::pltxt2htm::Ast<ndebug> {
+    -> ParsePlTxtResult<ndebug> {
 entry:
     while (true) {
         if (::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type() == ::pltxt2htm::NodeKind::md_ul) {
@@ -188,7 +213,7 @@ entry:
                 ::pltxt2htm::details::ParserFrameContext<ndebug> previous_frame(::std::move(frame));
                 call_stack.pop();
                 if (call_stack.empty()) {
-                    return ::std::move(previous_frame.subast);
+                    return ::pltxt2htm::details::ParsePlTxtResult<ndebug>{.subast = ::std::move(previous_frame.subast)};
                 }
                 ::pltxt2htm::details::stack_top<ndebug>(call_stack)
                     .subast.emplace_back(
@@ -278,7 +303,7 @@ entry:
                 ::pltxt2htm::details::ParserFrameContext<ndebug> previous_frame(::std::move(frame));
                 call_stack.pop();
                 if (call_stack.empty()) {
-                    return ::std::move(previous_frame.subast);
+                    return ::pltxt2htm::details::ParsePlTxtResult<ndebug>{.subast = ::std::move(previous_frame.subast)};
                 }
                 ::pltxt2htm::details::stack_top<ndebug>(call_stack)
                     .subast.emplace_back(
@@ -432,7 +457,7 @@ entry:
                 }
 
                 if (call_stack.empty()) {
-                    return table_ast;
+                    return ::pltxt2htm::details::ParsePlTxtResult<ndebug>{.subast = ::std::move(table_ast)};
                 }
 
                 auto&& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
@@ -1322,29 +1347,6 @@ entry:
                 case u8'p':
                     [[fallthrough]];
                 case u8'P': {
-                    // parsing html <p></p> tag
-                    if (auto opt_p_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug>(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_p_tag_len.has_value()) {
-                        bool in_p_frame{false};
-                        for (auto const& v : call_stack.container) {
-                            if (v.get_nested_tag_type() == ::pltxt2htm::NodeKind::html_p) {
-                                in_p_frame = true;
-                                break;
-                            }
-                        }
-                        if (in_p_frame == false) {
-                            current_index +=
-                                opt_p_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
-                            call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                                ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                    ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
-                                    ::pltxt2htm::NodeKind::html_p},
-                                ::pltxt2htm::Ast<ndebug>{}));
-                            goto entry;
-                        }
-                    }
                     if (auto opt_pre_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"re">(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                         opt_pre_tag_len.has_value()) {
@@ -1962,6 +1964,13 @@ entry:
                             ::std::size_t const staged_index{current_index};
                             ::pltxt2htm::HtmlP staged_node(::std::move(result));
                             call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::ParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
                             parent_frame.current_index +=
@@ -2745,7 +2754,8 @@ entry:
                 // <b>e</b>xample
                 // ```
                 // Text without any tag in the end will hit this branch.
-                return ::std::move(frame.subast);
+                return ::pltxt2htm::details::ParsePlTxtResult<ndebug>{.subast = ::std::move(frame.subast),
+                                                                      .consumed_bytes = staged_index};
             }
             // Considering the following markdown:
             // ```md

--- a/include/pltxt2htm/experimental/html_parser.hh
+++ b/include/pltxt2htm/experimental/html_parser.hh
@@ -17,6 +17,44 @@
 namespace pltxt2htm::experimental {
 namespace details {
 
+/**
+ * @brief Return type of find_next_block_after_line_break.
+ */
+struct FindNextBlockAfterLineBreakResult {
+    ::std::size_t advance_count; ///< Bytes consumed from the input subview.
+    bool new_frame_been_pushed_into_call_stack; ///< Whether a new frame was pushed.
+};
+
+/**
+ * @brief Scan for a block-level frame at the current position and push it onto the call stack.
+ * @tparam ndebug Contract checking mode.
+ * @param pltext Input subview starting at the candidate block position.
+ * @param call_stack Active parser call stack.
+ * @return How many bytes were consumed and whether a new frame was created.
+ * @note Only handles the `<p>` block for now; other block elements are out of scope for the html parser.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto find_next_block_after_line_break(
+    ::fast_io::u8string_view pltext,
+    ::fast_io::stack<::pltxt2htm::details::ParserFrameContext<ndebug>>& call_stack) noexcept
+    -> ::pltxt2htm::experimental::details::FindNextBlockAfterLineBreakResult {
+    if (auto opt_p_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<p">(pltext);
+        opt_p_tag_len.has_value()) {
+        ::std::size_t const consumed{opt_p_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1};
+        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, consumed)},
+                ::pltxt2htm::NodeKind::html_p},
+            ::pltxt2htm::Ast<ndebug>{}));
+        return ::pltxt2htm::experimental::details::FindNextBlockAfterLineBreakResult{
+            .advance_count = consumed, .new_frame_been_pushed_into_call_stack = true};
+    }
+    return ::pltxt2htm::experimental::details::FindNextBlockAfterLineBreakResult{
+        .advance_count = 0, .new_frame_been_pushed_into_call_stack = false};
+}
+
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
 constexpr auto parse_pltxt_html(::fast_io::stack<::pltxt2htm::details::ParserFrameContext<ndebug>>& call_stack) noexcept
@@ -29,12 +67,29 @@ entry:
         auto&& result = top_frame.subast;
         ::std::size_t const pltext_size{pltext.size()};
 
+        // Check for block-level <p> tag at line start (start of input or after frame completion)
+        auto&& [entry_advance, entry_new_frame] =
+            ::pltxt2htm::experimental::details::find_next_block_after_line_break<ndebug>(
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), call_stack);
+        current_index += entry_advance;
+        if (entry_new_frame) {
+            goto entry;
+        }
+
         while (current_index < pltext_size) {
             char8_t const chr{::pltxt2htm::details::u8string_view_index<ndebug>(pltext, current_index)};
 
             if (chr == u8'\n') {
                 result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LineBreak{}));
                 ++current_index;
+                // Check for block-level <p> tag after newline
+                auto&& [nl_advance, nl_new_frame] =
+                    ::pltxt2htm::experimental::details::find_next_block_after_line_break<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), call_stack);
+                current_index += nl_advance;
+                if (nl_new_frame) {
+                    goto entry;
+                }
                 continue;
             }
             if (chr == u8' ') {
@@ -118,6 +173,17 @@ entry:
                         opt_br_tag_len.has_value()) {
                         current_index += opt_br_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
                         result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlBr{}));
+                        // Check for block-level <p> tag right after <br>. current_index currently sits
+                        // on the '>' of <br>, so the candidate block starts at current_index + 1.
+                        auto&& [br_advance, br_new_frame] =
+                            ::pltxt2htm::experimental::details::find_next_block_after_line_break<ndebug>(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 1),
+                                call_stack);
+                        current_index += br_advance;
+                        if (br_new_frame) {
+                            current_index += 1;
+                            goto entry;
+                        }
                         ++current_index;
                         continue;
                     }
@@ -422,28 +488,6 @@ entry:
                 case u8'p':
                     [[fallthrough]];
                 case u8'P': {
-                    if (auto opt_p_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug>(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_p_tag_len.has_value()) {
-                        bool in_p_frame{false};
-                        for (auto const& v : call_stack.container) {
-                            if (v.get_nested_tag_type() == ::pltxt2htm::NodeKind::html_p) {
-                                in_p_frame = true;
-                                break;
-                            }
-                        }
-                        if (in_p_frame == false) {
-                            current_index +=
-                                opt_p_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
-                            call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                                ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                    ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
-                                    ::pltxt2htm::NodeKind::html_p},
-                                ::pltxt2htm::Ast<ndebug>{}));
-                            goto entry;
-                        }
-                    }
                     if (auto opt_pre_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"re">(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                         opt_pre_tag_len.has_value()) {

--- a/include/pltxt2htm/parser.hh
+++ b/include/pltxt2htm/parser.hh
@@ -59,7 +59,7 @@ constexpr auto parse_pltxt(::fast_io::u8string_view pltext) noexcept -> ::pltxt2
             break;
         }
         ::pltxt2htm::NodeKind const type_of_subast{call_stack.top().get_nested_tag_type()};
-        auto subast = ::pltxt2htm::details::parse_pltxt<ndebug>(call_stack);
+        auto&& [subast, consumed_bytes] = ::pltxt2htm::details::parse_pltxt<ndebug>(call_stack);
         switch (type_of_subast) {
         case ::pltxt2htm::NodeKind::md_atx_h1: {
             result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdAtxH1<ndebug>{::std::move(subast)}));
@@ -101,6 +101,14 @@ constexpr auto parse_pltxt(::fast_io::u8string_view pltext) noexcept -> ::pltxt2
             result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdTable<ndebug>{::std::move(subast)}));
             continue;
         }
+        case ::pltxt2htm::NodeKind::html_p: {
+            // details::parse_pltxt reported how many bytes of the html_p frame's pltext it
+            // consumed (up to the matching </p>, or all of it if unclosed). Advance start_index
+            // past it so the remaining text handler doesn't re-process the consumed content.
+            start_index += consumed_bytes;
+            result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlP<ndebug>{::std::move(subast)}));
+            continue;
+        }
         default:
             [[unlikely]] {
                 pltxt2htm_unreachable(u8"Unexpected node kind");
@@ -116,7 +124,7 @@ constexpr auto parse_pltxt(::fast_io::u8string_view pltext) noexcept -> ::pltxt2
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, start_index)},
                 ::pltxt2htm::NodeKind::text},
             ::std::move(result)));
-        result = ::pltxt2htm::details::parse_pltxt<ndebug>(call_stack);
+        result = ::std::move(::pltxt2htm::details::parse_pltxt<ndebug>(call_stack).subast);
     }
 
     bool const call_stack_is_empty{call_stack.empty()};

--- a/tests/test_html_p_tag.cc
+++ b/tests/test_html_p_tag.cc
@@ -49,7 +49,8 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
         auto plunity_richtext_answer = ::fast_io::u8string_view{
-            u8"<p>text<size=20>\uFF1C</size>p<size=20>\uFF1E</size>text</p><size=20>\uFF1C</size>/p<size=20>\uFF1E</size>"};
+            u8"<p>text<size=20>\uFF1C</size>p<size=20>\uFF1E</size>text</p><size=20>\uFF1C</size>/p<size=20>\uFF1E</"
+            u8"size>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
@@ -66,21 +67,50 @@ int main() {
     {
         auto pltext = ::fast_io::u8string_view{u8"t<p></p>t"};
         auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
-        auto answer = ::fast_io::u8string_view{u8"t<p></p>t"};
+        auto answer = ::fast_io::u8string_view{u8"t&lt;p&gt;&lt;/p&gt;t"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"t<p></p>t"};
+        auto plunity_richtext_answer = ::fast_io::u8string_view{
+            u8"t<size=20>\uFF1C</size>p<size=20>\uFF1E</size><size=20>\uFF1C</size>/p<size=20>\uFF1E</size>t"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
     {
         auto pltext = ::fast_io::u8string_view{u8"t<p></p"};
         auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
-        auto answer = ::fast_io::u8string_view{u8"t<p>&lt;/p</p>"};
+        auto answer = ::fast_io::u8string_view{u8"t&lt;p&gt;&lt;/p"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"t<p><size=20>\uFF1C</size>/p</p>"};
+        auto plunity_richtext_answer =
+            ::fast_io::u8string_view{u8"t<size=20>\uFF1C</size>p<size=20>\uFF1E</size><size=20>\uFF1C</size>/p"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"text\n<p>text</p>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"text<br><p>text</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\n<p>text</p>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"text<br><p>text</p>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"text<br><p>text</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\n<p>text</p>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"text<br><p>text</p>"};
+        auto html = ::pltxt2htm_test::pltxt4htmlunittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"text<br><p>text</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
     }
 
     return 0;


### PR DESCRIPTION
<p> is no longer recognized at arbitrary inline positions. It is now only parsed as a block-level element when it appears at the start of input, after a newline, or immediately following a <br> tag. Inline occurrences of <p></p> are treated as plain text and escaped accordingly.

To support this, parse_pltxt() now returns ParsePlTxtResult<ndebug> instead of Ast<ndebug>. The new consumed_bytes field reports how many bytes of the bottom frame's pltext were actually consumed (up to the matching </p>, or all of it if unclosed), allowing the caller to skip already-processed content and avoid double parsing.

The experimental html_parser is updated in sync, and test expectations are adjusted to reflect the new block-only <p> behavior.