### PR TITLE
feat(parser): treat <blockquote> as a block-level element and fix HtmlSpan move semantics

### DIFF
--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -260,6 +260,20 @@ constexpr auto find_next_block_after_line_break(
             return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{
                 .advance_count = current_index, .new_frame_been_pushed_into_call_stack = true};
         }
+        // Check for HTML <blockquote> tag at line start
+        if (auto opt_blockquote_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<blockquote">(
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+            opt_blockquote_tag_len.has_value()) {
+            current_index += opt_blockquote_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
+            call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                    ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                    ::pltxt2htm::NodeKind::html_blockquote},
+                ::pltxt2htm::Ast<ndebug>{}));
+            return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{
+                .advance_count = current_index, .new_frame_been_pushed_into_call_stack = true};
+        }
         return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{.advance_count = current_index,
                                                                        .new_frame_been_pushed_into_call_stack = false};
     }
@@ -976,20 +990,6 @@ entry:
                         }
                         ++current_index;
                         continue;
-                    }
-                    if (auto opt_blockquote_tag = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"lockquote">(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_blockquote_tag.has_value()) {
-                        // parsing pl&html <b> tag
-                        current_index +=
-                            opt_blockquote_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
-                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
-                                ::pltxt2htm::NodeKind::html_blockquote},
-                            ::pltxt2htm::Ast<ndebug>{}));
-                        goto entry;
                     }
                     result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
                     ++current_index;
@@ -2579,6 +2579,13 @@ entry:
                             ::std::size_t const staged_index{current_index};
                             ::pltxt2htm::HtmlBlockquote staged_node(::std::move(result));
                             call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::ParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
                             parent_frame.current_index +=

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -1729,8 +1729,8 @@ entry:
                             ::std::size_t const staged_index{current_index};
                             ::pltxt2htm::HtmlSpan staged_node(::std::move(result),
                                                               ::std::move(frame.get_html_span_color()),
-                                                              ::std::move(frame.get_html_span_font_size()),
-                                                              ::std::move(frame.get_html_span_vertical_align()));
+                                                              frame.get_html_span_font_size(),
+                                                              frame.get_html_span_vertical_align());
                             call_stack.pop();
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
@@ -2890,7 +2890,7 @@ entry:
             case ::pltxt2htm::NodeKind::html_span: {
                 parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlSpan<ndebug>{
                     ::std::move(subast), ::std::move(frame.get_html_span_color()),
-                    ::std::move(frame.get_html_span_font_size()), ::std::move(frame.get_html_span_vertical_align())}));
+                    frame.get_html_span_font_size(), frame.get_html_span_vertical_align()}));
                 parent_index += staged_index;
                 goto entry;
             }

--- a/include/pltxt2htm/experimental/html_parser.hh
+++ b/include/pltxt2htm/experimental/html_parser.hh
@@ -743,8 +743,8 @@ entry:
                             ::std::size_t const staged_index{current_index};
                             ::pltxt2htm::HtmlSpan staged_node(::std::move(result),
                                                               ::std::move(frame.get_html_span_color()),
-                                                              ::std::move(frame.get_html_span_font_size()),
-                                                              ::std::move(frame.get_html_span_vertical_align()));
+                                                              frame.get_html_span_font_size(),
+                                                              frame.get_html_span_vertical_align());
                             call_stack.pop();
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
@@ -1396,7 +1396,7 @@ entry:
             case ::pltxt2htm::NodeKind::html_span: {
                 parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlSpan<ndebug>{
                     ::std::move(subast), ::std::move(frame.get_html_span_color()),
-                    ::std::move(frame.get_html_span_font_size()), ::std::move(frame.get_html_span_vertical_align())}));
+                    frame.get_html_span_font_size(), frame.get_html_span_vertical_align()}));
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_a: {

--- a/include/pltxt2htm/experimental/html_parser.hh
+++ b/include/pltxt2htm/experimental/html_parser.hh
@@ -31,7 +31,7 @@ struct FindNextBlockAfterLineBreakResult {
  * @param pltext Input subview starting at the candidate block position.
  * @param call_stack Active parser call stack.
  * @return How many bytes were consumed and whether a new frame was created.
- * @note Only handles the `<p>` and `<h1>`–`<h6>` blocks for now; other block elements are out of scope for the html parser.
+ * @note Only handles the `<p>`, `<h1>`–`<h6>` and `<blockquote>` blocks for now; other block elements are out of scope for the html parser.
  */
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
@@ -119,6 +119,18 @@ constexpr auto find_next_block_after_line_break(
                 ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, consumed)},
                 ::pltxt2htm::NodeKind::html_h6},
