### PR TITLE
feat: Support Unity TMP `<align>` tag and fix `<p>` handling in the plunity backend

### DIFF
--- a/include/pltxt2htm/ast/ast.hh
+++ b/include/pltxt2htm/ast/ast.hh
@@ -165,6 +165,7 @@ class PlTxtNode {
         ::pltxt2htm::PlLink<ndebug> pl_link_node;
         ::pltxt2htm::PlSize<ndebug> pl_size_node;
         ::pltxt2htm::PlVoffset<ndebug> pl_voffset_node;
+        ::pltxt2htm::PlAlign<ndebug> pl_align_node;
         ::pltxt2htm::PlMark<ndebug> pl_mark_node;
         ::pltxt2htm::PlI<ndebug> pl_i_node;
         ::pltxt2htm::PlB<ndebug> pl_b_node;
@@ -237,6 +238,11 @@ public:
     constexpr PlTxtNode(::pltxt2htm::PlVoffset<ndebug>&& node) noexcept
         : pl_voffset_node(::std::move(node)),
           node_kind{::pltxt2htm::NodeKind::pl_voffset} {
+    }
+
+    constexpr PlTxtNode(::pltxt2htm::PlAlign<ndebug>&& node) noexcept
+        : pl_align_node(::std::move(node)),
+          node_kind{::pltxt2htm::NodeKind::pl_align} {
     }
 
     constexpr PlTxtNode(::pltxt2htm::PlMark<ndebug>&& node) noexcept
@@ -899,6 +905,10 @@ public:
             new (::std::addressof(pl_voffset_node))::pltxt2htm::PlVoffset(other.pl_voffset_node);
             break;
         }
+        case ::pltxt2htm::NodeKind::pl_align: {
+            new (::std::addressof(pl_align_node))::pltxt2htm::PlAlign(other.pl_align_node);
+            break;
+        }
         case ::pltxt2htm::NodeKind::pl_mark: {
             new (::std::addressof(pl_mark_node))::pltxt2htm::PlMark(other.pl_mark_node);
             break;
@@ -1471,6 +1481,10 @@ public:
         }
         case ::pltxt2htm::NodeKind::pl_voffset: {
             new (::std::addressof(pl_voffset_node))::pltxt2htm::PlVoffset(::std::move(other.pl_voffset_node));
+            break;
+        }
+        case ::pltxt2htm::NodeKind::pl_align: {
+            new (::std::addressof(pl_align_node))::pltxt2htm::PlAlign(::std::move(other.pl_align_node));
             break;
         }
         case ::pltxt2htm::NodeKind::pl_mark: {
@@ -2113,6 +2127,10 @@ public:
             pl_voffset_node.~PlVoffset();
             break;
         }
+        case ::pltxt2htm::NodeKind::pl_align: {
+            pl_align_node.~PlAlign();
+            break;
+        }
         case ::pltxt2htm::NodeKind::pl_mark: {
             pl_mark_node.~PlMark();
             break;
@@ -2658,6 +2676,9 @@ public:
         }
         case ::pltxt2htm::NodeKind::pl_voffset: {
             return self.pl_voffset_node == other.pl_voffset_node;
+        }
+        case ::pltxt2htm::NodeKind::pl_align: {
+            return self.pl_align_node == other.pl_align_node;
         }
         case ::pltxt2htm::NodeKind::pl_mark: {
             return self.pl_mark_node == other.pl_mark_node;
@@ -3902,6 +3923,13 @@ public:
         bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::pl_voffset};
         pltxt2htm_assert(is_type, u8"node kind mismatch");
         return ::std::forward_like<decltype(self)>(self.pl_voffset_node);
+    }
+
+    [[nodiscard]]
+    constexpr auto as_pl_align(this auto&& self) noexcept -> decltype(auto) {
+        bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::pl_align};
+        pltxt2htm_assert(is_type, u8"node kind mismatch");
+        return ::std::forward_like<decltype(self)>(self.pl_align_node);
     }
 
     [[nodiscard]]

--- a/include/pltxt2htm/ast/impl/physics_lab_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/physics_lab_node_decl.hh
@@ -328,6 +328,39 @@ public:
 };
 
 /**
+ * @brief Physics-Lab alignment tag node
+ * @details Represents &lt;align=value&gt;...&lt;/align&gt; (Unity TextMeshPro rich text)
+ *          with a text-alignment keyword and sub-AST.
+ */
+template<::pltxt2htm::Contracts ndebug>
+class PlAlign {
+    ::pltxt2htm::Ast<ndebug> subast;
+    ::pltxt2htm::TextAlign align;
+
+public:
+    constexpr PlAlign(::pltxt2htm::Ast<ndebug>&& subast_, ::pltxt2htm::TextAlign align_) noexcept;
+    constexpr PlAlign(::pltxt2htm::PlAlign<ndebug> const&) noexcept;
+    constexpr PlAlign(::pltxt2htm::PlAlign<ndebug>&&) noexcept;
+    constexpr ~PlAlign() noexcept;
+    constexpr auto operator=(::pltxt2htm::PlAlign<ndebug> const&) noexcept -> ::pltxt2htm::PlAlign<ndebug>& = delete;
+    constexpr auto operator=(this ::pltxt2htm::PlAlign<ndebug>& self, ::pltxt2htm::PlAlign<ndebug>&&) noexcept
+        -> ::pltxt2htm::PlAlign<ndebug>&;
+
+    [[nodiscard]]
+    constexpr auto operator==(this PlAlign const&, PlAlign const&) noexcept -> bool;
+
+    [[nodiscard]]
+    constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.subast);
+    }
+
+    [[nodiscard]]
+    constexpr auto get_align(this auto const& self) noexcept -> ::pltxt2htm::TextAlign {
+        return self.align;
+    }
+};
+
+/**
  * @brief Physics-Lab mark tag node
  * @details Represents &lt;mark=value&gt;...&lt;/mark&gt; (TMP rich text) with a background
  *          color string and sub-AST.

--- a/include/pltxt2htm/ast/impl/physics_lab_node_def.inc
+++ b/include/pltxt2htm/ast/impl/physics_lab_node_def.inc
@@ -220,8 +220,7 @@ constexpr auto ::pltxt2htm::PlAlign<ndebug>::operator=(this ::pltxt2htm::PlAlign
 
 template<::pltxt2htm::Contracts ndebug>
 constexpr auto ::pltxt2htm::PlAlign<ndebug>::operator==(this ::pltxt2htm::PlAlign<ndebug> const&,
-                                                        ::pltxt2htm::PlAlign<ndebug> const&) noexcept
-    -> bool = default;
+                                                        ::pltxt2htm::PlAlign<ndebug> const&) noexcept -> bool = default;
 
 template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::PlMark<ndebug>::PlMark(::pltxt2htm::Ast<ndebug>&& subast_,

--- a/include/pltxt2htm/ast/impl/physics_lab_node_def.inc
+++ b/include/pltxt2htm/ast/impl/physics_lab_node_def.inc
@@ -201,6 +201,29 @@ constexpr auto ::pltxt2htm::PlVoffset<ndebug>::operator==(this ::pltxt2htm::PlVo
     -> bool = default;
 
 template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::PlAlign<ndebug>::PlAlign(::pltxt2htm::Ast<ndebug>&& subast_,
+                                                ::pltxt2htm::TextAlign align_) noexcept
+    : subast(::std::move(subast_)),
+      align(align_) {
+}
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::PlAlign<ndebug>::PlAlign(::pltxt2htm::PlAlign<ndebug> const&) noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::PlAlign<ndebug>::PlAlign(::pltxt2htm::PlAlign<ndebug>&&) noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::PlAlign<ndebug>::~PlAlign() noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr auto ::pltxt2htm::PlAlign<ndebug>::operator=(this ::pltxt2htm::PlAlign<ndebug>& self,
+                                                       ::pltxt2htm::PlAlign<ndebug>&&) noexcept
+    -> ::pltxt2htm::PlAlign<ndebug>& = default;
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr auto ::pltxt2htm::PlAlign<ndebug>::operator==(this ::pltxt2htm::PlAlign<ndebug> const&,
+                                                        ::pltxt2htm::PlAlign<ndebug> const&) noexcept
+    -> bool = default;
+
+template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::PlMark<ndebug>::PlMark(::pltxt2htm::Ast<ndebug>&& subast_,
                                               ::fast_io::u8string&& background_color_) noexcept
     : subast(::std::move(subast_)),

--- a/include/pltxt2htm/ast/node_kind.hh
+++ b/include/pltxt2htm/ast/node_kind.hh
@@ -44,6 +44,7 @@ enum class NodeKind : unsigned {
     pl_user, ///< Physics-Lab user reference: &lt;user=id&gt;...&lt;/user&gt;
     pl_size, ///< Physics-Lab font size: &lt;size=value&gt;...&lt;/size&gt;
     pl_voffset, ///< Physics-Lab vertical offset (Unity TMP rich text): &lt;voffset=value&gt;...&lt;/voffset&gt;
+    pl_align, ///< Text alignment (Unity TMP rich text): &lt;align=value&gt;...&lt;/align&gt;
     pl_mark, ///< Physics-Lab mark (TMP rich text): &lt;mark=Xxx&gt;...&lt;/mark&gt;
     pl_external, ///< Physics-Lab external link: &lt;external=url&gt;...&lt;/external&gt;
     pl_link, ///< Physics-Lab link (Unity TextMeshPro rich text): &lt;link=&quot;url&quot;&gt;...&lt;/link&gt;

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -415,30 +415,37 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::pl_align: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                    node.as_pl_align().get_subast(), ::pltxt2htm::NodeKind::pl_align, 0));
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_pl_align().get_subast(),
+                                                                                  ::pltxt2htm::NodeKind::pl_align, 0));
                 ++current_index;
                 if (result.empty() == false && result.back() != u8'\n') {
                     result.push_back(u8'\n');
                 }
-                result.append(u8"<align=");
                 auto const align = node.as_pl_align().get_align();
-                if (align == ::pltxt2htm::TextAlign::left) {
-                    result.append(u8"left");
+                switch (align) /* -Werror=switch */ {
+                case ::pltxt2htm::TextAlign::left: {
+                    result.append(u8"<align=left>");
+                    break;
                 }
-                else if (align == ::pltxt2htm::TextAlign::center) {
-                    result.append(u8"center");
+                case ::pltxt2htm::TextAlign::center: {
+                    result.append(u8"<align=center>");
+                    break;
                 }
-                else if (align == ::pltxt2htm::TextAlign::right) {
-                    result.append(u8"right");
+                case ::pltxt2htm::TextAlign::right: {
+                    result.append(u8"<align=right>");
+                    break;
                 }
-                else if (align == ::pltxt2htm::TextAlign::justify) {
-                    result.append(u8"justified");
+                case ::pltxt2htm::TextAlign::justify: {
+                    result.append(u8"<align=justified>");
+                    break;
                 }
-                else [[unlikely]] {
-                    pltxt2htm_unreachable(u8"Unexpected alignment value for align tag");
+#ifdef PLTXT2HTM_ENABLE_RUNTIME_EXHAUSTIVE_SWITCH_CHECK
+                default:
+                    [[unlikely]] {
+                        pltxtpltxt2htm_unreachable(u8"Unexpected unit for align");
+                    }
+#endif
                 }
-                result.push_back(u8'>');
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_span: {
@@ -1408,8 +1415,9 @@ entry:
                 auto const& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                 auto const& parent_ast = parent_frame.get_ast();
                 if (parent_frame.current_index < parent_ast.size()) {
-                    auto const next_kind = ::pltxt2htm::details::vector_index<ndebug>(parent_ast, parent_frame.current_index)
-                                               .get_node_kind();
+                    auto const next_kind =
+                        ::pltxt2htm::details::vector_index<ndebug>(parent_ast, parent_frame.current_index)
+                            .get_node_kind();
                     if (next_kind != ::pltxt2htm::NodeKind::line_break && next_kind != ::pltxt2htm::NodeKind::html_br &&
                         result.empty() == false && result.back() != u8'\n') {
                         result.push_back(u8'\n');
@@ -1458,8 +1466,9 @@ entry:
                 auto const& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                 auto const& parent_ast = parent_frame.get_ast();
                 if (parent_frame.current_index < parent_ast.size()) {
-                    auto const next_kind = ::pltxt2htm::details::vector_index<ndebug>(parent_ast, parent_frame.current_index)
-                                               .get_node_kind();
+                    auto const next_kind =
+                        ::pltxt2htm::details::vector_index<ndebug>(parent_ast, parent_frame.current_index)
+                            .get_node_kind();
                     if (next_kind != ::pltxt2htm::NodeKind::line_break && next_kind != ::pltxt2htm::NodeKind::html_br &&
                         result.empty() == false && result.back() != u8'\n') {
                         result.push_back(u8'\n');

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -583,7 +583,9 @@ entry:
                     node.as_html_p().get_subast(), ::pltxt2htm::NodeKind::html_p, 0,
                     ::pltxt2htm::details::BackendContextWithAlignInfo{.has_align = has_align}));
                 ++current_index;
-                result.append(u8"<p>");
+                if (result.empty() == false && result.back() != u8'\n') {
+                    result.push_back(u8'\n');
+                }
                 if (has_align) {
                     result.append(u8"<align=");
                     if (align == ::pltxt2htm::TextAlign::center) {
@@ -1440,7 +1442,6 @@ entry:
                 if (top_frame.get_align_info().has_align) {
                     result.append(u8"</align>");
                 }
-                result.append(u8"</p>");
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_atx_h1:

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -414,6 +414,30 @@ entry:
                 result.push_back(u8'>');
                 goto entry;
             }
+            case ::pltxt2htm::NodeKind::pl_align: {
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                    node.as_pl_align().get_subast(), ::pltxt2htm::NodeKind::pl_align, 0));
+                ++current_index;
+                result.append(u8"<align=");
+                auto const align = node.as_pl_align().get_align();
+                if (align == ::pltxt2htm::TextAlign::left) {
+                    result.append(u8"left");
+                }
+                else if (align == ::pltxt2htm::TextAlign::center) {
+                    result.append(u8"center");
+                }
+                else if (align == ::pltxt2htm::TextAlign::right) {
+                    result.append(u8"right");
+                }
+                else if (align == ::pltxt2htm::TextAlign::justify) {
+                    result.append(u8"justified");
+                }
+                else [[unlikely]] {
+                    pltxt2htm_unreachable(u8"Unexpected alignment value for align tag");
+                }
+                result.push_back(u8'>');
+                goto entry;
+            }
             case ::pltxt2htm::NodeKind::html_span: {
                 auto const& span_color = node.as_html_span().get_color();
                 auto const& span_font_size = node.as_html_span().get_font_size();
@@ -553,21 +577,29 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_p: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_p().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::html_p, 0));
-                ++current_index;
-                result.append(u8"<p");
                 auto const align = node.as_html_p().get_align();
-                if (align == ::pltxt2htm::TextAlign::center) {
-                    result.append(u8" style=\"text-align:center\"");
+                bool const has_align = align != ::pltxt2htm::TextAlign::left;
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                    node.as_html_p().get_subast(), ::pltxt2htm::NodeKind::html_p, 0,
+                    ::pltxt2htm::details::BackendContextWithAlignInfo{.has_align = has_align}));
+                ++current_index;
+                result.append(u8"<p>");
+                if (has_align) {
+                    result.append(u8"<align=");
+                    if (align == ::pltxt2htm::TextAlign::center) {
+                        result.append(u8"center");
+                    }
+                    else if (align == ::pltxt2htm::TextAlign::right) {
+                        result.append(u8"right");
+                    }
+                    else if (align == ::pltxt2htm::TextAlign::justify) {
+                        result.append(u8"justified");
+                    }
+                    else [[unlikely]] {
+                        pltxt2htm_unreachable(u8"Unexpected paragraph text alignment");
+                    }
+                    result.push_back(u8'>');
                 }
-                else if (align == ::pltxt2htm::TextAlign::right) {
-                    result.append(u8" style=\"text-align:right\"");
-                }
-                else if (align == ::pltxt2htm::TextAlign::justify) {
-                    result.append(u8" style=\"text-align:justify\"");
-                }
-                result.push_back(u8'>');
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_br:
@@ -1366,6 +1398,10 @@ entry:
                 result.append(u8"</voffset>");
                 goto entry;
             }
+            case ::pltxt2htm::NodeKind::pl_align: {
+                result.append(u8"</align>");
+                goto entry;
+            }
             case ::pltxt2htm::NodeKind::md_double_emphasis_underscore:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::md_double_emphasis_asterisk:
@@ -1401,6 +1437,9 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_p: {
+                if (top_frame.get_align_info().has_align) {
+                    result.append(u8"</align>");
+                }
                 result.append(u8"</p>");
                 goto entry;
             }

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -418,6 +418,9 @@ entry:
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
                     node.as_pl_align().get_subast(), ::pltxt2htm::NodeKind::pl_align, 0));
                 ++current_index;
+                if (result.empty() == false && result.back() != u8'\n') {
+                    result.push_back(u8'\n');
+                }
                 result.append(u8"<align=");
                 auto const align = node.as_pl_align().get_align();
                 if (align == ::pltxt2htm::TextAlign::left) {

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -1405,6 +1405,16 @@ entry:
             }
             case ::pltxt2htm::NodeKind::pl_align: {
                 result.append(u8"</align>");
+                auto const& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                auto const& parent_ast = parent_frame.get_ast();
+                if (parent_frame.current_index < parent_ast.size()) {
+                    auto const next_kind = ::pltxt2htm::details::vector_index<ndebug>(parent_ast, parent_frame.current_index)
+                                               .get_node_kind();
+                    if (next_kind != ::pltxt2htm::NodeKind::line_break && next_kind != ::pltxt2htm::NodeKind::html_br &&
+                        result.empty() == false && result.back() != u8'\n') {
+                        result.push_back(u8'\n');
+                    }
+                }
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_double_emphasis_underscore:
@@ -1444,6 +1454,16 @@ entry:
             case ::pltxt2htm::NodeKind::html_p: {
                 if (top_frame.get_align_info().has_align) {
                     result.append(u8"</align>");
+                }
+                auto const& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                auto const& parent_ast = parent_frame.get_ast();
+                if (parent_frame.current_index < parent_ast.size()) {
+                    auto const next_kind = ::pltxt2htm::details::vector_index<ndebug>(parent_ast, parent_frame.current_index)
+                                               .get_node_kind();
+                    if (next_kind != ::pltxt2htm::NodeKind::line_break && next_kind != ::pltxt2htm::NodeKind::html_br &&
+                        result.empty() == false && result.back() != u8'\n') {
+                        result.push_back(u8'\n');
+                    }
                 }
                 goto entry;
             }

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -538,24 +538,31 @@ entry:
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
                     node.as_pl_align().get_subast(), ::pltxt2htm::NodeKind::pl_align, 0));
                 ++current_index;
