### PR TITLE
fix: render hr as a plain-text separator in plunity backend

### DIFF
--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -812,12 +812,13 @@ entry:
                 result.append(u8"<i>");
                 goto entry;
             }
-            case ::pltxt2htm::NodeKind::md_hr: {
-                result.append(u8" ---\n");
-                continue;
-            }
+            case ::pltxt2htm::NodeKind::md_hr:
+                [[fallthrough]];
             case ::pltxt2htm::NodeKind::html_hr: {
-                result.append(u8"<hr>");
+                if (result.empty() == false && result.back() != u8'\n') {
+                    result.push_back(u8'\n');
+                }
+                result.append(u8"---\n");
                 continue;
             }
             case ::pltxt2htm::NodeKind::html_note: {

--- a/tests/test_html_hr_tag.cc
+++ b/tests/test_html_hr_tag.cc
@@ -23,7 +23,7 @@ int main() {
     {
         auto pltext = ::fast_io::u8string_view{u8"<hr>"};
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<hr>"};
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"---\n"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 

--- a/tests/test_md_thematic_break.cc
+++ b/tests/test_md_thematic_break.cc
@@ -43,7 +43,7 @@ int main() {
         auto answer = ::fast_io::u8string_view{u8"<hr>"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer = ::fast_io::u8string_view{u8" ---\n"};
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"---\n"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 


### PR DESCRIPTION
Both md_hr and html_hr now emit a plain '---' line wrapped by newlines instead of a raw '<hr>' tag or a leading-space ' ---', so block separation works and Unity TMP can display it.