+            ::pltxt2htm::Ast<ndebug>{}));
+        return ::pltxt2htm::experimental::details::FindNextBlockAfterLineBreakResult{
+            .advance_count = consumed, .new_frame_been_pushed_into_call_stack = true};
+    }
+    if (auto opt_blockquote_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<blockquote">(pltext);
+        opt_blockquote_tag_len.has_value()) {
+        ::std::size_t const consumed{opt_blockquote_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1};
+        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, consumed)},
+                ::pltxt2htm::NodeKind::html_blockquote},
             ::pltxt2htm::Ast<ndebug>{}));
         return ::pltxt2htm::experimental::details::FindNextBlockAfterLineBreakResult{
             .advance_count = consumed, .new_frame_been_pushed_into_call_stack = true};
@@ -258,19 +270,6 @@ entry:
                         }
                         ++current_index;
                         continue;
-                    }
-                    if (auto opt_blockquote_tag = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"lockquote">(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_blockquote_tag.has_value()) {
-                        current_index +=
-                            opt_blockquote_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
-                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
-                                ::pltxt2htm::NodeKind::html_blockquote},
-                            ::pltxt2htm::Ast<ndebug>{}));
-                        goto entry;
                     }
                     result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
                     ++current_index;

--- a/include/pltxt2htm/parser.hh
+++ b/include/pltxt2htm/parser.hh
@@ -145,6 +145,12 @@ constexpr auto parse_pltxt(::fast_io::u8string_view pltext) noexcept -> ::pltxt2
             result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlH6<ndebug>{::std::move(subast)}));
             continue;
         }
