### PR TITLE
feat(parser): restrict `<h2>`–`<h6>` tag parsing to block-level contexts

### DIFF
--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -204,6 +204,62 @@ constexpr auto find_next_block_after_line_break(
             return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{
                 .advance_count = current_index, .new_frame_been_pushed_into_call_stack = true};
         }
+        // Check for HTML <h3> tag at line start
+        if (auto opt_h3_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<h3">(
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+            opt_h3_tag_len.has_value()) {
+            current_index += opt_h3_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
+            call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                    ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                    ::pltxt2htm::NodeKind::html_h3},
+                ::pltxt2htm::Ast<ndebug>{}));
+            return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{
+                .advance_count = current_index, .new_frame_been_pushed_into_call_stack = true};
+        }
+        // Check for HTML <h4> tag at line start
+        if (auto opt_h4_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<h4">(
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+            opt_h4_tag_len.has_value()) {
+            current_index += opt_h4_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
+            call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                    ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                    ::pltxt2htm::NodeKind::html_h4},
+                ::pltxt2htm::Ast<ndebug>{}));
+            return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{
+                .advance_count = current_index, .new_frame_been_pushed_into_call_stack = true};
+        }
+        // Check for HTML <h5> tag at line start
+        if (auto opt_h5_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<h5">(
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+            opt_h5_tag_len.has_value()) {
+            current_index += opt_h5_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
+            call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                    ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                    ::pltxt2htm::NodeKind::html_h5},
+                ::pltxt2htm::Ast<ndebug>{}));
+            return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{
+                .advance_count = current_index, .new_frame_been_pushed_into_call_stack = true};
+        }
+        // Check for HTML <h6> tag at line start
+        if (auto opt_h6_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<h6">(
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+            opt_h6_tag_len.has_value()) {
+            current_index += opt_h6_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
+            call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                    ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                    ::pltxt2htm::NodeKind::html_h6},
+                ::pltxt2htm::Ast<ndebug>{}));
+            return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{
+                .advance_count = current_index, .new_frame_been_pushed_into_call_stack = true};
+        }
         return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{.advance_count = current_index,
                                                                        .new_frame_been_pushed_into_call_stack = false};
     }
@@ -1126,58 +1182,6 @@ entry:
                 case u8'h':
                     [[fallthrough]];
                 case u8'H': {
-                    if (auto opt_h3_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"3">(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_h3_tag_len.has_value()) {
-                        // parsing html <h3> tag
-                        current_index += opt_h3_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
-                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
-                                ::pltxt2htm::NodeKind::html_h3},
-                            ::pltxt2htm::Ast<ndebug>{}));
-                        goto entry;
-                    }
-                    if (auto opt_h4_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"4">(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_h4_tag_len.has_value()) {
-                        // parsing html <h4> tag
-                        current_index += opt_h4_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
-                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
-                                ::pltxt2htm::NodeKind::html_h4},
-                            ::pltxt2htm::Ast<ndebug>{}));
-                        goto entry;
-                    }
-                    if (auto opt_h5_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"5">(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_h5_tag_len.has_value()) {
-                        // parsing html <h5> tag
-                        current_index += opt_h5_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
-                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
-                                ::pltxt2htm::NodeKind::html_h5},
-                            ::pltxt2htm::Ast<ndebug>{}));
-                        goto entry;
-                    }
-                    if (auto opt_h6_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"6">(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_h6_tag_len.has_value()) {
-                        // parsing html <h6> tag
-                        current_index += opt_h6_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
-                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
-                                ::pltxt2htm::NodeKind::html_h6},
-                            ::pltxt2htm::Ast<ndebug>{}));
-                        goto entry;
-                    }
                     if (auto opt_tag_len = ::pltxt2htm::details::try_parse_self_closing_tag<ndebug, u8"r">(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                         opt_tag_len.has_value()) {
@@ -2044,6 +2048,13 @@ entry:
                             ::std::size_t const staged_index{current_index};
                             ::pltxt2htm::HtmlH3 staged_node(::std::move(result));
                             call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::ParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
                             parent_frame.current_index +=
@@ -2063,6 +2074,13 @@ entry:
                             ::std::size_t const staged_index{current_index};
                             ::pltxt2htm::HtmlH4 staged_node(::std::move(result));
                             call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::ParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
                             parent_frame.current_index +=
@@ -2082,6 +2100,13 @@ entry:
                             ::std::size_t const staged_index{current_index};
                             ::pltxt2htm::HtmlH5 staged_node(::std::move(result));
                             call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::ParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
                             parent_frame.current_index +=
@@ -2101,6 +2126,13 @@ entry:
                             ::std::size_t const staged_index{current_index};
                             ::pltxt2htm::HtmlH6 staged_node(::std::move(result));
                             call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::ParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
                             parent_frame.current_index +=

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -190,6 +190,20 @@ constexpr auto find_next_block_after_line_break(
             return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{
                 .advance_count = current_index, .new_frame_been_pushed_into_call_stack = true};
         }
+        // Check for HTML <h2> tag at line start
+        if (auto opt_h2_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<h2">(
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+            opt_h2_tag_len.has_value()) {
+            current_index += opt_h2_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
+            call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                    ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                    ::pltxt2htm::NodeKind::html_h2},
+                ::pltxt2htm::Ast<ndebug>{}));
+            return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{
+                .advance_count = current_index, .new_frame_been_pushed_into_call_stack = true};
+        }
         return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{.advance_count = current_index,
                                                                        .new_frame_been_pushed_into_call_stack = false};
     }
