### PR TITLE
feat: render code fence and code span with NerdFont in plunity backend

### DIFF
--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -965,21 +965,21 @@ entry:
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
                     node.as_md_code_span_1_backtick().get_subast(), ::pltxt2htm::NodeKind::md_code_span_1_backtick, 0));
                 ++current_index;
-                result.push_back(u8' ');
+                result.append(u8"<font=\"PhysicsLab-NerdFont SDF\"> ");
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_code_span_2_backtick: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
                     node.as_md_code_span_2_backtick().get_subast(), ::pltxt2htm::NodeKind::md_code_span_2_backtick, 0));
                 ++current_index;
-                result.push_back(u8' ');
+                result.append(u8"<font=\"PhysicsLab-NerdFont SDF\"> ");
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_code_span_3_backtick: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
                     node.as_md_code_span_3_backtick().get_subast(), ::pltxt2htm::NodeKind::md_code_span_3_backtick, 0));
                 ++current_index;
-                result.push_back(u8' ');
+                result.append(u8"<font=\"PhysicsLab-NerdFont SDF\"> ");
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_code: {
@@ -1341,24 +1341,14 @@ entry:
                 continue;
             }
             case ::pltxt2htm::NodeKind::md_code_fence_backtick: {
-                result.append(u8"```");
-                auto const& opt_language = node.as_md_code_fence_backtick().get_language();
-                if (opt_language.has_value()) {
-                    result.append(opt_language.template value<ndebug == ::pltxt2htm::Contracts::ignore>());
-                }
-                result.push_back(u8'\n');
+                result.append(u8"<font=\"PhysicsLab-NerdFont SDF\">\n");
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
                     node.as_md_code_fence_backtick().get_subast(), ::pltxt2htm::NodeKind::md_code_fence_backtick, 0));
                 ++current_index;
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_code_fence_tilde: {
-                result.append(u8"```");
-                auto const& opt_language = node.as_md_code_fence_tilde().get_language();
-                if (opt_language.has_value()) {
-                    result.append(opt_language.template value<ndebug == ::pltxt2htm::Contracts::ignore>());
-                }
-                result.push_back(u8'\n');
+                result.append(u8"<font=\"PhysicsLab-NerdFont SDF\">\n");
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
                     node.as_md_code_fence_tilde().get_subast(), ::pltxt2htm::NodeKind::md_code_fence_tilde, 0));
                 ++current_index;
@@ -1619,7 +1609,7 @@ entry:
             case ::pltxt2htm::NodeKind::md_code_span_2_backtick:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::md_code_span_3_backtick: {
-                result.push_back(u8' ');
+                result.append(u8" </font>");
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_code: {
@@ -1696,7 +1686,7 @@ entry:
             case ::pltxt2htm::NodeKind::md_code_fence_backtick:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::md_code_fence_tilde: {
-                result.append(u8"\n```");
+                result.append(u8"\n</font>");
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_link:

--- a/tests/test_md_code_fence.cc
+++ b/tests/test_md_code_fence.cc
@@ -43,7 +43,8 @@ int main() {
         auto answer = ::fast_io::u8string_view{u8"<pre><code class=\"language-py\">print(1)</code></pre>"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"```py\nprint(1)\n```"};
+        auto plunity_richtext_answer =
+            ::fast_io::u8string_view{u8"<font=\"PhysicsLab-NerdFont SDF\">\nprint(1)\n</font>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
@@ -226,25 +227,25 @@ print("Hello World")
 
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"```\ntest\n```");
-        auto answer = ::fast_io::u8string_view{u8"```\ntest\n```"};
+        auto answer = ::fast_io::u8string_view{u8"<font=\"PhysicsLab-NerdFont SDF\">\ntest\n</font>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"```py\ntest\n```");
-        auto answer = ::fast_io::u8string_view{u8"```py\ntest\n```"};
+        auto answer = ::fast_io::u8string_view{u8"<font=\"PhysicsLab-NerdFont SDF\">\ntest\n</font>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"~~~\ntest\n~~~");
-        auto answer = ::fast_io::u8string_view{u8"```\ntest\n```"};
+        auto answer = ::fast_io::u8string_view{u8"<font=\"PhysicsLab-NerdFont SDF\">\ntest\n</font>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"~~~py\ntest\n~~~");
-        auto answer = ::fast_io::u8string_view{u8"```py\ntest\n```"};
+        auto answer = ::fast_io::u8string_view{u8"<font=\"PhysicsLab-NerdFont SDF\">\ntest\n</font>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_md_code_span.cc
+++ b/tests/test_md_code_span.cc
@@ -7,7 +7,7 @@ int main() {
         auto answer = ::fast_io::u8string_view{u8"<code>test</code>"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
-        auto plunity_richtext_answer = ::fast_io::u8string_view{u8" test "};
+        auto plunity_richtext_answer = ::fast_io::u8string_view{u8"<font=\"PhysicsLab-NerdFont SDF\"> test </font>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
@@ -75,19 +75,19 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"ab`test`cd");
-        auto answer = ::fast_io::u8string_view{u8"ab test cd"};
+        auto answer = ::fast_io::u8string_view{u8"ab<font=\"PhysicsLab-NerdFont SDF\"> test </font>cd"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"ab``test``cd");
-        auto answer = ::fast_io::u8string_view{u8"ab test cd"};
+        auto answer = ::fast_io::u8string_view{u8"ab<font=\"PhysicsLab-NerdFont SDF\"> test </font>cd"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"ab```test```cd");
-        auto answer = ::fast_io::u8string_view{u8"ab test cd"};
+        auto answer = ::fast_io::u8string_view{u8"ab<font=\"PhysicsLab-NerdFont SDF\"> test </font>cd"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 


### PR DESCRIPTION
fenced code blocks and inline code spans now emit
<font="PhysicsLab-NerdFont SDF">...</font> instead of raw backtick markers or plain spaced text, so Unity TMP displays code in a monospace font. The fence language hint is dropped.