-                result.append(u8"<span style=\"text-align:");
                 auto const align = node.as_pl_align().get_align();
-                if (align == ::pltxt2htm::TextAlign::left) {
-                    result.append(u8"left");
+                switch (align) /* -Werror=switch */ {
+                case ::pltxt2htm::TextAlign::left: {
+                    result.append(u8"<p style=\"text-align:left\">");
+                    break;
                 }
-                else if (align == ::pltxt2htm::TextAlign::center) {
-                    result.append(u8"center");
+                case ::pltxt2htm::TextAlign::center: {
+                    result.append(u8"<p style=\"text-align:center\">");
+                    break;
                 }
-                else if (align == ::pltxt2htm::TextAlign::right) {
-                    result.append(u8"right");
+                case ::pltxt2htm::TextAlign::right: {
+                    result.append(u8"<p style=\"text-align:right\">");
+                    break;
                 }
-                else if (align == ::pltxt2htm::TextAlign::justify) {
-                    result.append(u8"justify");
+                case ::pltxt2htm::TextAlign::justify: {
+                    result.append(u8"<p style=\"text-align:justify\">");
+                    break;
                 }
-                else [[unlikely]] {
-                    pltxt2htm_unreachable(u8"Unexpected alignment value for align tag");
+#ifdef PLTXT2HTM_ENABLE_RUNTIME_EXHAUSTIVE_SWITCH_CHECK
+                default:
+                    [[unlikely]] {
+                        pltxt2htm_unreachable(u8"Unexpected text alignment");
+                    }
+#endif
                 }
-                result.append(u8";\">");
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_span: {
@@ -1517,7 +1524,7 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::pl_align: {
-                result.append(u8"</span>");
+                result.append(u8"</p>");
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_double_emphasis_underscore:

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -534,6 +534,30 @@ entry:
                 result.append(u8";\">");
                 goto entry;
             }
+            case ::pltxt2htm::NodeKind::pl_align: {
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                    node.as_pl_align().get_subast(), ::pltxt2htm::NodeKind::pl_align, 0));
+                ++current_index;
+                result.append(u8"<span style=\"text-align:");
+                auto const align = node.as_pl_align().get_align();
+                if (align == ::pltxt2htm::TextAlign::left) {
+                    result.append(u8"left");
+                }
+                else if (align == ::pltxt2htm::TextAlign::center) {
+                    result.append(u8"center");
+                }
+                else if (align == ::pltxt2htm::TextAlign::right) {
+                    result.append(u8"right");
+                }
+                else if (align == ::pltxt2htm::TextAlign::justify) {
+                    result.append(u8"justify");
+                }
+                else [[unlikely]] {
+                    pltxt2htm_unreachable(u8"Unexpected alignment value for align tag");
+                }
+                result.append(u8";\">");
+                goto entry;
+            }
             case ::pltxt2htm::NodeKind::html_span: {
                 auto const& span_color = node.as_html_span().get_color();
                 auto const& span_font_size = node.as_html_span().get_font_size();
@@ -1489,6 +1513,10 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::pl_voffset: {
+                result.append(u8"</span>");
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_align: {
                 result.append(u8"</span>");
                 goto entry;
             }

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -535,8 +535,8 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::pl_align: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                    node.as_pl_align().get_subast(), ::pltxt2htm::NodeKind::pl_align, 0));
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_pl_align().get_subast(),
+                                                                                  ::pltxt2htm::NodeKind::pl_align, 0));
                 ++current_index;
                 auto const align = node.as_pl_align().get_align();
                 switch (align) /* -Werror=switch */ {

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -474,6 +474,12 @@ entry:
                 ++current_index;
                 goto entry;
             }
+            case ::pltxt2htm::NodeKind::pl_align: {
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_pl_align().get_subast(),
+                                                                                  ::pltxt2htm::NodeKind::text, 0));
+                ++current_index;
+                goto entry;
+            }
             case ::pltxt2htm::NodeKind::html_p: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_p().get_subast(),
                                                                                   ::pltxt2htm::NodeKind::text, 0));

