### PR TITLE
feat: support fractional values in span font-size

### DIFF
--- a/benches/include/bench_fixtures.hh
+++ b/benches/include/bench_fixtures.hh
@@ -179,7 +179,7 @@ inline auto build_html_span_ast(::std::size_t count) -> ::pltxt2htm::Ast<ndebug>
         sub.push_back(::pltxt2htm::PlTxtNode<ndebug>{::pltxt2htm::U8Char{u8't'}});
         ast.push_back(::pltxt2htm::PlTxtNode<ndebug>{::pltxt2htm::HtmlSpan<ndebug>{
             ::std::move(sub), ::fast_io::u8string{u8"color:red;font-size:16px"},
-            ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>>{::exception::nullopt},
+            ::exception::optional<::pltxt2htm::ValueWithUnit<double>>{::exception::nullopt},
             ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>>{::exception::nullopt}}});
     }
     return ast;

--- a/benches/src/bench_micro.cc
+++ b/benches/src/bench_micro.cc
@@ -44,7 +44,7 @@ BENCHMARK_DEFINE_F(MicroFixture, NodeCreate_HtmlSpan)(benchmark::State& st) {
         sub.push_back(::pltxt2htm::PlTxtNode<ndebug>{::pltxt2htm::U8Char{u8't'}});
         ::pltxt2htm::PlTxtNode<ndebug> node{::pltxt2htm::HtmlSpan<ndebug>{
             ::std::move(sub), ::fast_io::u8string{u8"color:red;"},
-            ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>>{::exception::nullopt},
+            ::exception::optional<::pltxt2htm::ValueWithUnit<double>>{::exception::nullopt},
             ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>>{::exception::nullopt}}};
         ::benchmark::DoNotOptimize(node);
     }

--- a/include/pltxt2htm/ast/impl/html_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/html_node_decl.hh
@@ -514,19 +514,19 @@ public:
  * @brief HTML &lt;span style="color:...;font-size:...;vertical-align:..."&gt; node
  * @details Represents an HTML span element with color/font-size/vertical-align style attributes.
  *          color stores the CSS color value (e.g. "red" or "#FF0000").