@@ -1112,19 +1126,6 @@ entry:
                 case u8'h':
                     [[fallthrough]];
                 case u8'H': {
-                    if (auto opt_h2_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"2">(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_h2_tag_len.has_value()) {
-                        // parsing html <h2> tag
-                        current_index += opt_h2_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
-                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
-                                ::pltxt2htm::NodeKind::html_h2},
-                            ::pltxt2htm::Ast<ndebug>{}));
-                        goto entry;
-                    }
                     if (auto opt_h3_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"3">(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                         opt_h3_tag_len.has_value()) {
@@ -2017,6 +2018,13 @@ entry:
                             ::std::size_t const staged_index{current_index};
                             ::pltxt2htm::HtmlH2 staged_node(::std::move(result));
                             call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::ParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
                             parent_frame.current_index +=

--- a/include/pltxt2htm/experimental/html_parser.hh
+++ b/include/pltxt2htm/experimental/html_parser.hh
@@ -31,7 +31,7 @@ struct FindNextBlockAfterLineBreakResult {
  * @param pltext Input subview starting at the candidate block position.
  * @param call_stack Active parser call stack.
  * @return How many bytes were consumed and whether a new frame was created.
- * @note Only handles the `<p>` and `<h1>` blocks for now; other block elements are out of scope for the html parser.
+ * @note Only handles the `<p>`, `<h1>`, and `<h2>` blocks for now; other block elements are out of scope for the html parser.
  */
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
@@ -59,6 +59,18 @@ constexpr auto find_next_block_after_line_break(
                 ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, consumed)},
                 ::pltxt2htm::NodeKind::html_h1},
+            ::pltxt2htm::Ast<ndebug>{}));
+        return ::pltxt2htm::experimental::details::FindNextBlockAfterLineBreakResult{
+            .advance_count = consumed, .new_frame_been_pushed_into_call_stack = true};
+    }
+    if (auto opt_h2_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<h2">(pltext);
+        opt_h2_tag_len.has_value()) {
+        ::std::size_t const consumed{opt_h2_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1};
+        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, consumed)},
+                ::pltxt2htm::NodeKind::html_h2},
             ::pltxt2htm::Ast<ndebug>{}));
         return ::pltxt2htm::experimental::details::FindNextBlockAfterLineBreakResult{
             .advance_count = consumed, .new_frame_been_pushed_into_call_stack = true};