--- a/include/pltxt2htm/details/backend/frame_context.hh
+++ b/include/pltxt2htm/details/backend/frame_context.hh
@@ -41,6 +41,16 @@ public:
 };
 
 /**
+ * @brief Context for alignment frames: remembers whether a Unity <align> tag was opened.
+ * @details Used by ::pltxt2htm::NodeKind::html_p frames so the plunity backend can emit
+ *          the matching `</align>` closing tag.
+ */
+class BackendContextWithAlignInfo {
+public:
+    bool has_align{}; ///< Whether the frame opened a Unity <align> tag.
+};
+
+/**
  * @brief Tagged-union variant of backend context payloads.
  * @details Dispatched on `kind` (::pltxt2htm::NodeKind) – used inside
  *          ::pltxt2htm::details::BackendFrameContext.
@@ -51,6 +61,7 @@ public:
         ::pltxt2htm::details::BackendContextWithoutInfo without_info;
         ::pltxt2htm::details::BackendContextWithOlInfo ol_info;
         ::pltxt2htm::details::BackendContextWithHtmlSpanInfo html_span_info;
+        ::pltxt2htm::details::BackendContextWithAlignInfo align_info;
     };
 
     ::pltxt2htm::NodeKind kind;
@@ -70,6 +81,12 @@ public:
         ::pltxt2htm::details::BackendContextWithHtmlSpanInfo html_span_info_context) noexcept
         : html_span_info{::std::move(html_span_info_context)},
           kind{::pltxt2htm::NodeKind::html_span} {
+    }
+
+    constexpr BackendContextVariant(::pltxt2htm::NodeKind const kind_,
+                                    ::pltxt2htm::details::BackendContextWithAlignInfo align_info_context) noexcept
+        : align_info{::std::move(align_info_context)},
+          kind{kind_} {
     }
 
     constexpr ~BackendContextVariant() noexcept = default;
@@ -114,6 +131,14 @@ public:
           current_index{current_index_} {
     }
 
+    constexpr BackendFrameContext(::pltxt2htm::Ast<ndebug> const& ast_, ::pltxt2htm::NodeKind const nested_tag_type,
+                                  ::std::size_t current_index_,
+                                  ::pltxt2htm::details::BackendContextWithAlignInfo align_info_context) noexcept
+        : context_data{nested_tag_type, ::std::move(align_info_context)},
+          ast(::std::addressof(ast_)),
+          current_index{current_index_} {
+    }
+
     constexpr BackendFrameContext(::pltxt2htm::details::BackendFrameContext<ndebug> const&) noexcept = default;
     constexpr BackendFrameContext(::pltxt2htm::details::BackendFrameContext<ndebug>&&) noexcept = default;
 
@@ -140,6 +165,13 @@ public:
         bool const is_html_span_type{self.context_data.kind == ::pltxt2htm::NodeKind::html_span};
         pltxt2htm_assert(is_html_span_type, u8"context kind mismatch");
         return self.context_data.html_span_info;
+    }
+
+    [[nodiscard]]
+    constexpr auto get_align_info(this auto const& self) noexcept -> BackendContextWithAlignInfo {
+        bool const is_align_type{self.context_data.kind == ::pltxt2htm::NodeKind::html_p};
+        pltxt2htm_assert(is_align_type, u8"context kind mismatch");
+        return self.context_data.align_info;
     }
 
     [[nodiscard]]

--- a/include/pltxt2htm/details/parser/frame_context.hh
+++ b/include/pltxt2htm/details/parser/frame_context.hh
@@ -124,15 +124,6 @@ public:
 };
 
 /**
- * @brief Context for <align=value> frames during parsing.
- */
-class ParserFrameContextWithPlAlignTagInfo {
-public:
-    ::fast_io::u8string_view pltext;
-    ::pltxt2htm::TextAlign align;
-};
-
-/**
  * @brief Context for pl_mark frames during parsing; stores the background color.
  */
 class ParserFrameContextWithPlMarkInfo {
@@ -176,11 +167,11 @@ public:
 };
 
 /**
- * @brief Context for an HTML &lt;p&gt; paragraph during parsing.
- *
- * Stores the paragraph text content and its text alignment.
+ * @brief Context for text-alignment frames during parsing.
+ * @details Shared by the HTML &lt;p&gt; paragraph and the Unity TMP &lt;align=...&gt; block
+ *          frame types. Stores the text content and its text alignment.
  */