+        case ::pltxt2htm::NodeKind::html_blockquote: {
+            // Same as html_p: advance start_index past the consumed html_blockquote content.
+            start_index += consumed_bytes;
+            result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlBlockquote<ndebug>{::std::move(subast)}));
+            continue;
+        }
         default:
             [[unlikely]] {
                 pltxt2htm_unreachable(u8"Unexpected node kind");

--- a/tests/test_common_parser.cc
+++ b/tests/test_common_parser.cc
@@ -237,7 +237,7 @@ int main() {
     {
         auto html =
             ::pltxt2htm_test::pltxt2common_htmld(u8"<code>code</code><pre>pre</pre><blockquote>quote</blockquote>");
-        auto answer = ::fast_io::u8string_view{u8"codeprequote"};
+        auto answer = ::fast_io::u8string_view{u8"codepre&lt;blockquote&gt;quote&lt;/blockquote&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_html_blockquote_tag.cc
+++ b/tests/test_html_blockquote_tag.cc
@@ -5,55 +5,122 @@ int main() {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote>text</blockquote>");
         auto answer = ::fast_io::u8string_view{u8"<blockquote>text</blockquote>"};
         pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<blockquote>text</blockquote>");
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<blockquote>text</blockquote>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
     {
-        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<BLOCKQUOTE    >text</BlockQuote  >");
+        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"<BLOCKQUOTE    >text</BlockQuote  >");
         auto answer = ::fast_io::u8string_view{u8"<blockquote>text</blockquote>"};
-        pltxt2htm_test_assert_equal(html, answer);
+        pltxt2htm_test_assert_equal(htmltest, answer);
     }
 
     {
-        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote><color=red>text</color></blockquote>");
+        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote><color=red>text</color></blockquote>");
         auto answer = ::fast_io::u8string_view{u8"<blockquote><span style=\"color:red;\">text</span></blockquote>"};
-        pltxt2htm_test_assert_equal(html, answer);
+        pltxt2htm_test_assert_equal(htmltest, answer);
+        auto htmlu = ::pltxt2htm_test::pltxt4htmlunittest(u8"<blockquote><color=red>text</color></blockquote>");
+        auto htmlu_answer = ::fast_io::u8string_view{u8"<blockquote>&lt;color=red&gt;text&lt;/color&gt;</blockquote>"};
+        pltxt2htm_test_assert_equal(htmlu, htmlu_answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<blockquote><color=red>text</color></blockquote>");
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<blockquote><color=red>text</color></blockquote>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
     {
-        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote><color=red>text</blockquote></color>");
+        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote><color=red>text</blockquote></color>");
         auto answer = ::fast_io::u8string_view{
             u8"<blockquote><span style=\"color:red;\">text&lt;/blockquote&gt;</span></blockquote>"};
-        pltxt2htm_test_assert_equal(html, answer);
+        pltxt2htm_test_assert_equal(htmltest, answer);
+        auto htmlu = ::pltxt2htm_test::pltxt4htmlunittest(u8"<blockquote><color=red>text</blockquote></color>");
+        auto htmlu_answer = ::fast_io::u8string_view{u8"<blockquote>&lt;color=red&gt;text</blockquote>&lt;/color&gt;"};
+        pltxt2htm_test_assert_equal(htmlu, htmlu_answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<blockquote><color=red>text</blockquote></color>");
+        auto plunity_richtext_answer = ::fast_io::u8string_view{
+            u8"<blockquote><color=red>text<size=20>\uFF1C</size>/blockquote<size=20>\uFF1E</size></color></blockquote>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
     {
-        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote>text<blockquote>text</blockquote></blockquote>");
-        auto answer = ::fast_io::u8string_view{u8"<blockquote>text<blockquote>text</blockquote></blockquote>"};
-        pltxt2htm_test_assert_equal(html, answer);
+        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote>text<blockquote>text</blockquote></blockquote>");
+        auto answer = ::fast_io::u8string_view{u8"<blockquote>text&lt;blockquote&gt;text</blockquote>&lt;/blockquote&gt;"};
+        pltxt2htm_test_assert_equal(htmltest, answer);
+        auto plunity_richtext =
+            ::pltxt2htm_test::pltxt2plunity_introduction(u8"<blockquote>text<blockquote>text</blockquote></blockquote>");
+        auto plunity_richtext_answer = ::fast_io::u8string_view{
+            u8"<blockquote>text<size=20>\uFF1C</size>blockquote<size=20>\uFF1E</size>text</blockquote>"
+            u8"<size=20>\uFF1C</size>/blockquote<size=20>\uFF1E</size>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
     {
-        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote>");
+        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote>");
         auto answer = ::fast_io::u8string_view{u8"<blockquote></blockquote>"};
-        pltxt2htm_test_assert_equal(html, answer);
+        pltxt2htm_test_assert_equal(htmltest, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<blockquote>");
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<blockquote></blockquote>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
     {
-        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote");
+        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote");
         auto answer = ::fast_io::u8string_view{u8"&lt;blockquote"};
-        pltxt2htm_test_assert_equal(html, answer);
+        pltxt2htm_test_assert_equal(htmltest, answer);
     }
 
     {
-        auto html = ::pltxt2htm_test::pltxt4unittest(u8"t<blockquote></blockquote>t");
-        auto answer = ::fast_io::u8string_view{u8"t<blockquote></blockquote>t"};
-        pltxt2htm_test_assert_equal(html, answer);
+        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"t<blockquote></blockquote>t");
+        auto answer = ::fast_io::u8string_view{u8"t&lt;blockquote&gt;&lt;/blockquote&gt;t"};
+        pltxt2htm_test_assert_equal(htmltest, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(u8"t<blockquote></blockquote>t");
+        auto plunity_richtext_answer = ::fast_io::u8string_view{
+            u8"t<size=20>\uFF1C</size>blockquote<size=20>\uFF1E</size><size=20>\uFF1C</size>/blockquote<size=20>\uFF1E</size>t"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
     {
-        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"ab<blockquote>test</blockquote>cd");
-        auto answer = ::fast_io::u8string_view{u8"ab<blockquote>test</blockquote>cd"};
-        pltxt2htm_test_assert_equal(html, answer);
+        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"t<blockquote></blockquote");
+        auto answer = ::fast_io::u8string_view{u8"t&lt;blockquote&gt;&lt;/blockquote"};
+        pltxt2htm_test_assert_equal(htmltest, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(u8"t<blockquote></blockquote");
+        auto plunity_richtext_answer = ::fast_io::u8string_view{
+            u8"t<size=20>\uFF1C</size>blockquote<size=20>\uFF1E</size><size=20>\uFF1C</size>/blockquote"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"ab<blockquote>test</blockquote>cd");
+        auto answer = ::fast_io::u8string_view{u8"ab&lt;blockquote&gt;test&lt;/blockquote&gt;cd"};
+        pltxt2htm_test_assert_equal(htmltest, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(u8"ab<blockquote>test</blockquote>cd");
+        auto plunity_richtext_answer = ::fast_io::u8string_view{
+            u8"ab<size=20>\uFF1C</size>blockquote<size=20>\uFF1E</size>test<size=20>\uFF1C</size>/blockquote<size=20>\uFF1E</size>cd"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"text\n<blockquote>text</blockquote>");
+        auto answer = ::fast_io::u8string_view{u8"text<br><blockquote>text</blockquote>"};
+        pltxt2htm_test_assert_equal(htmltest, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(u8"text\n<blockquote>text</blockquote>");
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\n<blockquote>text</blockquote>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"text<br><blockquote>text</blockquote>");
+        auto answer = ::fast_io::u8string_view{u8"text<br><blockquote>text</blockquote>"};
+        pltxt2htm_test_assert_equal(htmltest, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(u8"text<br><blockquote>text</blockquote>");
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\n<blockquote>text</blockquote>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    {
+        auto htmltest = ::pltxt2htm_test::pltxt4htmlunittest(u8"text<br><blockquote>text</blockquote>");
+        auto answer = ::fast_io::u8string_view{u8"text<br><blockquote>text</blockquote>"};
+        pltxt2htm_test_assert_equal(htmltest, answer);
     }
 
     return 0;

--- a/tests/test_html_blockquote_tag.cc
+++ b/tests/test_html_blockquote_tag.cc
@@ -11,15 +11,15 @@ int main() {
     }
 
     {
-        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"<BLOCKQUOTE    >text</BlockQuote  >");
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<BLOCKQUOTE    >text</BlockQuote  >");
         auto answer = ::fast_io::u8string_view{u8"<blockquote>text</blockquote>"};
-        pltxt2htm_test_assert_equal(htmltest, answer);
+        pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
-        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote><color=red>text</color></blockquote>");
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote><color=red>text</color></blockquote>");
         auto answer = ::fast_io::u8string_view{u8"<blockquote><span style=\"color:red;\">text</span></blockquote>"};
-        pltxt2htm_test_assert_equal(htmltest, answer);
+        pltxt2htm_test_assert_equal(html, answer);
         auto htmlu = ::pltxt2htm_test::pltxt4htmlunittest(u8"<blockquote><color=red>text</color></blockquote>");
         auto htmlu_answer = ::fast_io::u8string_view{u8"<blockquote>&lt;color=red&gt;text&lt;/color&gt;</blockquote>"};
         pltxt2htm_test_assert_equal(htmlu, htmlu_answer);
@@ -29,10 +29,10 @@ int main() {
     }
 
     {
-        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote><color=red>text</blockquote></color>");
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote><color=red>text</blockquote></color>");
         auto answer = ::fast_io::u8string_view{
             u8"<blockquote><span style=\"color:red;\">text&lt;/blockquote&gt;</span></blockquote>"};
-        pltxt2htm_test_assert_equal(htmltest, answer);
+        pltxt2htm_test_assert_equal(html, answer);
         auto htmlu = ::pltxt2htm_test::pltxt4htmlunittest(u8"<blockquote><color=red>text</blockquote></color>");
         auto htmlu_answer = ::fast_io::u8string_view{u8"<blockquote>&lt;color=red&gt;text</blockquote>&lt;/color&gt;"};
         pltxt2htm_test_assert_equal(htmlu, htmlu_answer);
@@ -43,9 +43,9 @@ int main() {
     }
 
     {
-        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote>text<blockquote>text</blockquote></blockquote>");
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote>text<blockquote>text</blockquote></blockquote>");
         auto answer = ::fast_io::u8string_view{u8"<blockquote>text&lt;blockquote&gt;text</blockquote>&lt;/blockquote&gt;"};
-        pltxt2htm_test_assert_equal(htmltest, answer);
+        pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext =
             ::pltxt2htm_test::pltxt2plunity_introduction(u8"<blockquote>text<blockquote>text</blockquote></blockquote>");
         auto plunity_richtext_answer = ::fast_io::u8string_view{
@@ -55,24 +55,24 @@ int main() {
     }
 
     {
-        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote>");
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote>");
         auto answer = ::fast_io::u8string_view{u8"<blockquote></blockquote>"};
-        pltxt2htm_test_assert_equal(htmltest, answer);
+        pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<blockquote>");
         auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<blockquote></blockquote>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
     {
-        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote");
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<blockquote");
         auto answer = ::fast_io::u8string_view{u8"&lt;blockquote"};
-        pltxt2htm_test_assert_equal(htmltest, answer);
+        pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
-        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"t<blockquote></blockquote>t");
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"t<blockquote></blockquote>t");
         auto answer = ::fast_io::u8string_view{u8"t&lt;blockquote&gt;&lt;/blockquote&gt;t"};
-        pltxt2htm_test_assert_equal(htmltest, answer);
+        pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(u8"t<blockquote></blockquote>t");
         auto plunity_richtext_answer = ::fast_io::u8string_view{
             u8"t<size=20>\uFF1C</size>blockquote<size=20>\uFF1E</size><size=20>\uFF1C</size>/blockquote<size=20>\uFF1E</size>t"};
@@ -80,9 +80,9 @@ int main() {
     }
 
     {
-        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"t<blockquote></blockquote");
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"t<blockquote></blockquote");
         auto answer = ::fast_io::u8string_view{u8"t&lt;blockquote&gt;&lt;/blockquote"};
-        pltxt2htm_test_assert_equal(htmltest, answer);
+        pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(u8"t<blockquote></blockquote");
         auto plunity_richtext_answer = ::fast_io::u8string_view{
             u8"t<size=20>\uFF1C</size>blockquote<size=20>\uFF1E</size><size=20>\uFF1C</size>/blockquote"};
@@ -90,9 +90,9 @@ int main() {
     }
 
     {
-        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"ab<blockquote>test</blockquote>cd");
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"ab<blockquote>test</blockquote>cd");
         auto answer = ::fast_io::u8string_view{u8"ab&lt;blockquote&gt;test&lt;/blockquote&gt;cd"};
-        pltxt2htm_test_assert_equal(htmltest, answer);
+        pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(u8"ab<blockquote>test</blockquote>cd");
         auto plunity_richtext_answer = ::fast_io::u8string_view{
             u8"ab<size=20>\uFF1C</size>blockquote<size=20>\uFF1E</size>test<size=20>\uFF1C</size>/blockquote<size=20>\uFF1E</size>cd"};
@@ -100,27 +100,27 @@ int main() {
     }
 
     {
-        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"text\n<blockquote>text</blockquote>");
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"text\n<blockquote>text</blockquote>");
         auto answer = ::fast_io::u8string_view{u8"text<br><blockquote>text</blockquote>"};
-        pltxt2htm_test_assert_equal(htmltest, answer);
+        pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(u8"text\n<blockquote>text</blockquote>");
         auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\n<blockquote>text</blockquote>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
     {
-        auto htmltest = ::pltxt2htm_test::pltxt4unittest(u8"text<br><blockquote>text</blockquote>");
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"text<br><blockquote>text</blockquote>");
         auto answer = ::fast_io::u8string_view{u8"text<br><blockquote>text</blockquote>"};
-        pltxt2htm_test_assert_equal(htmltest, answer);
+        pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(u8"text<br><blockquote>text</blockquote>");
         auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\n<blockquote>text</blockquote>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
     {
-        auto htmltest = ::pltxt2htm_test::pltxt4htmlunittest(u8"text<br><blockquote>text</blockquote>");
+        auto html = ::pltxt2htm_test::pltxt4htmlunittest(u8"text<br><blockquote>text</blockquote>");
         auto answer = ::fast_io::u8string_view{u8"text<br><blockquote>text</blockquote>"};
-        pltxt2htm_test_assert_equal(htmltest, answer);
+        pltxt2htm_test_assert_equal(html, answer);
     }
 
     return 0;


### PR DESCRIPTION
### Problem

Previously, `<blockquote>` was parsed via an inline hack that matched `lockquote` after a `<b` sequence. This caused several issues:

1. **Incorrect block semantics**: `<blockquote>` was not recognized as a block-level element at line start. It could only appear inline, which broke nesting rules and produced wrong output when mixed with other block elements like `<p>` or `<h1>`–`<h6>`.
2. **Ambiguous inline parsing**: A standalone `<blockquote>` in the middle of a paragraph was treated as a tag rather than literal text, causing unexpected HTML escaping behavior.
3. **Unnecessary `std::move` on scalar returns**: `HtmlSpan` construction used `std::move` on `get_html_span_font_size()` and `get_html_span_vertical_align()`, which return values that don't benefit from move semantics and may trigger compiler warnings.

### Solution

- **Move `<blockquote>` detection into `find_next_block_after_line_break`** (both `details/parser/parser.hh` and `experimental/html_parser.hh`), making it a first-class block element alongside `<p>` and `<h1>`–`<h6>`.
- **Remove the old inline `lockquote` hack** from the `<` character handling path. Inline `<blockquote>` sequences are now treated as plain text and properly escaped by the downstream formatter.
- **Add `html_blockquote` handling in `parser.hh`** so the top-level dispatcher correctly advances the cursor and wraps the sub-AST.
- **Fix `HtmlSpan` construction** by removing `std::move` from scalar font-size and vertical-align accessors.
- **Add `call_stack.empty()` guard** in the `html_blockquote` frame exit path to prevent UB when the tag closes at the top level.