@@ -319,18 +331,6 @@ entry:
                 case u8'h':
                     [[fallthrough]];
                 case u8'H': {
-                    if (auto opt_h2_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"2">(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_h2_tag_len.has_value()) {
-                        current_index += opt_h2_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
-                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
-                                ::pltxt2htm::NodeKind::html_h2},
-                            ::pltxt2htm::Ast<ndebug>{}));
-                        goto entry;
-                    }
                     if (auto opt_h3_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"3">(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                         opt_h3_tag_len.has_value()) {

--- a/include/pltxt2htm/experimental/html_parser.hh
+++ b/include/pltxt2htm/experimental/html_parser.hh
@@ -31,7 +31,7 @@ struct FindNextBlockAfterLineBreakResult {
  * @param pltext Input subview starting at the candidate block position.
  * @param call_stack Active parser call stack.
  * @return How many bytes were consumed and whether a new frame was created.
- * @note Only handles the `<p>`, `<h1>`, and `<h2>` blocks for now; other block elements are out of scope for the html parser.
+ * @note Only handles the `<p>` and `<h1>`–`<h6>` blocks for now; other block elements are out of scope for the html parser.
  */
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
@@ -71,6 +71,54 @@ constexpr auto find_next_block_after_line_break(
                 ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, consumed)},
                 ::pltxt2htm::NodeKind::html_h2},
+            ::pltxt2htm::Ast<ndebug>{}));
+        return ::pltxt2htm::experimental::details::FindNextBlockAfterLineBreakResult{
+            .advance_count = consumed, .new_frame_been_pushed_into_call_stack = true};
+    }
+    if (auto opt_h3_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<h3">(pltext);
+        opt_h3_tag_len.has_value()) {
+        ::std::size_t const consumed{opt_h3_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1};
+        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, consumed)},
+                ::pltxt2htm::NodeKind::html_h3},
+            ::pltxt2htm::Ast<ndebug>{}));
+        return ::pltxt2htm::experimental::details::FindNextBlockAfterLineBreakResult{
+            .advance_count = consumed, .new_frame_been_pushed_into_call_stack = true};
+    }
+    if (auto opt_h4_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<h4">(pltext);
+        opt_h4_tag_len.has_value()) {
+        ::std::size_t const consumed{opt_h4_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1};
+        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, consumed)},
+                ::pltxt2htm::NodeKind::html_h4},
+            ::pltxt2htm::Ast<ndebug>{}));
+        return ::pltxt2htm::experimental::details::FindNextBlockAfterLineBreakResult{
+            .advance_count = consumed, .new_frame_been_pushed_into_call_stack = true};
+    }
+    if (auto opt_h5_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<h5">(pltext);
+        opt_h5_tag_len.has_value()) {
+        ::std::size_t const consumed{opt_h5_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1};
+        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, consumed)},
+                ::pltxt2htm::NodeKind::html_h5},
+            ::pltxt2htm::Ast<ndebug>{}));
+        return ::pltxt2htm::experimental::details::FindNextBlockAfterLineBreakResult{
+            .advance_count = consumed, .new_frame_been_pushed_into_call_stack = true};
+    }
+    if (auto opt_h6_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<h6">(pltext);
+        opt_h6_tag_len.has_value()) {
+        ::std::size_t const consumed{opt_h6_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1};
+        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, consumed)},
+                ::pltxt2htm::NodeKind::html_h6},
             ::pltxt2htm::Ast<ndebug>{}));
         return ::pltxt2htm::experimental::details::FindNextBlockAfterLineBreakResult{
             .advance_count = consumed, .new_frame_been_pushed_into_call_stack = true};
@@ -331,54 +379,6 @@ entry:
                 case u8'h':
                     [[fallthrough]];
                 case u8'H': {
-                    if (auto opt_h3_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"3">(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_h3_tag_len.has_value()) {
-                        current_index += opt_h3_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
-                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
-                                ::pltxt2htm::NodeKind::html_h3},
-                            ::pltxt2htm::Ast<ndebug>{}));
-                        goto entry;
-                    }
-                    if (auto opt_h4_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"4">(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_h4_tag_len.has_value()) {
-                        current_index += opt_h4_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
-                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
-                                ::pltxt2htm::NodeKind::html_h4},
-                            ::pltxt2htm::Ast<ndebug>{}));
-                        goto entry;
-                    }
-                    if (auto opt_h5_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"5">(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_h5_tag_len.has_value()) {
-                        current_index += opt_h5_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
-                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
-                                ::pltxt2htm::NodeKind::html_h5},
-                            ::pltxt2htm::Ast<ndebug>{}));
-                        goto entry;
-                    }
-                    if (auto opt_h6_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"6">(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_h6_tag_len.has_value()) {
-                        current_index += opt_h6_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
-                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
-                                ::pltxt2htm::NodeKind::html_h6},
-                            ::pltxt2htm::Ast<ndebug>{}));
-                        goto entry;
-                    }
                     if (auto opt_tag_len = ::pltxt2htm::details::try_parse_self_closing_tag<ndebug, u8"r">(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                         opt_tag_len.has_value()) {

--- a/include/pltxt2htm/parser.hh
+++ b/include/pltxt2htm/parser.hh
@@ -121,6 +121,30 @@ constexpr auto parse_pltxt(::fast_io::u8string_view pltext) noexcept -> ::pltxt2
             result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlH2<ndebug>{::std::move(subast)}));
             continue;
         }