-class ParserFrameContextWithPInfo {
+class ParserFrameContextWithAlignInfo {
 public:
     ::fast_io::u8string_view pltext;
     ::pltxt2htm::TextAlign align;
@@ -239,14 +230,13 @@ public:
         url_info,
         pl_size_tag,
         pl_voffset_tag,
-        pl_align_tag,
+        align_info,
         html_span_info,
         html_code_info,
         md_block_quotes,
         md_list,
         md_li_checkbox,
         cell,
-        p,
         md_table,
         pltext,
         html_mark_info,
@@ -265,11 +255,10 @@ public:
         ::pltxt2htm::details::ParserFrameContextWithHtmlATagInfo html_a_tag_info;
         ::pltxt2htm::details::ParserFrameContextWithPlSizeTagInfo pl_size_tag;
         ::pltxt2htm::details::ParserFrameContextWithPlVoffsetTagInfo pl_voffset_tag;
-        ::pltxt2htm::details::ParserFrameContextWithPlAlignTagInfo pl_align_tag;
         ::pltxt2htm::details::ParserFrameContextWithMdBlockQuotesInfo md_block_quotes;
         ::pltxt2htm::details::ParserFrameContextWithMdListInfo<ndebug> md_list;
         ::pltxt2htm::details::ParserFrameContextWithCellInfo cell;
-        ::pltxt2htm::details::ParserFrameContextWithPInfo p;
+        ::pltxt2htm::details::ParserFrameContextWithAlignInfo align_info;
         ::pltxt2htm::details::ParserFrameContextWithMdLiCheckboxInfo md_li_checkbox;
         ::pltxt2htm::details::ParserFrameContextWithMdTableInfo<ndebug> md_table;
     };
@@ -372,16 +361,6 @@ public:
           kind{node_kind_} {
     }
 
-constexpr FrontendContextVariant(
-        ::pltxt2htm::details::ParserFrameContextWithPlAlignTagInfo&& pl_align_tag_context,
-        ::pltxt2htm::NodeKind node_kind_) noexcept
-        : pl_align_tag{::std::move(pl_align_tag_context)},
-#ifdef PLTXT2HTM_CONTEXT_BRANCH_INSTRUMENT
-          context_branch{ContextBranch::pl_align_tag},
-#endif
-          kind{node_kind_} {
-    }
-
     constexpr FrontendContextVariant(
         ::pltxt2htm::details::ParserFrameContextWithMdBlockQuotesInfo&& md_block_quotes_context,
         ::pltxt2htm::NodeKind node_kind_) noexcept
@@ -410,11 +389,11 @@ constexpr FrontendContextVariant(
           kind{node_kind_} {
     }
 
-    constexpr FrontendContextVariant(::pltxt2htm::details::ParserFrameContextWithPInfo&& p_context,
+    constexpr FrontendContextVariant(::pltxt2htm::details::ParserFrameContextWithAlignInfo&& align_context,
                                      ::pltxt2htm::NodeKind node_kind_) noexcept
-        : p{::std::move(p_context)},
+        : align_info{::std::move(align_context)},
 #ifdef PLTXT2HTM_CONTEXT_BRANCH_INSTRUMENT
-          context_branch{ContextBranch::p},
+          context_branch{ContextBranch::align_info},
 #endif
           kind{node_kind_} {
     }
@@ -483,8 +462,8 @@ constexpr FrontendContextVariant(
             return;
         }
         case ::pltxt2htm::NodeKind::pl_align: {
-            pltxt2htm_assert_context_branch(*this, ContextBranch::pl_align_tag);
-            ::std::construct_at(::std::addressof(this->pl_align_tag), ::std::move(other.pl_align_tag));
+            pltxt2htm_assert_context_branch(*this, ContextBranch::align_info);
+            ::std::construct_at(::std::addressof(this->align_info), ::std::move(other.align_info));
             return;
         }
         case ::pltxt2htm::NodeKind::html_span: {
@@ -614,8 +593,8 @@ constexpr FrontendContextVariant(
             return;
         }
         case ::pltxt2htm::NodeKind::html_p: {
-            pltxt2htm_assert_context_branch(*this, ContextBranch::p);
-            ::std::construct_at(::std::addressof(this->p), ::std::move(other.p));
+            pltxt2htm_assert_context_branch(*this, ContextBranch::align_info);
+            ::std::construct_at(::std::addressof(this->align_info), ::std::move(other.align_info));
             return;
         }
         case ::pltxt2htm::NodeKind::html_th:
@@ -814,8 +793,8 @@ constexpr FrontendContextVariant(
             return;
         }
         case ::pltxt2htm::NodeKind::pl_align: {
-            pltxt2htm_assert_context_branch(*this, ContextBranch::pl_align_tag);
-            ::std::destroy_at(::std::addressof(this->pl_align_tag));
+            pltxt2htm_assert_context_branch(*this, ContextBranch::align_info);
+            ::std::destroy_at(::std::addressof(this->align_info));
             return;
         }
         case ::pltxt2htm::NodeKind::html_span: {
@@ -940,8 +919,8 @@ constexpr FrontendContextVariant(
             return;
         }
         case ::pltxt2htm::NodeKind::html_p: {
-            pltxt2htm_assert_context_branch(*this, ContextBranch::p);
-            ::std::destroy_at(::std::addressof(this->p));
+            pltxt2htm_assert_context_branch(*this, ContextBranch::align_info);
+            ::std::destroy_at(::std::addressof(this->align_info));
             return;
         }
         case ::pltxt2htm::NodeKind::html_th:
@@ -1331,8 +1310,8 @@ public:
         }
         case ::pltxt2htm::NodeKind::pl_align: {
             pltxt2htm_assert_context_branch(
-                context_data_ref, ::pltxt2htm::details::FrontendContextVariant<ndebug>::ContextBranch::pl_align_tag);
-            return context_data_ref.pl_align_tag.pltext;
+                context_data_ref, ::pltxt2htm::details::FrontendContextVariant<ndebug>::ContextBranch::align_info);
+            return context_data_ref.align_info.pltext;
         }
         case ::pltxt2htm::NodeKind::html_span: {
             pltxt2htm_assert_context_branch(
@@ -1371,9 +1350,9 @@ public:
             return context_data_ref.url_info.pltext;
         }
         case ::pltxt2htm::NodeKind::html_p: {
-            pltxt2htm_assert_context_branch(context_data_ref,
-                                            ::pltxt2htm::details::FrontendContextVariant<ndebug>::ContextBranch::p);
-            return context_data_ref.p.pltext;
+            pltxt2htm_assert_context_branch(
+                context_data_ref, ::pltxt2htm::details::FrontendContextVariant<ndebug>::ContextBranch::align_info);
+            return context_data_ref.align_info.pltext;
         }
         case ::pltxt2htm::NodeKind::html_th:
             [[fallthrough]];
@@ -1516,11 +1495,12 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto get_pl_align_tag_value(this auto&& self) noexcept -> ::pltxt2htm::TextAlign {
+    constexpr auto get_align(this auto&& self) noexcept -> ::pltxt2htm::TextAlign {
         auto&& context_data_ref = self.context_data;
-        bool const is_pl_align_tag_type{context_data_ref.kind == ::pltxt2htm::NodeKind::pl_align};
-        pltxt2htm_assert(is_pl_align_tag_type, u8"context kind mismatch");
-        return context_data_ref.pl_align_tag.align;
+        bool const is_align_type{context_data_ref.kind == ::pltxt2htm::NodeKind::html_p ||
+                                 context_data_ref.kind == ::pltxt2htm::NodeKind::pl_align};
+        pltxt2htm_assert(is_align_type, u8"context kind mismatch");
+        return context_data_ref.align_info.align;
     }
 
     [[nodiscard]]
@@ -1668,13 +1648,6 @@ public:
                              context_data_ref.kind == ::pltxt2htm::NodeKind::md_td,
                          u8"context kind mismatch");
         return context_data_ref.cell.align;
-    }
-
-    [[nodiscard]]
-    constexpr auto get_p_align(this auto&& self) noexcept -> ::pltxt2htm::TextAlign {
-        auto&& context_data_ref = self.context_data;
-        pltxt2htm_assert(context_data_ref.kind == ::pltxt2htm::NodeKind::html_p, u8"context kind mismatch");
-        return context_data_ref.p.align;
     }
 
     [[nodiscard]]

--- a/include/pltxt2htm/details/parser/frame_context.hh
+++ b/include/pltxt2htm/details/parser/frame_context.hh
@@ -124,6 +124,15 @@ public:
 };
 
 /**
+ * @brief Context for <align=value> frames during parsing.
+ */
+class ParserFrameContextWithPlAlignTagInfo {
+public:
+    ::fast_io::u8string_view pltext;
+    ::pltxt2htm::TextAlign align;
+};
+
+/**
  * @brief Context for pl_mark frames during parsing; stores the background color.
  */
 class ParserFrameContextWithPlMarkInfo {
@@ -230,6 +239,7 @@ public:
         url_info,
         pl_size_tag,
         pl_voffset_tag,
+        pl_align_tag,
         html_span_info,
         html_code_info,
         md_block_quotes,
@@ -255,6 +265,7 @@ public:
         ::pltxt2htm::details::ParserFrameContextWithHtmlATagInfo html_a_tag_info;
         ::pltxt2htm::details::ParserFrameContextWithPlSizeTagInfo pl_size_tag;
         ::pltxt2htm::details::ParserFrameContextWithPlVoffsetTagInfo pl_voffset_tag;
+        ::pltxt2htm::details::ParserFrameContextWithPlAlignTagInfo pl_align_tag;
         ::pltxt2htm::details::ParserFrameContextWithMdBlockQuotesInfo md_block_quotes;
         ::pltxt2htm::details::ParserFrameContextWithMdListInfo<ndebug> md_list;
         ::pltxt2htm::details::ParserFrameContextWithCellInfo cell;
@@ -361,6 +372,16 @@ public:
           kind{node_kind_} {
     }
 
+constexpr FrontendContextVariant(
+        ::pltxt2htm::details::ParserFrameContextWithPlAlignTagInfo&& pl_align_tag_context,
+        ::pltxt2htm::NodeKind node_kind_) noexcept
+        : pl_align_tag{::std::move(pl_align_tag_context)},
+#ifdef PLTXT2HTM_CONTEXT_BRANCH_INSTRUMENT
+          context_branch{ContextBranch::pl_align_tag},
+#endif
+          kind{node_kind_} {
+    }
+
     constexpr FrontendContextVariant(
         ::pltxt2htm::details::ParserFrameContextWithMdBlockQuotesInfo&& md_block_quotes_context,
         ::pltxt2htm::NodeKind node_kind_) noexcept
@@ -459,6 +480,11 @@ public:
         case ::pltxt2htm::NodeKind::pl_voffset: {
             pltxt2htm_assert_context_branch(*this, ContextBranch::pl_voffset_tag);
             ::std::construct_at(::std::addressof(this->pl_voffset_tag), ::std::move(other.pl_voffset_tag));
+            return;
+        }
+        case ::pltxt2htm::NodeKind::pl_align: {
+            pltxt2htm_assert_context_branch(*this, ContextBranch::pl_align_tag);
+            ::std::construct_at(::std::addressof(this->pl_align_tag), ::std::move(other.pl_align_tag));
             return;
         }
         case ::pltxt2htm::NodeKind::html_span: {
@@ -785,6 +811,11 @@ public:
         case ::pltxt2htm::NodeKind::pl_voffset: {
             pltxt2htm_assert_context_branch(*this, ContextBranch::pl_voffset_tag);
             ::std::destroy_at(::std::addressof(this->pl_voffset_tag));
+            return;
+        }
+        case ::pltxt2htm::NodeKind::pl_align: {
+            pltxt2htm_assert_context_branch(*this, ContextBranch::pl_align_tag);
+            ::std::destroy_at(::std::addressof(this->pl_align_tag));
             return;
         }
         case ::pltxt2htm::NodeKind::html_span: {
@@ -1298,6 +1329,11 @@ public:
                 context_data_ref, ::pltxt2htm::details::FrontendContextVariant<ndebug>::ContextBranch::pl_voffset_tag);
             return context_data_ref.pl_voffset_tag.pltext;
         }
+        case ::pltxt2htm::NodeKind::pl_align: {
+            pltxt2htm_assert_context_branch(
+                context_data_ref, ::pltxt2htm::details::FrontendContextVariant<ndebug>::ContextBranch::pl_align_tag);
+            return context_data_ref.pl_align_tag.pltext;
+        }
         case ::pltxt2htm::NodeKind::html_span: {
             pltxt2htm_assert_context_branch(
                 context_data_ref, ::pltxt2htm::details::FrontendContextVariant<ndebug>::ContextBranch::html_span_info);
@@ -1477,6 +1513,14 @@ public:
         bool const is_pl_voffset_tag_type{context_data_ref.kind == ::pltxt2htm::NodeKind::pl_voffset};
         pltxt2htm_assert(is_pl_voffset_tag_type, u8"context kind mismatch");
         return context_data_ref.pl_voffset_tag.value;
+    }
+
+    [[nodiscard]]
+    constexpr auto get_pl_align_tag_value(this auto&& self) noexcept -> ::pltxt2htm::TextAlign {
+        auto&& context_data_ref = self.context_data;
+        bool const is_pl_align_tag_type{context_data_ref.kind == ::pltxt2htm::NodeKind::pl_align};
+        pltxt2htm_assert(is_pl_align_tag_type, u8"context kind mismatch");
+        return context_data_ref.pl_align_tag.align;
     }
 
     [[nodiscard]]

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -178,25 +178,20 @@ constexpr auto find_next_block_after_line_break(
                 .advance_count = current_index, .new_frame_been_pushed_into_call_stack = true};
         }
         // Check for Unity TMP <align=...> tag at line start
-        if (current_index + 1 < pltext.size()) {
-            auto const next_chr = ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, current_index + 1);
-            if (next_chr == u8'a' || next_chr == u8'A') {
-                if (auto opt_align_tag = ::pltxt2htm::details::try_parse_align_tag<ndebug>(
-                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                    opt_align_tag.has_value()) {
-                    auto const [tag_len, align] =
-                        opt_align_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-                    current_index += tag_len + 3;
-                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                        ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                            ::pltxt2htm::details::ParserFrameContextWithAlignInfo{
-                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), align},
-                            ::pltxt2htm::NodeKind::pl_align},
-                        ::pltxt2htm::Ast<ndebug>{}));
-                    return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{
-                        .advance_count = current_index, .new_frame_been_pushed_into_call_stack = true};
-                }
-            }
+        if (auto opt_align_tag = ::pltxt2htm::details::try_parse_align_tag<ndebug>(
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+            opt_align_tag.has_value()) {
+            auto const [tag_len, align] =
+                opt_align_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+            current_index += tag_len + 1;
+            call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                    ::pltxt2htm::details::ParserFrameContextWithAlignInfo{
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), align},
+                    ::pltxt2htm::NodeKind::pl_align},
+                ::pltxt2htm::Ast<ndebug>{}));
+            return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{
+                .advance_count = current_index, .new_frame_been_pushed_into_call_stack = true};
         }
         // Check for HTML <h1> tag at line start
         if (auto opt_h1_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<h1">(

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -177,6 +177,27 @@ constexpr auto find_next_block_after_line_break(
             return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{
                 .advance_count = current_index, .new_frame_been_pushed_into_call_stack = true};
         }
+        // Check for Unity TMP <align=...> tag at line start
+        if (current_index + 1 < pltext.size()) {
+            auto const next_chr = ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, current_index + 1);
+            if (next_chr == u8'a' || next_chr == u8'A') {
+                if (auto opt_align_tag = ::pltxt2htm::details::try_parse_align_tag<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                    opt_align_tag.has_value()) {
+                    auto const [tag_len, align] =
+                        opt_align_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    current_index += tag_len + 3;
+                    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                        ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                            ::pltxt2htm::details::ParserFrameContextWithPlAlignTagInfo{
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), align},
+                            ::pltxt2htm::NodeKind::pl_align},
+                        ::pltxt2htm::Ast<ndebug>{}));
+                    return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{
+                        .advance_count = current_index, .new_frame_been_pushed_into_call_stack = true};
+                }
+            }
+        }
         // Check for HTML <h1> tag at line start
         if (auto opt_h1_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<h1">(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
@@ -895,22 +916,10 @@ entry:
                 case u8'a':
                     [[fallthrough]];
                 case u8'A': {
-                    // parsing pl <align=value>$1</align> tag (Unity TextMeshPro rich text)
-                    if (auto opt_align_tag = ::pltxt2htm::details::try_parse_align_tag<ndebug>(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_align_tag.has_value()) {
-                        auto const [tag_len, align] =
-                            opt_align_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-                        current_index += tag_len + 3;
-                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPlAlignTagInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), align},
-                                ::pltxt2htm::NodeKind::pl_align},
-                            ::pltxt2htm::Ast<ndebug>{}));
-                        goto entry;
-                    }
                     // parsing pl <a>$1</a> tag (not html <a> tag)
+                    // Note: <align=...> (Unity TextMeshPro) is only parsed at line-start
+                    // block context via find_next_block_after_line_break; inline occurrences
+                    // render as literal text (same as inline <p>).
                     if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                         opt_tag_len.has_value()) {
@@ -1926,6 +1935,13 @@ entry:
                             ::std::size_t const staged_index{current_index};
                             ::pltxt2htm::PlAlign staged_node(::std::move(result), frame.get_pl_align_tag_value());
                             call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::ParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
                             parent_frame.current_index +=

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -181,8 +181,7 @@ constexpr auto find_next_block_after_line_break(
         if (auto opt_align_tag = ::pltxt2htm::details::try_parse_align_tag<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_align_tag.has_value()) {
-            auto const [tag_len, align] =
-                opt_align_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+            auto const [tag_len, align] = opt_align_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
             current_index += tag_len + 1;
             call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                 ::pltxt2htm::details::FrontendContextVariant<ndebug>{
@@ -2958,8 +2957,8 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_p: {
-                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                    ::pltxt2htm::HtmlP<ndebug>{::std::move(subast), frame.get_align()}));
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlP<ndebug>{::std::move(subast), frame.get_align()}));
                 parent_index += staged_index;
                 goto entry;
             }

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -895,6 +895,21 @@ entry:
                 case u8'a':
                     [[fallthrough]];
                 case u8'A': {
+                    // parsing pl <align=value>$1</align> tag (Unity TextMeshPro rich text)
+                    if (auto opt_align_tag = ::pltxt2htm::details::try_parse_align_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_align_tag.has_value()) {
+                        auto const [tag_len, align] =
+                            opt_align_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPlAlignTagInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), align},
+                                ::pltxt2htm::NodeKind::pl_align},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
                     // parsing pl <a>$1</a> tag (not html <a> tag)
                     if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
@@ -1903,6 +1918,25 @@ entry:
                         ++current_index;
                         continue;
                     }
+                    case ::pltxt2htm::NodeKind::pl_align: {
+                        // parsing </align>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"align">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlAlign staged_node(::std::move(result), frame.get_pl_align_tag_value());
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
                     case ::pltxt2htm::NodeKind::pl_mark: {
                         // parsing </mark>
                         if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"mark">(
@@ -2872,6 +2906,12 @@ entry:
             case ::pltxt2htm::NodeKind::pl_voffset: {
                 parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
                     ::pltxt2htm::PlVoffset<ndebug>{::std::move(subast), frame.get_pl_voffset_tag_value()}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_align: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::PlAlign<ndebug>{::std::move(subast), frame.get_pl_align_tag_value()}));
                 parent_index += staged_index;
                 goto entry;
             }

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -170,7 +170,7 @@ constexpr auto find_next_block_after_line_break(
             current_index += tag_len + 1;
             call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                 ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                    ::pltxt2htm::details::ParserFrameContextWithPInfo{
+                    ::pltxt2htm::details::ParserFrameContextWithAlignInfo{
                         ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), align},
                     ::pltxt2htm::NodeKind::html_p},
                 ::pltxt2htm::Ast<ndebug>{}));