- *          font_size stores the font-size value+unit if present (e.g. {20, px} for 20px).
+ *          font_size stores the font-size value+unit if present (e.g. {20.5, px} for 20.5px).
  *          vertical_align stores the vertical-align value+unit if present (e.g. {super} or {5, px}).
  */
 template<::pltxt2htm::Contracts ndebug>
 class HtmlSpan {
     ::pltxt2htm::Ast<ndebug> subast;
     ::fast_io::u8string color;
-    ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> font_size;
+    ::exception::optional<::pltxt2htm::ValueWithUnit<double>> font_size;
     ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>> vertical_align;
 
 public:
     constexpr HtmlSpan(::pltxt2htm::Ast<ndebug>&& subast_, ::fast_io::u8string&& color_,
-                       ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> font_size_,
+                       ::exception::optional<::pltxt2htm::ValueWithUnit<double>> font_size_,
                        ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>> vertical_align_) noexcept;
     constexpr HtmlSpan(::pltxt2htm::HtmlSpan<ndebug> const&) noexcept;
     constexpr HtmlSpan(::pltxt2htm::HtmlSpan<ndebug>&&) noexcept;
@@ -550,7 +550,7 @@ public:
 
     [[nodiscard]]
     constexpr auto get_font_size(this auto&& self) noexcept
-        -> ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> {
+        -> ::exception::optional<::pltxt2htm::ValueWithUnit<double>> {
         return self.font_size;
     }
 

--- a/include/pltxt2htm/ast/impl/html_node_def.inc
+++ b/include/pltxt2htm/ast/impl/html_node_def.inc
@@ -546,7 +546,7 @@ constexpr auto ::pltxt2htm::HtmlColgroup<ndebug>::operator==(this ::pltxt2htm::H
 template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::HtmlSpan<ndebug>::HtmlSpan(
     ::pltxt2htm::Ast<ndebug>&& subast_, ::fast_io::u8string&& color_,
-    ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> font_size_,
+    ::exception::optional<::pltxt2htm::ValueWithUnit<double>> font_size_,
     ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>> vertical_align_) noexcept
     : subast(::std::move(subast_)),
       color(::std::move(color_)),

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -686,17 +686,21 @@ entry:
                 if (has_font_size) {
                     auto const& font_size = span_font_size.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                     result.append(u8"<size=");
-                    result.append(::pltxt2htm::details::double2str(font_size.value));
                     switch (font_size.unit) /* -Werror=switch */ {
                     case ::pltxt2htm::Unit::percent: {
+                        result.append(::pltxt2htm::details::double2str(font_size.value));
                         result.push_back(u8'%');
                         break;
                     }
                     case ::pltxt2htm::Unit::em: {
+                        result.append(::pltxt2htm::details::double2str(font_size.value));
                         result.append(u8"em");
                         break;
                     }
                     case ::pltxt2htm::Unit::px: {
+                        // plunity <size> counts two scale units per CSS px; match the /2 applied
+                        // by the plunity->plweb mapping (e.g. 12.5px -> <size=25>, size=11 -> 6px).
+                        result.append(::pltxt2htm::details::double2str(font_size.value * 2));
                         break;
                     }
 #ifdef PLTXT2HTM_ENABLE_RUNTIME_EXHAUSTIVE_SWITCH_CHECK

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -686,7 +686,7 @@ entry:
                 if (has_font_size) {
                     auto const& font_size = span_font_size.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                     result.append(u8"<size=");
-                    result.append(::pltxt2htm::details::size_t2str(font_size.value));
+                    result.append(::pltxt2htm::details::double2str(font_size.value));
                     switch (font_size.unit) /* -Werror=switch */ {
                     case ::pltxt2htm::Unit::percent: {
                         result.push_back(u8'%');

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -732,7 +732,7 @@ entry:
                 if (has_font_size) {
                     auto const& font_size = span_font_size.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                     result.append(u8"font-size:");
-                    result.append(::pltxt2htm::details::size_t2str(font_size.value));
+                    result.append(::pltxt2htm::details::double2str(font_size.value));
                     switch (font_size.unit) /* -Werror=switch */ {
                     case ::pltxt2htm::Unit::percent: {
                         result.push_back(u8'%');

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -153,7 +153,7 @@ entry:
                 if (has_font_size) {
                     auto const& font_size = span_font_size.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                     result.append(u8"font-size:");
-                    result.append(::pltxt2htm::details::size_t2str(font_size.value));
+                    result.append(::pltxt2htm::details::double2str(font_size.value));
                     switch (font_size.unit) /* -Werror=switch */ {
                     case ::pltxt2htm::Unit::percent: {
                         result.push_back(u8'%');

--- a/include/pltxt2htm/details/parser/frame_context.hh
+++ b/include/pltxt2htm/details/parser/frame_context.hh
@@ -64,7 +64,7 @@ class ParserFrameContextWithHtmlSpanInfo {
 public:
     ::fast_io::u8string_view pltext;
     ::fast_io::u8string color;
-    ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> font_size;
+    ::exception::optional<::pltxt2htm::ValueWithUnit<double>> font_size;
     ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>> vertical_align;
 };
 
@@ -1606,7 +1606,7 @@ public:
 
     [[nodiscard]]
     constexpr auto get_html_span_font_size(this auto&& self) noexcept
-        -> ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> {
+        -> ::exception::optional<::pltxt2htm::ValueWithUnit<double>> {
         auto&& context_data_ref = self.context_data;
         bool const is_html_span_type{context_data_ref.kind == ::pltxt2htm::NodeKind::html_span};
         pltxt2htm_assert(is_html_span_type, u8"context kind mismatch");

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -1238,7 +1238,7 @@ template<::pltxt2htm::Contracts ndebug>
 struct TryParseSpanTagResult {
     ::std::size_t tag_len; ///< Length of the matched tag.
     ::fast_io::u8string color; ///< Extracted color value.
-    ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>>
+    ::exception::optional<::pltxt2htm::ValueWithUnit<double>>
         font_size; ///< Extracted font-size value+unit (if present).
     ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>>
         vertical_align; ///< Extracted vertical-align value (if present).
@@ -1249,11 +1249,11 @@ struct TryParseSpanTagResult {
  */
 struct TryParseFontSizeValueResult {
     ::std::size_t end;
-    ::pltxt2htm::ValueWithUnit<::std::size_t> value;
+    ::pltxt2htm::ValueWithUnit<double> value;
 };
 
 /**
- * @brief Parse a non-zero integer optionally followed by lowercase `px`, `em` or `%`.
+ * @brief Parse a non-zero number optionally followed by lowercase `px`, `em` or `%`.
  * @details `pltext` must already be subviewed so that it starts at the value, and
  *          the returned `end` is relative to that subview.
  */
@@ -1261,7 +1261,7 @@ template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
 constexpr auto try_parse_font_size_value(::fast_io::u8string_view pltext) noexcept
     -> ::exception::optional<::pltxt2htm::details::TryParseFontSizeValueResult> {
-    auto opt_decimal = ::pltxt2htm::details::try_parse_size_t_decimal_value<ndebug>(pltext);
+    auto opt_decimal = ::pltxt2htm::details::try_parse_double_decimal_value<ndebug>(pltext);
     if (opt_decimal.has_value() == false) {
         return ::exception::nullopt;
     }
@@ -1981,7 +1981,7 @@ template<::pltxt2htm::Contracts ndebug>
 struct TryParseSpanStyleResult {
     ::std::size_t end; ///< Byte offset just past the closing quote, relative to the input subview.
     ::fast_io::u8string color; ///< Extracted color value, empty if none was present.
-    ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>>
+    ::exception::optional<::pltxt2htm::ValueWithUnit<double>>
         font_size; ///< Extracted font-size value+unit, if present.
     ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>>
         vertical_align; ///< Extracted vertical-align value, if present.
@@ -1993,7 +1993,7 @@ constexpr auto try_parse_span_style(::fast_io::u8string_view pltext, char8_t con
     -> ::exception::optional<TryParseSpanStyleResult<ndebug>> {
     ::std::size_t p{};
     ::fast_io::u8string color{};
-    ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> font_size{::exception::nullopt};
+    ::exception::optional<::pltxt2htm::ValueWithUnit<double>> font_size{::exception::nullopt};
     ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>> vertical_align{::exception::nullopt};
 
     while (p < pltext.size()) {
@@ -2146,7 +2146,7 @@ constexpr auto try_parse_span_tag(::fast_io::u8string_view pltext) noexcept
     ::std::size_t pos{4}; // skip past "span" (the 's' was consumed by the trie dispatch)
     bool found_style{false};
     ::fast_io::u8string color{};
-    ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> font_size{::exception::nullopt};
+    ::exception::optional<::pltxt2htm::ValueWithUnit<double>> font_size{::exception::nullopt};
     ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>> vertical_align{::exception::nullopt};
 
     while (pos < pltext.size()) {

--- a/include/pltxt2htm/details/utils.hh
+++ b/include/pltxt2htm/details/utils.hh
@@ -511,9 +511,10 @@ constexpr auto try_parse_double_decimal_value(::fast_io::u8string_view str) noex
     if (pos == 0) {
         return ::exception::nullopt;
     }
-    // Reject values that overflow ::std::size_t so oversized tags stay literal text
-    // (preserving the historical behavior of try_parse_size_t_decimal_value).
-    if (parsed_value > static_cast<double>(::std::numeric_limits<::std::size_t>::max())) {
+    // Reject values that cannot be represented in ::std::size_t so oversized tags stay literal
+    // text (preserving the historical behavior of try_parse_size_t_decimal_value). `>=` is used
+    // because double(std::size_t max) rounds up to 2^64, and any double >= 2^64 cannot fit.
+    if (parsed_value >= static_cast<double>(::std::numeric_limits<::std::size_t>::max())) {
         return ::exception::nullopt;
     }
     return TryParseDoubleDecimalValueResult{.end = pos, .value = parsed_value};
@@ -571,9 +572,8 @@ constexpr auto double2str(double value) noexcept -> ::fast_io::u8string {
             }
             candidate.append(digit_str);
         }
-        auto opt_reparsed =
-            ::pltxt2htm::details::try_parse_double_decimal_value<::pltxt2htm::Contracts::quick_enforce>(
-                ::fast_io::u8string_view{candidate.data(), candidate.size()});
+        auto opt_reparsed = ::pltxt2htm::details::try_parse_double_decimal_value<::pltxt2htm::Contracts::quick_enforce>(
+            ::fast_io::u8string_view{candidate.data(), candidate.size()});
         bool const round_trips = opt_reparsed.has_value() && (opt_reparsed.template value<true>().value == value);
         if (round_trips) {
             return candidate;

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -63,7 +63,7 @@ template<::pltxt2htm::Contracts ndebug>
 class OptimizerContextWithHtmlSpanInfo {
 public:
     ::fast_io::u8string_view color{};
-    ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> font_size{::exception::nullopt};
+    ::exception::optional<::pltxt2htm::ValueWithUnit<double>> font_size{::exception::nullopt};
     ::exception::optional<::pltxt2htm::VerticalAlignValue<ndebug>> vertical_align{::exception::nullopt};
 };
 
@@ -341,7 +341,7 @@ public:
 
     [[nodiscard]]
     constexpr auto get_html_span_font_size(this auto const& self) noexcept
-        -> ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> {
+        -> ::exception::optional<::pltxt2htm::ValueWithUnit<double>> {
         auto&& context_data_ref = self.context_data;
         bool const is_html_span_type{context_data_ref.kind == ::pltxt2htm::NodeKind::html_span};
         pltxt2htm_assert(is_html_span_type, u8"context kind mismatch");
@@ -545,8 +545,7 @@ entry:
                         auto const inner_fs = subnode.as_html_span().get_font_size();
                         auto const inner_va = subnode.as_html_span().get_vertical_align();
                         auto merged_color = ::fast_io::u8string{inner_color.empty() ? outer_color : inner_color};
-                        ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> merged_fs{
-                            ::exception::nullopt};
+                        ::exception::optional<::pltxt2htm::ValueWithUnit<double>> merged_fs{::exception::nullopt};
                         if (inner_fs.has_value()) {
                             merged_fs = inner_fs.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                         }
@@ -571,8 +570,7 @@ entry:
                     if (subnode.get_node_kind() == ::pltxt2htm::NodeKind::pl_color) {
                         auto const outer_fs = node.as_html_span().get_font_size();
                         auto const outer_va = node.as_html_span().get_vertical_align();
-                        ::exception::optional<::pltxt2htm::ValueWithUnit<::std::size_t>> merged_fs{
-                            ::exception::nullopt};
+                        ::exception::optional<::pltxt2htm::ValueWithUnit<double>> merged_fs{::exception::nullopt};
                         if (outer_fs.has_value()) {
                             merged_fs = outer_fs.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                         }

--- a/tests/test_html_span_tag.cc
+++ b/tests/test_html_span_tag.cc
@@ -387,9 +387,60 @@ int main() {
     }
 
     {
-        // maximum valid font-size value (boundary of overflow detection)
+        // font-size that cannot be represented in double/std::size_t stays literal
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<span style=\"font-size:18446744073709551614px\">text</span>");
-        auto answer = ::fast_io::u8string_view{u8"<span style=\"font-size:18446744073709551614px;\">text</span>"};
+        auto answer = ::fast_io::u8string_view{
+            u8"&lt;span&nbsp;style=&quot;font-size:18446744073709551614px&quot;&gt;text&lt;/span&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // fractional font-size accepted and round-tripped
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<span style=\"font-size:12.5px\">text</span>");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"font-size:12.5px;\">text</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // fractional font-size with em unit
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<span style=\"font-size:1.5em\">text</span>");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"font-size:1.5em;\">text</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // fractional font-size with percent unit
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<span style=\"font-size:87.5%\">text</span>");
+        auto answer = ::fast_io::u8string_view{u8"<span style=\"font-size:87.5%;\">text</span>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // leading-dot font-size rejected (stays literal)
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<span style=\"font-size:.5px\">text</span>");
+        auto answer = ::fast_io::u8string_view{u8"&lt;span&nbsp;style=&quot;font-size:.5px&quot;&gt;text&lt;/span&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // font-size with empty fractional part rejected (stays literal)
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<span style=\"font-size:12.px\">text</span>");
+        auto answer =
+            ::fast_io::u8string_view{u8"&lt;span&nbsp;style=&quot;font-size:12.px&quot;&gt;text&lt;/span&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // fractional font-size -> plunity
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<span style=\"font-size:12.5px\">text</span>");
+        auto answer = ::fast_io::u8string_view{u8"<size=12.5>text</size>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    {
+        // fractional font-size -> plunity with em unit
+        auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<span style=\"font-size:1.5em\">text</span>");
+        auto answer = ::fast_io::u8string_view{u8"<size=1.5em>text</size>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_html_span_tag.cc
+++ b/tests/test_html_span_tag.cc
@@ -431,9 +431,9 @@ int main() {
     }
 
     {
-        // fractional font-size -> plunity
+        // fractional font-size -> plunity (css px count double plunity size units)
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<span style=\"font-size:12.5px\">text</span>");
-        auto answer = ::fast_io::u8string_view{u8"<size=12.5>text</size>"};
+        auto answer = ::fast_io::u8string_view{u8"<size=25>text</size>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -452,14 +452,14 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<span style=\"font-size:20px\">text</span>");
-        auto answer = ::fast_io::u8string_view{u8"<size=20>text</size>"};
+        auto answer = ::fast_io::u8string_view{u8"<size=40>text</size>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html =
             ::pltxt2htm_test::pltxt2plunity_introduction(u8"<span style=\"color:blue;font-size:16px\">text</span>");
-        auto answer = ::fast_io::u8string_view{u8"<color=blue><size=16>text</size></color>"};
+        auto answer = ::fast_io::u8string_view{u8"<color=blue><size=32>text</size></color>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -675,7 +675,7 @@ int main() {
         // color+font-size+px vertical-align combined in Unity output
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(
             u8"<span style=\"color:red;font-size:16px;vertical-align:5px\">text</span>");
-        auto answer = ::fast_io::u8string_view{u8"<color=red><size=16><voffset=5>text</voffset></size></color>"};
+        auto answer = ::fast_io::u8string_view{u8"<color=red><size=32><voffset=5>text</voffset></size></color>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 


### PR DESCRIPTION
Change the html_span font-size from ValueWithUnit<size_t> to ValueWithUnit<double> so fractional font sizes (e.g. 12.5px, 1.5em) parse and round-trip. All three backends emit the value via double2str. Tighten the double parser overflow guard to >= so values above double(size_t max) stay literal text instead of emitting a wrong number.