+        case ::pltxt2htm::NodeKind::html_h3: {
+            // Same as html_p: advance start_index past the consumed html_h3 content.
+            start_index += consumed_bytes;
+            result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlH3<ndebug>{::std::move(subast)}));
+            continue;
+        }
+        case ::pltxt2htm::NodeKind::html_h4: {
+            // Same as html_p: advance start_index past the consumed html_h4 content.
+            start_index += consumed_bytes;
+            result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlH4<ndebug>{::std::move(subast)}));
+            continue;
+        }
+        case ::pltxt2htm::NodeKind::html_h5: {
+            // Same as html_p: advance start_index past the consumed html_h5 content.
+            start_index += consumed_bytes;
+            result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlH5<ndebug>{::std::move(subast)}));
+            continue;
+        }
+        case ::pltxt2htm::NodeKind::html_h6: {
+            // Same as html_p: advance start_index past the consumed html_h6 content.
+            start_index += consumed_bytes;
+            result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlH6<ndebug>{::std::move(subast)}));
+            continue;
+        }
         default:
             [[unlikely]] {
                 pltxt2htm_unreachable(u8"Unexpected node kind");

--- a/include/pltxt2htm/parser.hh
+++ b/include/pltxt2htm/parser.hh
@@ -115,6 +115,12 @@ constexpr auto parse_pltxt(::fast_io::u8string_view pltext) noexcept -> ::pltxt2
             result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlH1<ndebug>{::std::move(subast)}));
             continue;
         }