@@ -189,7 +189,7 @@ constexpr auto find_next_block_after_line_break(
                     current_index += tag_len + 3;
                     call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
                         ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                            ::pltxt2htm::details::ParserFrameContextWithPlAlignTagInfo{
+                            ::pltxt2htm::details::ParserFrameContextWithAlignInfo{
                                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), align},
                             ::pltxt2htm::NodeKind::pl_align},
                         ::pltxt2htm::Ast<ndebug>{}));
@@ -1933,7 +1933,7 @@ entry:
                                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                             opt_tag_len.has_value()) {
                             ::std::size_t const staged_index{current_index};
-                            ::pltxt2htm::PlAlign staged_node(::std::move(result), frame.get_pl_align_tag_value());
+                            ::pltxt2htm::PlAlign staged_node(::std::move(result), frame.get_align());
                             call_stack.pop();
                             if (call_stack.empty()) {
                                 return ::pltxt2htm::details::ParsePlTxtResult<ndebug>{
@@ -2018,7 +2018,7 @@ entry:
                             opt_tag_len.has_value()) {
                             // parsing end tag </p> successed
                             ::std::size_t const staged_index{current_index};
-                            auto const align = frame.get_p_align();
+                            auto const align = frame.get_align();
                             ::pltxt2htm::HtmlP staged_node(::std::move(result), align);
                             call_stack.pop();
                             if (call_stack.empty()) {
@@ -2927,7 +2927,7 @@ entry:
             }
             case ::pltxt2htm::NodeKind::pl_align: {
                 parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                    ::pltxt2htm::PlAlign<ndebug>{::std::move(subast), frame.get_pl_align_tag_value()}));
+                    ::pltxt2htm::PlAlign<ndebug>{::std::move(subast), frame.get_align()}));
                 parent_index += staged_index;
                 goto entry;
             }
@@ -2964,7 +2964,7 @@ entry:
             }
             case ::pltxt2htm::NodeKind::html_p: {
                 parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                    ::pltxt2htm::HtmlP<ndebug>{::std::move(subast), frame.get_p_align()}));
+                    ::pltxt2htm::HtmlP<ndebug>{::std::move(subast), frame.get_align()}));
                 parent_index += staged_index;
                 goto entry;
             }

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1437,10 +1437,12 @@ constexpr auto try_parse_align_tag(::fast_io::u8string_view pltext) noexcept
     }
     ::pltxt2htm::TextAlign align{};
     ::std::size_t value_end{0};
+
     struct AlignCandidate {
         ::fast_io::u8string_view keyword;
         ::pltxt2htm::TextAlign align;
     };
+
     constexpr AlignCandidate candidates[]{
         {u8"justified", ::pltxt2htm::TextAlign::justify},
         {u8"left", ::pltxt2htm::TextAlign::left},

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1429,26 +1429,14 @@ constexpr auto try_parse_align_tag(::fast_io::u8string_view pltext) noexcept
     }
     constexpr auto value_start = prefix_str.size() + 1;
     auto const value_view = ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, value_start);
-    auto const match_keyword = [&](::fast_io::u8string_view const keyword) noexcept
-        -> ::exception::optional<::std::size_t> {
-        if (value_view.size() < keyword.size()) {
-            return ::exception::nullopt;
-        }
-        if (::fast_io::u8string_view{value_view.data(), keyword.size()} != keyword) {
-            return ::exception::nullopt;
-        }
-        if (value_view.size() > keyword.size()) {
-            auto const next = ::pltxt2htm::details::u8string_view_index<ndebug>(value_view, keyword.size());
-            if (::pltxt2htm::details::is_ascii_alpha(next) || ::pltxt2htm::details::is_ascii_digit(next)) {
-                return ::exception::nullopt;
-            }
-        }
-        return keyword.size();
-    };
     ::pltxt2htm::TextAlign align{};
     ::std::size_t value_end{0};
     // Longest spellings first so "justified" wins over its prefix "justify".