+        case ::pltxt2htm::NodeKind::html_h2: {
+            // Same as html_p: advance start_index past the consumed html_h2 content.
+            start_index += consumed_bytes;
+            result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlH2<ndebug>{::std::move(subast)}));
+            continue;
+        }
         default:
             [[unlikely]] {
                 pltxt2htm_unreachable(u8"Unexpected node kind");

--- a/tests/test_html_h2_tag.cc
+++ b/tests/test_html_h2_tag.cc
@@ -46,11 +46,12 @@ int main() {
     {
         auto pltext = ::fast_io::u8string_view{u8"<h2>text<h2>text</h2></h2>"};
         auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
-        auto answer = ::fast_io::u8string_view{u8"<h2>text<h2>text</h2></h2>"};
+        auto answer = ::fast_io::u8string_view{u8"<h2>text&lt;h2&gt;text</h2>&lt;/h2&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer =
-            ::fast_io::u8string_view{u8"<size=37><b>text<size=37><b>text</b></size></b></size>"};
+        auto plunity_richtext_answer = ::fast_io::u8string_view{
+            u8"<size=37><b>text<size=20>\uFF1C</size>h2<size=20>\uFF1E</size>text</b></size>"
+            u8"<size=20>\uFF1C</size>/h2<size=20>\uFF1E</size>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
@@ -72,6 +73,66 @@ int main() {
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
         auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<size=37><b><size=20>\uFF1C</size>/h2</b></size>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"# <h2>text"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"<h1>&lt;h2&gt;text</h1>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer =
+            ::fast_io::u8string_view{u8"<size=38><b><size=20>\uFF1C</size>h2<size=20>\uFF1E</size>text</b></size>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"t<h2></h2>t"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"t&lt;h2&gt;&lt;/h2&gt;t"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{
+            u8"t<size=20>\uFF1C</size>h2<size=20>\uFF1E</size><size=20>\uFF1C</size>/h2<size=20>\uFF1E</size>t"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"t<h2></h2"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"t&lt;h2&gt;&lt;/h2"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer =
+            ::fast_io::u8string_view{u8"t<size=20>\uFF1C</size>h2<size=20>\uFF1E</size><size=20>\uFF1C</size>/h2"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"text\n<h2>text</h2>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"text<br><h2>text</h2>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\n<size=37><b>text</b></size>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"text<br><h2>text</h2>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"text<br><h2>text</h2>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\n<size=37><b>text</b></size>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"text<br><h2>text</h2>"};
+        auto html = ::pltxt2htm_test::pltxt4htmlunittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"text<br><h2>text</h2>"};
+        pltxt2htm_test_assert_equal(html, answer);
     }
 
     return 0;

--- a/tests/test_html_h3_tag.cc
+++ b/tests/test_html_h3_tag.cc
@@ -46,11 +46,12 @@ int main() {
     {
         auto pltext = ::fast_io::u8string_view{u8"<h3>text<h3>text</h3></h3>"};
         auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
-        auto answer = ::fast_io::u8string_view{u8"<h3>text<h3>text</h3></h3>"};
+        auto answer = ::fast_io::u8string_view{u8"<h3>text&lt;h3&gt;text</h3>&lt;/h3&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer =
-            ::fast_io::u8string_view{u8"<size=36><b>text<size=36><b>text</b></size></b></size>"};
+        auto plunity_richtext_answer = ::fast_io::u8string_view{
+            u8"<size=36><b>text<size=20>\uFF1C</size>h3<size=20>\uFF1E</size>text</b></size>"
+            u8"<size=20>\uFF1C</size>/h3<size=20>\uFF1E</size>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
@@ -72,6 +73,66 @@ int main() {
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
         auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<size=36><b><size=20>\uFF1C</size>/h3</b></size>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"# <h3>text"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"<h1>&lt;h3&gt;text</h1>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer =
+            ::fast_io::u8string_view{u8"<size=38><b><size=20>\uFF1C</size>h3<size=20>\uFF1E</size>text</b></size>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"t<h3></h3>t"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"t&lt;h3&gt;&lt;/h3&gt;t"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{
+            u8"t<size=20>\uFF1C</size>h3<size=20>\uFF1E</size><size=20>\uFF1C</size>/h3<size=20>\uFF1E</size>t"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"t<h3></h3"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"t&lt;h3&gt;&lt;/h3"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer =
+            ::fast_io::u8string_view{u8"t<size=20>\uFF1C</size>h3<size=20>\uFF1E</size><size=20>\uFF1C</size>/h3"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"text\n<h3>text</h3>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"text<br><h3>text</h3>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\n<size=36><b>text</b></size>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"text<br><h3>text</h3>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"text<br><h3>text</h3>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\n<size=36><b>text</b></size>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"text<br><h3>text</h3>"};
+        auto html = ::pltxt2htm_test::pltxt4htmlunittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"text<br><h3>text</h3>"};
+        pltxt2htm_test_assert_equal(html, answer);
     }
 
     return 0;

--- a/tests/test_html_h4_tag.cc
+++ b/tests/test_html_h4_tag.cc
@@ -46,11 +46,12 @@ int main() {
     {
         auto pltext = ::fast_io::u8string_view{u8"<h4>text<h4>text</h4></h4>"};
         auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
-        auto answer = ::fast_io::u8string_view{u8"<h4>text<h4>text</h4></h4>"};
+        auto answer = ::fast_io::u8string_view{u8"<h4>text&lt;h4&gt;text</h4>&lt;/h4&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer =
-            ::fast_io::u8string_view{u8"<size=35><b>text<size=35><b>text</b></size></b></size>"};
+        auto plunity_richtext_answer = ::fast_io::u8string_view{
+            u8"<size=35><b>text<size=20>\uFF1C</size>h4<size=20>\uFF1E</size>text</b></size>"
+            u8"<size=20>\uFF1C</size>/h4<size=20>\uFF1E</size>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
@@ -72,6 +73,66 @@ int main() {
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
         auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<size=35><b><size=20>\uFF1C</size>/h4</b></size>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"# <h4>text"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"<h1>&lt;h4&gt;text</h1>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer =
+            ::fast_io::u8string_view{u8"<size=38><b><size=20>\uFF1C</size>h4<size=20>\uFF1E</size>text</b></size>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"t<h4></h4>t"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"t&lt;h4&gt;&lt;/h4&gt;t"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{
+            u8"t<size=20>\uFF1C</size>h4<size=20>\uFF1E</size><size=20>\uFF1C</size>/h4<size=20>\uFF1E</size>t"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"t<h4></h4"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"t&lt;h4&gt;&lt;/h4"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer =
+            ::fast_io::u8string_view{u8"t<size=20>\uFF1C</size>h4<size=20>\uFF1E</size><size=20>\uFF1C</size>/h4"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"text\n<h4>text</h4>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"text<br><h4>text</h4>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\n<size=35><b>text</b></size>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"text<br><h4>text</h4>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"text<br><h4>text</h4>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\n<size=35><b>text</b></size>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"text<br><h4>text</h4>"};
+        auto html = ::pltxt2htm_test::pltxt4htmlunittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"text<br><h4>text</h4>"};
+        pltxt2htm_test_assert_equal(html, answer);
     }
 
     return 0;

--- a/tests/test_html_h5_tag.cc
+++ b/tests/test_html_h5_tag.cc
@@ -45,10 +45,12 @@ int main() {
     {
         auto pltext = ::fast_io::u8string_view{u8"<h5>text<h5>text</h5></h5>"};
         auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
-        auto answer = ::fast_io::u8string_view{u8"<h5>text<h5>text</h5></h5>"};
+        auto answer = ::fast_io::u8string_view{u8"<h5>text&lt;h5&gt;text</h5>&lt;/h5&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<b>text<b>text</b></b>"};
+        auto plunity_richtext_answer = ::fast_io::u8string_view{
+            u8"<b>text<size=20>\uFF1C</size>h5<size=20>\uFF1E</size>text</b>"
+            u8"<size=20>\uFF1C</size>/h5<size=20>\uFF1E</size>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
@@ -70,6 +72,66 @@ int main() {
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
         auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<b><size=20>\uFF1C</size>/h5</b>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"# <h5>text"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"<h1>&lt;h5&gt;text</h1>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer =
+            ::fast_io::u8string_view{u8"<size=38><b><size=20>\uFF1C</size>h5<size=20>\uFF1E</size>text</b></size>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"t<h5></h5>t"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"t&lt;h5&gt;&lt;/h5&gt;t"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{
+            u8"t<size=20>\uFF1C</size>h5<size=20>\uFF1E</size><size=20>\uFF1C</size>/h5<size=20>\uFF1E</size>t"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"t<h5></h5"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"t&lt;h5&gt;&lt;/h5"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer =
+            ::fast_io::u8string_view{u8"t<size=20>\uFF1C</size>h5<size=20>\uFF1E</size><size=20>\uFF1C</size>/h5"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"text\n<h5>text</h5>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"text<br><h5>text</h5>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\n<b>text</b>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"text<br><h5>text</h5>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"text<br><h5>text</h5>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\n<b>text</b>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"text<br><h5>text</h5>"};
+        auto html = ::pltxt2htm_test::pltxt4htmlunittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"text<br><h5>text</h5>"};
+        pltxt2htm_test_assert_equal(html, answer);
     }
 
     return 0;

--- a/tests/test_html_h6_tag.cc
+++ b/tests/test_html_h6_tag.cc
@@ -45,10 +45,12 @@ int main() {
     {
         auto pltext = ::fast_io::u8string_view{u8"<h6>text<h6>text</h6></h6>"};
         auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
-        auto answer = ::fast_io::u8string_view{u8"<h6>text<h6>text</h6></h6>"};
+        auto answer = ::fast_io::u8string_view{u8"<h6>text&lt;h6&gt;text</h6>&lt;/h6&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<b>text<b>text</b></b>"};
+        auto plunity_richtext_answer = ::fast_io::u8string_view{
+            u8"<b>text<size=20>\uFF1C</size>h6<size=20>\uFF1E</size>text</b>"
+            u8"<size=20>\uFF1C</size>/h6<size=20>\uFF1E</size>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
@@ -63,6 +65,49 @@ int main() {
     }
 
     {
+        auto pltext = ::fast_io::u8string_view{u8"<h6></h6"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"<h6>&lt;/h6</h6>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<b><size=20>\uFF1C</size>/h6</b>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"# <h6>text"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"<h1>&lt;h6&gt;text</h1>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer =
+            ::fast_io::u8string_view{u8"<size=38><b><size=20>\uFF1C</size>h6<size=20>\uFF1E</size>text</b></size>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"t<h6></h6>t"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"t&lt;h6&gt;&lt;/h6&gt;t"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{
+            u8"t<size=20>\uFF1C</size>h6<size=20>\uFF1E</size><size=20>\uFF1C</size>/h6<size=20>\uFF1E</size>t"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"t<h6></h6"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"t&lt;h6&gt;&lt;/h6"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer =
+            ::fast_io::u8string_view{u8"t<size=20>\uFF1C</size>h6<size=20>\uFF1E</size><size=20>\uFF1C</size>/h6"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
         auto pltext = ::fast_io::u8string_view{u8"<h6>text</h5>text</h6></h6>"};
         auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
         auto answer = ::fast_io::u8string_view{u8"<h6>text&lt;/h5&gt;text</h6>&lt;/h6&gt;"};
@@ -72,6 +117,33 @@ int main() {
             u8"<b>text<size=20>\uFF1C</size>/h5<size=20>\uFF1E</size>text</b><size=20>\uFF1C</size>/"
             u8"h6<size=20>\uFF1E</size>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"text\n<h6>text</h6>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"text<br><h6>text</h6>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\n<b>text</b>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"text<br><h6>text</h6>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"text<br><h6>text</h6>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\n<b>text</b>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto pltext = ::fast_io::u8string_view{u8"text<br><h6>text</h6>"};
+        auto html = ::pltxt2htm_test::pltxt4htmlunittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"text<br><h6>text</h6>"};
+        pltxt2htm_test_assert_equal(html, answer);
     }
 
     return 0;


### PR DESCRIPTION
`<h2>` through `<h6>` are no longer recognized at arbitrary inline positions. They are now only parsed as block-level elements when they appear at the start of input, after a newline, or immediately following a `<br>` tag, consistent with the previous `<p>` and `<h1>` changes. Inline occurrences of these tags are treated as plain text and escaped accordingly.

To support this, `find_next_block_after_line_break()` now detects `<h2>`–`<h6>` at line starts and pushes the corresponding `html_hX` frame, and each `</hX>` closing handler reports how many bytes of the bottom frame's pltext were consumed (up to the matching `</hX>`, or all of it if unclosed). The public `parse_pltxt()` advances `start_index` past the consumed `html_hX` content so the remaining text handler doesn't re-process it.

The experimental `html_parser` is updated in sync, and test expectations are adjusted to reflect the new block-only `<h2>`–`<h6>` behavior, including new cases for line-start, post-newline, post-`<br>`, and inline-literal forms.

## Commits

- `b3bbfad` feat(parser): restrict `<h2>` tag parsing to block-level contexts
- `8f63f70` feat(parser): restrict `<h3>`–`<h6>` tag parsing to block-level contexts

## Changes

- `include/pltxt2htm/details/parser/parser.hh`: `<h2>`–`<h6>` detection in `find_next_block_after_line_break()`, removed inline detection from the `h/H` dispatch, empty-stack early returns in the `</hX>` closing handlers.
- `include/pltxt2htm/parser.hh`: added `html_h2`–`html_h6` cases that advance `start_index` past consumed content.
- `include/pltxt2htm/experimental/html_parser.hh`: mirrored block detection and inline-detection removal.
- `tests/test_html_h2_tag.cc` … `test_html_h6_tag.cc`: updated and new block-level test cases.

## Testing

- All 75 tests pass (`ctest --test-dir build_win`).