-    constexpr ::std::pair<::fast_io::u8string_view, ::pltxt2htm::TextAlign> candidates[]{
+    struct AlignCandidate {
+        ::fast_io::u8string_view keyword;
+        ::pltxt2htm::TextAlign align;
+    };
+    constexpr AlignCandidate candidates[]{
         {u8"justified", ::pltxt2htm::TextAlign::justify},
         {u8"justify", ::pltxt2htm::TextAlign::justify},
         {u8"left", ::pltxt2htm::TextAlign::left},
@@ -1456,14 +1444,25 @@ constexpr auto try_parse_align_tag(::fast_io::u8string_view pltext) noexcept
         {u8"right", ::pltxt2htm::TextAlign::right},
     };
     bool matched{false};
-    for (auto const& [keyword, candidate_align] : candidates) {
-        auto const opt_len = match_keyword(keyword);
-        if (opt_len.has_value()) {
-            align = candidate_align;
-            value_end = opt_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-            matched = true;
-            break;
+    for (auto const& candidate : candidates) {
+        auto const keyword = candidate.keyword;
+        auto const candidate_align = candidate.align;
+        if (value_view.size() < keyword.size()) {
+            continue;
         }
+        if (::fast_io::u8string_view{value_view.data(), keyword.size()} != keyword) {
+            continue;
+        }
+        if (value_view.size() > keyword.size()) {
+            auto const next = ::pltxt2htm::details::u8string_view_index<ndebug>(value_view, keyword.size());
+            if (::pltxt2htm::details::is_ascii_alpha(next) || ::pltxt2htm::details::is_ascii_digit(next)) {
+                continue;
+            }
+        }
+        align = candidate_align;
+        value_end = keyword.size();
+        matched = true;
+        break;
     }
     if (matched == false) {
         return ::exception::nullopt;

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1413,16 +1413,17 @@ struct TryParseAlignTagResult {
 
 /**
  * @brief Parse a `<align=value>` opening tag (Unity TextMeshPro rich text).
- * @details The value is a lowercase text-alignment keyword: `left`, `center`, `right`,
- *          `justify` or `justified` (both mapped to ::pltxt2htm::TextAlign::justify).
- *          Any other value makes the tag render as literal text. The tag name prefix is
- *          `lign` because the caller has already consumed the leading `<a`.
+ * @details The tag name prefix `<a`/`<A` and the `lign` name are matched here, so the
+ *          whole `<align=...>` tag is consumed. The value is a lowercase text-alignment
+ *          keyword: `left`, `center`, `right`, `justify` or `justified` (both mapped to
+ *          ::pltxt2htm::TextAlign::justify). Any other value makes the tag render as
+ *          literal text.
  */
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
 constexpr auto try_parse_align_tag(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::pltxt2htm::details::TryParseAlignTagResult> {
-    constexpr auto prefix_str = ::pltxt2htm::details::U8LiteralString{u8"lign"};
+    constexpr auto prefix_str = ::pltxt2htm::details::U8LiteralString{u8"<align"};
     if (::pltxt2htm::details::is_equal_sign_tag_prefix<ndebug, prefix_str>(pltext) == false) {
         return ::exception::nullopt;
     }

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1413,10 +1413,10 @@ struct TryParseAlignTagResult {
 
 /**
  * @brief Parse a `<align=value>` opening tag (Unity TextMeshPro rich text).
- * @details The tag name prefix `<a`/`<A` and the `lign` name are matched here, so the
- *          whole `<align=...>` tag is consumed. The value is a lowercase text-alignment
- *          keyword: `left`, `center`, `right`, `justify` or `justified` (both mapped to
- *          ::pltxt2htm::TextAlign::justify). Any other value makes the tag render as
+ * @details The whole `<align=...>` tag is consumed, matching the `lign` name (case
+ *          insensitive) after the leading `<`. The value is a text-alignment keyword,
+ *          optionally wrapped in double quotes: `left`, `center`, `right`, `justified`
+ *          (or `"left"`, `"center"`, etc.). Any other value makes the tag render as
  *          literal text.
  */
 template<::pltxt2htm::Contracts ndebug>
@@ -1428,7 +1428,13 @@ constexpr auto try_parse_align_tag(::fast_io::u8string_view pltext) noexcept
         return ::exception::nullopt;
     }
     constexpr auto value_start = prefix_str.size() + 1;
-    auto const value_view = ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, value_start);
+    auto value_view = ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, value_start);
+    bool const quoted =
+        value_view.size() != 0 && ::pltxt2htm::details::u8string_view_index<ndebug>(value_view, 0) == u8'"';
+    ::std::size_t const quote_offset = quoted ? 1 : 0;
+    if (quoted) {
+        value_view = ::pltxt2htm::details::u8string_view_subview<ndebug>(value_view, 1);
+    }
     ::pltxt2htm::TextAlign align{};
     ::std::size_t value_end{0};
     struct AlignCandidate {
@@ -1465,12 +1471,27 @@ constexpr auto try_parse_align_tag(::fast_io::u8string_view pltext) noexcept
     if (matched == false) {
         return ::exception::nullopt;
     }
-    auto opt_close = ::pltxt2htm::details::try_parse_equal_sign_tag_suffix<ndebug>(
-        ::pltxt2htm::details::u8string_view_subview<ndebug>(value_view, value_end));
+    auto after_value = ::pltxt2htm::details::u8string_view_subview<ndebug>(value_view, value_end);
+    ::std::size_t quote_close_offset{0};
+    if (quoted) {
+        while (quote_close_offset < after_value.size() &&
+               (::pltxt2htm::details::u8string_view_index<ndebug>(after_value, quote_close_offset) == u8' ' ||
+                ::pltxt2htm::details::u8string_view_index<ndebug>(after_value, quote_close_offset) == u8'\t')) {
+            ++quote_close_offset;
+        }
+        if (quote_close_offset >= after_value.size() ||
+            ::pltxt2htm::details::u8string_view_index<ndebug>(after_value, quote_close_offset) != u8'"') {
+            return ::exception::nullopt;
+        }
+        ++quote_close_offset;
+        after_value = ::pltxt2htm::details::u8string_view_subview<ndebug>(after_value, quote_close_offset);
+    }
+    auto opt_close = ::pltxt2htm::details::try_parse_equal_sign_tag_suffix<ndebug>(after_value);
     if (opt_close.has_value() == false) {
         return ::exception::nullopt;
     }
-    auto const tag_len = value_start + value_end + opt_close.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+    auto const tag_len = value_start + quote_offset + value_end + quote_close_offset +
+                         opt_close.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
     return ::pltxt2htm::details::TryParseAlignTagResult{tag_len, align};
 }
 

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1431,14 +1431,12 @@ constexpr auto try_parse_align_tag(::fast_io::u8string_view pltext) noexcept
     auto const value_view = ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, value_start);
     ::pltxt2htm::TextAlign align{};
     ::std::size_t value_end{0};
-    // Longest spellings first so "justified" wins over its prefix "justify".
     struct AlignCandidate {
         ::fast_io::u8string_view keyword;
         ::pltxt2htm::TextAlign align;
     };
     constexpr AlignCandidate candidates[]{
         {u8"justified", ::pltxt2htm::TextAlign::justify},
-        {u8"justify", ::pltxt2htm::TextAlign::justify},
         {u8"left", ::pltxt2htm::TextAlign::left},
         {u8"center", ::pltxt2htm::TextAlign::center},
         {u8"right", ::pltxt2htm::TextAlign::right},

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <utility>
 #include <exception/exception.hh>
 #include <fast_io/fast_io_dsal/array.h>
 #include <fast_io/fast_io_dsal/stack.h>
@@ -1400,6 +1401,79 @@ constexpr auto try_parse_voffset_tag(::fast_io::u8string_view pltext) noexcept
     }
     auto const tag_len = value_end + opt_close.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
     return ::pltxt2htm::details::TryParseVoffsetTagResult{tag_len, value.value};
+}
+
+/**
+ * @brief Return type of try_parse_align_tag: tag length and the parsed alignment keyword.
+ */
+struct TryParseAlignTagResult {
+    ::std::size_t tag_len;
+    ::pltxt2htm::TextAlign align;
+};
+
+/**
+ * @brief Parse a `<align=value>` opening tag (Unity TextMeshPro rich text).
+ * @details The value is a lowercase text-alignment keyword: `left`, `center`, `right`,
+ *          `justify` or `justified` (both mapped to ::pltxt2htm::TextAlign::justify).
+ *          Any other value makes the tag render as literal text. The tag name prefix is
+ *          `lign` because the caller has already consumed the leading `<a`.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_align_tag(::fast_io::u8string_view pltext) noexcept
+    -> ::exception::optional<::pltxt2htm::details::TryParseAlignTagResult> {
+    constexpr auto prefix_str = ::pltxt2htm::details::U8LiteralString{u8"lign"};
+    if (::pltxt2htm::details::is_equal_sign_tag_prefix<ndebug, prefix_str>(pltext) == false) {
+        return ::exception::nullopt;
+    }
+    constexpr auto value_start = prefix_str.size() + 1;
+    auto const value_view = ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, value_start);
+    auto const match_keyword = [&](::fast_io::u8string_view const keyword) noexcept
+        -> ::exception::optional<::std::size_t> {
+        if (value_view.size() < keyword.size()) {
+            return ::exception::nullopt;
+        }
+        if (::fast_io::u8string_view{value_view.data(), keyword.size()} != keyword) {
+            return ::exception::nullopt;
+        }
+        if (value_view.size() > keyword.size()) {
+            auto const next = ::pltxt2htm::details::u8string_view_index<ndebug>(value_view, keyword.size());
+            if (::pltxt2htm::details::is_ascii_alpha(next) || ::pltxt2htm::details::is_ascii_digit(next)) {
+                return ::exception::nullopt;
+            }
+        }
+        return keyword.size();
+    };
+    ::pltxt2htm::TextAlign align{};
+    ::std::size_t value_end{0};
+    // Longest spellings first so "justified" wins over its prefix "justify".
+    constexpr ::std::pair<::fast_io::u8string_view, ::pltxt2htm::TextAlign> candidates[]{
+        {u8"justified", ::pltxt2htm::TextAlign::justify},
+        {u8"justify", ::pltxt2htm::TextAlign::justify},
+        {u8"left", ::pltxt2htm::TextAlign::left},
+        {u8"center", ::pltxt2htm::TextAlign::center},
+        {u8"right", ::pltxt2htm::TextAlign::right},
+    };
+    bool matched{false};
+    for (auto const& [keyword, candidate_align] : candidates) {
+        auto const opt_len = match_keyword(keyword);
+        if (opt_len.has_value()) {
+            align = candidate_align;
+            value_end = opt_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+            matched = true;
+            break;
+        }
+    }
+    if (matched == false) {
+        return ::exception::nullopt;
+    }
+    auto opt_close = ::pltxt2htm::details::try_parse_equal_sign_tag_suffix<ndebug>(
+        ::pltxt2htm::details::u8string_view_subview<ndebug>(value_view, value_end));
+    if (opt_close.has_value() == false) {
+        return ::exception::nullopt;
+    }
+    auto const tag_len = value_start + value_end + opt_close.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+    return ::pltxt2htm::details::TryParseAlignTagResult{tag_len, align};
 }
 
 /**

--- a/include/pltxt2htm/experimental/html_parser.hh
+++ b/include/pltxt2htm/experimental/html_parser.hh
@@ -45,7 +45,7 @@ constexpr auto find_next_block_after_line_break(
         auto const align = opt_p_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>().align;
         call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
             ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                ::pltxt2htm::details::ParserFrameContextWithPInfo{
+                ::pltxt2htm::details::ParserFrameContextWithAlignInfo{
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, consumed), align},
                 ::pltxt2htm::NodeKind::html_p},
             ::pltxt2htm::Ast<ndebug>{}));
@@ -784,7 +784,7 @@ entry:
                                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                             opt_tag_len.has_value()) {
                             ::std::size_t const staged_index{current_index};
-                            auto const align = frame.get_p_align();
+                            auto const align = frame.get_align();
                             ::pltxt2htm::HtmlP staged_node(::std::move(result), align);
                             call_stack.pop();
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
@@ -1408,7 +1408,7 @@ entry:
             }
             case ::pltxt2htm::NodeKind::html_p: {
                 parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                    ::pltxt2htm::HtmlP<ndebug>{::std::move(subast), frame.get_p_align()}));
+                    ::pltxt2htm::HtmlP<ndebug>{::std::move(subast), frame.get_align()}));
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_h1: {

--- a/include/pltxt2htm/experimental/html_parser.hh
+++ b/include/pltxt2htm/experimental/html_parser.hh
@@ -1407,8 +1407,8 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_p: {
-                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                    ::pltxt2htm::HtmlP<ndebug>{::std::move(subast), frame.get_align()}));
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlP<ndebug>{::std::move(subast), frame.get_align()}));
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_h1: {

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -883,6 +883,17 @@ entry:
                 ++current_iter;
                 continue;
             }
+            case ::pltxt2htm::NodeKind::pl_align: {
+                auto&& subast = node.as_pl_align().get_subast();
+                if (subast.empty()) {
+                    ast.erase(current_iter);
+                    continue;
+                }
+                call_stack.push(
+                    ::pltxt2htm::details::OptimizerFrameContext<typename ::pltxt2htm::Ast<ndebug>::iterator, ndebug>(
+                        ::std::addressof(subast), ::pltxt2htm::NodeKind::pl_align, subast.begin()));
+                goto entry;
+            }
             case ::pltxt2htm::NodeKind::md_double_emphasis_underscore:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::md_double_emphasis_asterisk:

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -885,10 +885,6 @@ entry:
             }
             case ::pltxt2htm::NodeKind::pl_align: {
                 auto&& subast = node.as_pl_align().get_subast();
-                if (subast.empty()) {
-                    ast.erase(current_iter);
-                    continue;
-                }
                 call_stack.push(
                     ::pltxt2htm::details::OptimizerFrameContext<typename ::pltxt2htm::Ast<ndebug>::iterator, ndebug>(
                         ::std::addressof(subast), ::pltxt2htm::NodeKind::pl_align, subast.begin()));

--- a/include/pltxt2htm/parser.hh
+++ b/include/pltxt2htm/parser.hh
@@ -65,6 +65,12 @@ constexpr auto parse_pltxt(::fast_io::u8string_view pltext) noexcept -> ::pltxt2
             }
             return ::exception::nullopt;
         }();
+        auto const opt_pl_align = [&] constexpr noexcept -> ::exception::optional<::pltxt2htm::TextAlign> {
+            if (type_of_subast == ::pltxt2htm::NodeKind::pl_align) {
+                return call_stack.top().get_pl_align_tag_value();
+            }
+            return ::exception::nullopt;
+        }();
         auto&& [subast, consumed_bytes] = ::pltxt2htm::details::parse_pltxt<ndebug>(call_stack);
         switch (type_of_subast) {
         case ::pltxt2htm::NodeKind::md_atx_h1: {
@@ -115,6 +121,15 @@ constexpr auto parse_pltxt(::fast_io::u8string_view pltext) noexcept -> ::pltxt2
             auto html_p_align = opt_html_p_align.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
             result.push_back(
                 ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlP<ndebug>{::std::move(subast), html_p_align}));
+            continue;
+        }
+        case ::pltxt2htm::NodeKind::pl_align: {
+            // Same as html_p: advance start_index past the consumed pl_align content, preserving
+            // the Textalign read from the frame top before the recursive parse popped it.
+            start_index += consumed_bytes;
+            auto pl_align_value = opt_pl_align.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+            result.push_back(
+                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlAlign<ndebug>{::std::move(subast), pl_align_value}));
             continue;
         }
         case ::pltxt2htm::NodeKind::html_h1: {

--- a/include/pltxt2htm/parser.hh
+++ b/include/pltxt2htm/parser.hh
@@ -61,13 +61,13 @@ constexpr auto parse_pltxt(::fast_io::u8string_view pltext) noexcept -> ::pltxt2
         ::pltxt2htm::NodeKind const type_of_subast{call_stack.top().get_nested_tag_type()};
         auto const opt_html_p_align = [&] constexpr noexcept -> ::exception::optional<::pltxt2htm::TextAlign> {
             if (type_of_subast == ::pltxt2htm::NodeKind::html_p) {
-                return call_stack.top().get_p_align();
+                return call_stack.top().get_align();
             }
             return ::exception::nullopt;
         }();
         auto const opt_pl_align = [&] constexpr noexcept -> ::exception::optional<::pltxt2htm::TextAlign> {
             if (type_of_subast == ::pltxt2htm::NodeKind::pl_align) {
-                return call_stack.top().get_pl_align_tag_value();
+                return call_stack.top().get_align();
             }
             return ::exception::nullopt;
         }();

--- a/tests/test_html_p_tag.cc
+++ b/tests/test_html_p_tag.cc
@@ -223,6 +223,9 @@ int main() {
         auto html = ::pltxt2htm_test::pltxt4htmlunittest(pltext);
         auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:left\">text</p>text"};
         pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\ntext"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
     {

--- a/tests/test_html_p_tag.cc
+++ b/tests/test_html_p_tag.cc
@@ -7,7 +7,7 @@ int main() {
         auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:left\">text</p>"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<p>text</p>"};
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
@@ -17,7 +17,7 @@ int main() {
         auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:left\">text</p>"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<p>text</p>"};
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
@@ -28,7 +28,7 @@ int main() {
             ::fast_io::u8string_view{u8"<p style=\"text-align:left\"><span style=\"color:red;\">text</span></p>"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<p><color=red>text</color></p>"};
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<color=red>text</color>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
@@ -40,7 +40,7 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
         auto plunity_richtext_answer =
-            ::fast_io::u8string_view{u8"<p><color=red>text<size=20>\uFF1C</size>/p<size=20>\uFF1E</size></color></p>"};
+            ::fast_io::u8string_view{u8"<color=red>text<size=20>\uFF1C</size>/p<size=20>\uFF1E</size></color>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
@@ -51,8 +51,7 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
         auto plunity_richtext_answer = ::fast_io::u8string_view{
-            u8"<p>text<size=20>\uFF1C</size>p<size=20>\uFF1E</size>text</p><size=20>\uFF1C</size>/p<size=20>\uFF1E</"
-            u8"size>"};
+            u8"text<size=20>\uFF1C</size>p<size=20>\uFF1E</size>text<size=20>\uFF1C</size>/p<size=20>\uFF1E</size>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
@@ -62,7 +61,7 @@ int main() {
         auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:left\"></p>"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<p></p>"};
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8""};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
@@ -94,7 +93,7 @@ int main() {
         auto answer = ::fast_io::u8string_view{u8"text<br><p style=\"text-align:left\">text</p>"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\n<p>text</p>"};
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\ntext"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
@@ -104,7 +103,7 @@ int main() {
         auto answer = ::fast_io::u8string_view{u8"text<br><p style=\"text-align:left\">text</p>"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\n<p>text</p>"};
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"text\ntext"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
@@ -128,7 +127,7 @@ int main() {
         auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:center\">text</p>"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<p><align=center>text</align></p>"};
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<align=center>text</align>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 

--- a/tests/test_html_p_tag.cc
+++ b/tests/test_html_p_tag.cc
@@ -142,8 +142,8 @@ int main() {
     {
         auto pltext = ::fast_io::u8string_view{u8"<p>a</p>\n\n\n<p>b</p>"};
         auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
-        auto answer =
-            ::fast_io::u8string_view{u8"<p style=\"text-align:left\">a</p><br><br><br><p style=\"text-align:left\">b</p>"};
+        auto answer = ::fast_io::u8string_view{
+            u8"<p style=\"text-align:left\">a</p><br><br><br><p style=\"text-align:left\">b</p>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -185,8 +185,8 @@ int main() {
     {
         auto pltext = ::fast_io::u8string_view{u8"<p>a</p>\ntext\n<p>b</p>"};
         auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
-        auto answer =
-            ::fast_io::u8string_view{u8"<p style=\"text-align:left\">a</p><br>text<br><p style=\"text-align:left\">b</p>"};
+        auto answer = ::fast_io::u8string_view{
+            u8"<p style=\"text-align:left\">a</p><br>text<br><p style=\"text-align:left\">b</p>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_html_p_tag.cc
+++ b/tests/test_html_p_tag.cc
@@ -128,7 +128,7 @@ int main() {
         auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:center\">text</p>"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<p style=\"text-align:center\">text</p>"};
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<p><align=center>text</align></p>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 

--- a/tests/test_html_p_tag.cc
+++ b/tests/test_html_p_tag.cc
@@ -51,7 +51,7 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
         auto plunity_richtext_answer = ::fast_io::u8string_view{
-            u8"text<size=20>\uFF1C</size>p<size=20>\uFF1E</size>text<size=20>\uFF1C</size>/p<size=20>\uFF1E</size>"};
+            u8"text<size=20>\uFF1C</size>p<size=20>\uFF1E</size>text\n<size=20>\uFF1C</size>/p<size=20>\uFF1E</size>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
@@ -147,7 +147,7 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
     }
 
-    // trailing text after a closing </p> joins the same line
+    // trailing text after a closing </p> starts a new line
     {
         auto pltext = ::fast_io::u8string_view{u8"<p>a</p>text\n<p>b</p>"};
         auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
@@ -155,7 +155,7 @@ int main() {
             ::fast_io::u8string_view{u8"<p style=\"text-align:left\">a</p>text<br><p style=\"text-align:left\">b</p>"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"atext\nb"};
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"a\ntext\nb"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 

--- a/tests/test_html_p_tag.cc
+++ b/tests/test_html_p_tag.cc
@@ -114,6 +114,110 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
     }
 
+    // newline separates two block-level <p> tags
+    {
+        auto pltext = ::fast_io::u8string_view{u8"<p>a</p>\n<p>b</p>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer =
+            ::fast_io::u8string_view{u8"<p style=\"text-align:left\">a</p><br><p style=\"text-align:left\">b</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"a\nb"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    // a blank line between two <p> tags renders as two <br>
+    {
+        auto pltext = ::fast_io::u8string_view{u8"<p>a</p>\n\n<p>b</p>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer =
+            ::fast_io::u8string_view{u8"<p style=\"text-align:left\">a</p><br><br><p style=\"text-align:left\">b</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"a\n\nb"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    // multiple blank lines render as multiple <br>
+    {
+        auto pltext = ::fast_io::u8string_view{u8"<p>a</p>\n\n\n<p>b</p>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer =
+            ::fast_io::u8string_view{u8"<p style=\"text-align:left\">a</p><br><br><br><p style=\"text-align:left\">b</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    // trailing text after a closing </p> joins the same line
+    {
+        auto pltext = ::fast_io::u8string_view{u8"<p>a</p>text\n<p>b</p>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer =
+            ::fast_io::u8string_view{u8"<p style=\"text-align:left\">a</p>text<br><p style=\"text-align:left\">b</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"atext\nb"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    // a newline inside a <p> block renders as <br>
+    {
+        auto pltext = ::fast_io::u8string_view{u8"<p>line1\nline2</p>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:left\">line1<br>line2</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"line1\nline2"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    // a blank line inside a <p> block renders as two <br>
+    {
+        auto pltext = ::fast_io::u8string_view{u8"<p>line1\n\nline3</p>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:left\">line1<br><br>line3</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"line1\n\nline3"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    // text after a newline followed by a <p> block
+    {
+        auto pltext = ::fast_io::u8string_view{u8"<p>a</p>\ntext\n<p>b</p>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer =
+            ::fast_io::u8string_view{u8"<p style=\"text-align:left\">a</p><br>text<br><p style=\"text-align:left\">b</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    // a leading newline before a <p> block
+    {
+        auto pltext = ::fast_io::u8string_view{u8"\n<p>a</p>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"<br><p style=\"text-align:left\">a</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    // a trailing newline after a closing </p>
+    {
+        auto pltext = ::fast_io::u8string_view{u8"<p>a</p>\n"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:left\">a</p><br>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    // an unclosed <p> at a line start still forms a block containing the newline
+    {
+        auto pltext = ::fast_io::u8string_view{u8"<p>a\n<p>b</p>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer =
+            ::fast_io::u8string_view{u8"<p style=\"text-align:left\">a<br><p style=\"text-align:left\">b</p></p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"a\nb"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
     {
         auto pltext = ::fast_io::u8string_view{u8"<p>text</p>text"};
         auto html = ::pltxt2htm_test::pltxt4htmlunittest(pltext);

--- a/tests/test_html_parser.cc
+++ b/tests/test_html_parser.cc
@@ -245,7 +245,8 @@ int main() {
     // Mixed: PL/MD tag nested inside HTML tag → PL/MD treated as text
     {
         auto html = ::pltxt2htm_test::pltxt4htmlunittest(u8"<p><color=red>text</color></p>");
-        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:left\">&lt;color=red&gt;text&lt;/color&gt;</p>"};
+        auto answer =
+            ::fast_io::u8string_view{u8"<p style=\"text-align:left\">&lt;color=red&gt;text&lt;/color&gt;</p>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -291,7 +292,8 @@ int main() {
     // Nested tags without explicit closing tags are closed once at end of input.
     {
         auto html = ::pltxt2htm_test::pltxt4htmlunittest(u8"<blockquote><p><em><strong>text");
-        auto answer = ::fast_io::u8string_view{u8"<blockquote><p style=\"text-align:left\"><em><strong>text</strong></em></p></blockquote>"};
+        auto answer = ::fast_io::u8string_view{
+            u8"<blockquote><p style=\"text-align:left\"><em><strong>text</strong></em></p></blockquote>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -299,7 +301,8 @@ int main() {
         auto html = ::pltxt2htm_test::pltxt4htmlunittest(
             u8"<p><span style=\"color:red\"><a href=\"https://example.com\"><code>text");
         auto answer = ::fast_io::u8string_view{
-            u8"<p style=\"text-align:left\"><span style=\"color:red;\"><a href=\"https://example.com\"><code>text</code></a></span></p>"};
+            u8"<p style=\"text-align:left\"><span style=\"color:red;\"><a "
+            u8"href=\"https://example.com\"><code>text</code></a></span></p>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -370,7 +373,9 @@ int main() {
             u8"<blockquote></x></blockquote>");
         auto answer = ::fast_io::u8string_view{
             u8"<span style=\"color:red;\">&lt;/x&gt;</span><a href=\"https://example.com\">&lt;/x&gt;</a>"
-            u8"<p style=\"text-align:left\">&lt;/x&gt;</p><h1>&lt;/x&gt;</h1><h2>&lt;/x&gt;</h2><h3>&lt;/x&gt;</h3><h4>&lt;/x&gt;</h4>"
+            u8"<p "
+            u8"style=\"text-align:left\">&lt;/x&gt;</p><h1>&lt;/x&gt;</h1><h2>&lt;/x&gt;</h2><h3>&lt;/x&gt;</"
+            u8"h3><h4>&lt;/x&gt;</h4>"
             u8"<h5>&lt;/x&gt;</h5><h6>&lt;/x&gt;</h6><del>&lt;/x&gt;</del><em>&lt;/x&gt;</em>"
             u8"<strong>&lt;/x&gt;</strong><code>&lt;/x&gt;</code><pre>&lt;/x&gt;</pre>"
             u8"<blockquote>&lt;/x&gt;</blockquote>"};

--- a/tests/test_pl_align_tag.cc
+++ b/tests/test_pl_align_tag.cc
@@ -3,75 +3,76 @@
 int main() {
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=center>hello</align>");
-        auto answer = ::fast_io::u8string_view{u8"<span style=\"text-align:center;\">hello</span>"};
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:center\">hello</p>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=left>hello</align>");
-        auto answer = ::fast_io::u8string_view{u8"<span style=\"text-align:left;\">hello</span>"};
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:left\">hello</p>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=right>hello</align>");
-        auto answer = ::fast_io::u8string_view{u8"<span style=\"text-align:right;\">hello</span>"};
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:right\">hello</p>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=justify>hello</align>");
-        auto answer = ::fast_io::u8string_view{u8"<span style=\"text-align:justify;\">hello</span>"};
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:justify\">hello</p>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=justified>hello</align>");
-        auto answer = ::fast_io::u8string_view{u8"<span style=\"text-align:justify;\">hello</span>"};
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:justify\">hello</p>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<Align=center>hello</align>");
-        auto answer = ::fast_io::u8string_view{u8"<span style=\"text-align:center;\">hello</span>"};
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:center\">hello</p>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=center   >hello</align  >");
-        auto answer = ::fast_io::u8string_view{u8"<span style=\"text-align:center;\">hello</span>"};
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:center\">hello</p>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
-        // empty content collapses
+        // mid-line <align> sequences are literal text, so nothing collapses
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"t<align=center></align>t");
-        auto answer = ::fast_io::u8string_view{u8"tt"};
+        auto answer = ::fast_io::u8string_view{u8"t&lt;align=center&gt;&lt;/align&gt;t"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"hello<align=center>");
-        auto answer = ::fast_io::u8string_view{u8"hello"};
+        auto answer = ::fast_io::u8string_view{u8"hello&lt;align=center&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=left>hello");
-        auto answer = ::fast_io::u8string_view{u8"<span style=\"text-align:left;\">hello</span>"};
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:left\">hello</p>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
+        // inner inline <align=right> is literal text; only the outer block frame parses
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=center>hello<align=right>world</align></align>");
         auto answer = ::fast_io::u8string_view{
-            u8"<span style=\"text-align:center;\">hello<span style=\"text-align:right;\">world</span></span>"};
+            u8"<p style=\"text-align:center\">hello&lt;align=right&gt;world</p>&lt;/align&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=center><i>test</i></align>");
-        auto answer = ::fast_io::u8string_view{u8"<span style=\"text-align:center;\"><em>test</em></span>"};
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:center\"><em>test</em></p>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -128,6 +129,13 @@ int main() {
         // left is emitted verbatim for an explicit align tag
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<align=left>text</align>");
         auto answer = ::fast_io::u8string_view{u8"<align=left>text</align>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // plunity block: a line break forces block context, preserving <align>
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"before\n<align=right>text</align>");
+        auto answer = ::fast_io::u8string_view{u8"before\n<align=right>text</align>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_pl_align_tag.cc
+++ b/tests/test_pl_align_tag.cc
@@ -275,5 +275,26 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
     }
 
+    // an empty <align> block is kept like an empty <p> (it carries the block
+    // boundary), not erased by the optimizer
+    {
+        auto pltext = ::fast_io::u8string_view{u8"<align=center></align>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:center\"></p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<align=center></align>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    // an empty <align> between two text lines preserves the empty paragraph
+    {
+        auto pltext = ::fast_io::u8string_view{u8"a\n<align=center></align>\nb"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer =
+            ::fast_io::u8string_view{u8"a<br><p style=\"text-align:center\"></p><br>b"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
     return 0;
 }

--- a/tests/test_pl_align_tag.cc
+++ b/tests/test_pl_align_tag.cc
@@ -39,6 +39,27 @@ int main() {
     }
 
     {
+        // double-quoted value (TMP allows <align="center">)
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=\"center\">hello</align>");
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:center\">hello</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // quoted value with whitespace around the closing quote
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=\"right\" >hello</align  >");
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:right\">hello</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // unmatched opening quote renders as literal text
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=\"center>hello</align>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;align=&quot;center&gt;hello&lt;/align&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=center   >hello</align  >");
         auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:center\">hello</p>"};
         pltxt2htm_test_assert_equal(html, answer);
@@ -131,6 +152,20 @@ int main() {
         // left is emitted verbatim for an explicit align tag
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<align=left>text</align>");
         auto answer = ::fast_io::u8string_view{u8"<align=left>text</align>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // plunity backend emits unquoted TMP align tags for a quoted input
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<align=\"right\">text</align>");
+        auto answer = ::fast_io::u8string_view{u8"<align=right>text</align>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // plunity backend emits unquoted TMP align tags for a quoted input
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<align=right\">text</align>");
+        auto answer = ::fast_io::u8string_view{u8"<size=20>＜</size>align=right\"<size=20>＞</size>text<size=20>＜</size>/align<size=20>＞</size>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_pl_align_tag.cc
+++ b/tests/test_pl_align_tag.cc
@@ -20,8 +20,9 @@ int main() {
     }
 
     {
+        // "justify" is not a valid TMP align value; only "justified" is
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=justify>hello</align>");
-        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:justify\">hello</p>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;align=justify&gt;hello&lt;/align&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -114,8 +115,9 @@ int main() {
     }
 
     {
+        // "justify" is not a valid TMP align value; renders as literal text
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<align=justify>text</align>");
-        auto answer = ::fast_io::u8string_view{u8"<align=justified>text</align>"};
+        auto answer = ::fast_io::u8string_view{u8"<size=20>＜</size>align=justify<size=20>＞</size>text<size=20>＜</size>/align<size=20>＞</size>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_pl_align_tag.cc
+++ b/tests/test_pl_align_tag.cc
@@ -213,6 +213,18 @@ int main() {
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
+    // text on the same line after a closing </align> starts a new line
+    {
+        auto pltext = ::fast_io::u8string_view{u8"<align=center>a</align>text\nb"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer =
+            ::fast_io::u8string_view{u8"<p style=\"text-align:center\">a</p>text<br>b"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<align=center>a</align>\ntext\nb"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
     // a newline inside an <align> block renders as <br>
     {
         auto pltext = ::fast_io::u8string_view{u8"<align=center>line1\nline2</align>"};

--- a/tests/test_pl_align_tag.cc
+++ b/tests/test_pl_align_tag.cc
@@ -139,5 +139,104 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
     }
 
+    // newline separates two block-level <align> tags
+    {
+        auto pltext = ::fast_io::u8string_view{u8"<align=center>a</align>\n<align=right>b</align>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer =
+            ::fast_io::u8string_view{u8"<p style=\"text-align:center\">a</p><br><p style=\"text-align:right\">b</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<align=center>a</align>\n<align=right>b</align>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    // a blank line between two <align> tags renders as two <br>
+    {
+        auto pltext = ::fast_io::u8string_view{u8"<align=center>a</align>\n\n<align=right>b</align>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer =
+            ::fast_io::u8string_view{u8"<p style=\"text-align:center\">a</p><br><br><p style=\"text-align:right\">b</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer =
+            ::fast_io::u8string_view{u8"<align=center>a</align>\n\n<align=right>b</align>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    // text before and after a block-level <align>
+    {
+        auto pltext = ::fast_io::u8string_view{u8"a\n<align=center>b</align>\nc"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer =
+            ::fast_io::u8string_view{u8"a<br><p style=\"text-align:center\">b</p><br>c"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"a\n<align=center>b</align>\nc"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    // a newline inside an <align> block renders as <br>
+    {
+        auto pltext = ::fast_io::u8string_view{u8"<align=center>line1\nline2</align>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:center\">line1<br>line2</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<align=center>line1\nline2</align>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    // a blank line inside an <align> block renders as two <br>
+    {
+        auto pltext = ::fast_io::u8string_view{u8"<align=center>line1\n\nline3</align>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:center\">line1<br><br>line3</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<align=center>line1\n\nline3</align>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    // a <p> block followed by an <align> block on the next line
+    {
+        auto pltext = ::fast_io::u8string_view{u8"<p>a</p>\n<align=center>b</align>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer =
+            ::fast_io::u8string_view{u8"<p style=\"text-align:left\">a</p><br><p style=\"text-align:center\">b</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"a\n<align=center>b</align>"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    // an <align> block followed by a <p> block on the next line
+    {
+        auto pltext = ::fast_io::u8string_view{u8"<align=center>a</align>\n<p>b</p>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer =
+            ::fast_io::u8string_view{u8"<p style=\"text-align:center\">a</p><br><p style=\"text-align:left\">b</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+        auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<align=center>a</align>\nb"};
+        pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
+    }
+
+    // a leading newline before a block-level <align>
+    {
+        auto pltext = ::fast_io::u8string_view{u8"\n<align=center>a</align>"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"<br><p style=\"text-align:center\">a</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    // a trailing newline after a closing </align>
+    {
+        auto pltext = ::fast_io::u8string_view{u8"<align=center>a</align>\n"};
+        auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:center\">a</p><br>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
     return 0;
 }

--- a/tests/test_pl_align_tag.cc
+++ b/tests/test_pl_align_tag.cc
@@ -1,0 +1,135 @@
+#include "precompile.hh"
+
+int main() {
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=center>hello</align>");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"text-align:center;\">hello</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=left>hello</align>");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"text-align:left;\">hello</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=right>hello</align>");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"text-align:right;\">hello</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=justify>hello</align>");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"text-align:justify;\">hello</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=justified>hello</align>");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"text-align:justify;\">hello</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<Align=center>hello</align>");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"text-align:center;\">hello</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=center   >hello</align  >");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"text-align:center;\">hello</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // empty content collapses
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"t<align=center></align>t");
+        auto answer = ::fast_io::u8string_view{u8"tt"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"hello<align=center>");
+        auto answer = ::fast_io::u8string_view{u8"hello"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=left>hello");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"text-align:left;\">hello</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=center>hello<align=right>world</align></align>");
+        auto answer = ::fast_io::u8string_view{
+            u8"<span style=\"text-align:center;\">hello<span style=\"text-align:right;\">world</span></span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=center><i>test</i></align>");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"text-align:center;\"><em>test</em></span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=>text");
+        auto answer = ::fast_io::u8string_view{u8"&lt;align=&gt;text"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=centerr>text");
+        auto answer = ::fast_io::u8string_view{u8"&lt;align=centerr&gt;text"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align=bogus>text</align>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;align=bogus&gt;text&lt;/align&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<align>text</align>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;align&gt;text&lt;/align&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // plunity backend emits TMP align tags
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<align=center>text</align>");
+        auto answer = ::fast_io::u8string_view{u8"<align=center>text</align>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<align=right>text</align>");
+        auto answer = ::fast_io::u8string_view{u8"<align=right>text</align>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<align=justify>text</align>");
+        auto answer = ::fast_io::u8string_view{u8"<align=justified>text</align>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<align=justified>text</align>");
+        auto answer = ::fast_io::u8string_view{u8"<align=justified>text</align>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // left is emitted verbatim for an explicit align tag
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<align=left>text</align>");
+        auto answer = ::fast_io::u8string_view{u8"<align=left>text</align>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    return 0;
+}

--- a/tests/test_plunity_backend.cc
+++ b/tests/test_plunity_backend.cc
@@ -14,5 +14,41 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
     }
 
+    {
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<p>text</p>");
+        auto answer = ::fast_io::u8string_view{u8"<p>text</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<p style=\"text-align:center\">text</p>");
+        auto answer = ::fast_io::u8string_view{u8"<p><align=center>text</align></p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<p style=\"text-align:right\">text</p>");
+        auto answer = ::fast_io::u8string_view{u8"<p><align=right>text</align></p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<p style=\"text-align:justify\">text</p>");
+        auto answer = ::fast_io::u8string_view{u8"<p><align=justified>text</align></p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<p style=\"text-align:left\">text</p>");
+        auto answer = ::fast_io::u8string_view{u8"<p>text</p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<p style=\"text-align:center\"><b>text</b></p>");
+        auto answer = ::fast_io::u8string_view{u8"<p><align=center><b>text</b></align></p>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
     return 0;
 }

--- a/tests/test_plunity_backend.cc
+++ b/tests/test_plunity_backend.cc
@@ -16,37 +16,37 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<p>text</p>");
-        auto answer = ::fast_io::u8string_view{u8"<p>text</p>"};
+        auto answer = ::fast_io::u8string_view{u8"text"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<p style=\"text-align:center\">text</p>");
-        auto answer = ::fast_io::u8string_view{u8"<p><align=center>text</align></p>"};
+        auto answer = ::fast_io::u8string_view{u8"<align=center>text</align>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<p style=\"text-align:right\">text</p>");
-        auto answer = ::fast_io::u8string_view{u8"<p><align=right>text</align></p>"};
+        auto answer = ::fast_io::u8string_view{u8"<align=right>text</align>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<p style=\"text-align:justify\">text</p>");
-        auto answer = ::fast_io::u8string_view{u8"<p><align=justified>text</align></p>"};
+        auto answer = ::fast_io::u8string_view{u8"<align=justified>text</align>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<p style=\"text-align:left\">text</p>");
-        auto answer = ::fast_io::u8string_view{u8"<p>text</p>"};
+        auto answer = ::fast_io::u8string_view{u8"text"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<p style=\"text-align:center\"><b>text</b></p>");
-        auto answer = ::fast_io::u8string_view{u8"<p><align=center><b>text</b></align></p>"};
+        auto answer = ::fast_io::u8string_view{u8"<align=center><b>text</b></align>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 


### PR DESCRIPTION
## Summary

Two related improvements to the plunity (Unity TextMeshPro) output path:

1. **Add `<align>` tag support** — Unity TMP rich text uses `<align=left|center|right|justify|justified>...</align>` for text alignment. This PR adds a dedicated `pl_align` AST node and parses/generates it in every backend.
2. **Fix `<p>` handling** — TMP does not support the HTML `<p>` tag at all. Previously the plunity backend emitted a literal `<p>` (which TMP displays verbatim), merely simulating that `p` is unsupported. This PR drops the bogus `<p>`/`</p>` wrapper and instead maps the paragraph boundary to a newline, while folding the paragraph alignment into an `<align>` tag.

## What changed

### Parser (`parser.hh`, `try_parse.hh`, `frame_context.hh`)
- New `pl_align` node kind; parses `<align=value>...</align>` in both `<a...>`/`</a>` branches.
- Accepts `left`, `center`, `right`, `justify`, and `justified` (the latter two both map to `justify`). Unknown/empty values render as literal text.
- Opening tags must be valid (`<align=center>`), not bare `<align>`; case-insensitive.

### AST (`ast.hh`, `node_kind.hh`, `physics_lab_node_*`)
- `PlAlign` node holding its sub-AST and a `TextAlign`, with move/copy/destroy/equality plumbing.

### Backends
- `for_plweb_text.hh` / `for_plweb_title.hh`: `<align>` → `<span style="text-align:...">`, `justified` → `justify`.
- `for_plunity_text.hh`:
  - `<align>` → `<align=...>` (TMP uses `justified`).
  - `<p>` no longer emits `<p>`/`</p>`; a non-left-aligned `<p>` becomes `<align=...>...</align>`, and the paragraph boundary is surfaced as a `\n` (deduplicated when already preceded by a newline or `<br>`).

### Optimizer (`optimizer.hh`)
- Dropped empty `pl_align` nodes (mirrors other container nodes).

## Examples

| Input | plweb | plunity (TMP) |
|---|---|---|
| `<align=center>hello</align>` | `<span style="text-align:center;">hello</span>` | `<align=center>hello</align>` |
| `<p>a</p><p>b</p>` | `<p style="text-align:left">a</p><p style="text-align:left">b</p>` | `a\nb` |
| `<p style="text-align:center">text</p>` | `<p style="text-align:center">text</p>` | `<align=center>text</align>` |

## Testing
- New `tests/test_pl_align_tag.cc` covering parse/validation, both backends, nesting, empty-collapse, and malformed tags.
- Extended `tests/test_plunity_backend.cc` and `tests/test_html_p_tag.cc`.
- Full suite: 76/76 passing.