### PR TITLE
refactor(parser): parse HTML <pre><code> blocks into the Code node

### DIFF
--- a/cxxmodule/pltxt2htm/pltxt2htm.cppm
+++ b/cxxmodule/pltxt2htm/pltxt2htm.cppm
@@ -50,7 +50,7 @@ using ::pltxt2htm::Ast;
 using ::pltxt2htm::U8Char;
 using ::pltxt2htm::InvalidU8Char;
 using ::pltxt2htm::Text;
-using ::pltxt2htm::Code;
+using ::pltxt2htm::CodeFence;
 using ::pltxt2htm::Url;
 
 using ::pltxt2htm::LineBreak;

--- a/cxxmodule/pltxt2htm/pltxt2htm.cppm
+++ b/cxxmodule/pltxt2htm/pltxt2htm.cppm
@@ -89,8 +89,6 @@ using ::pltxt2htm::ListOl;
 using ::pltxt2htm::ListLi;
 using ::pltxt2htm::ListLiCheckbox;
 
-using ::pltxt2htm::HtmlCode;
-using ::pltxt2htm::HtmlPre;
 using ::pltxt2htm::HtmlBlockquote;
 
 // html table nodes

--- a/cxxmodule/pltxt2htm/pltxt2htm.cppm
+++ b/cxxmodule/pltxt2htm/pltxt2htm.cppm
@@ -89,6 +89,7 @@ using ::pltxt2htm::ListOl;
 using ::pltxt2htm::ListLi;
 using ::pltxt2htm::ListLiCheckbox;
 
+using ::pltxt2htm::HtmlCode;
 using ::pltxt2htm::HtmlBlockquote;
 
 // html table nodes

--- a/include/pltxt2htm/ast/ast.hh
+++ b/include/pltxt2htm/ast/ast.hh
@@ -71,6 +71,7 @@ class PlTxtNode {
         ::pltxt2htm::ListOl<ndebug> list_ol_node;
         ::pltxt2htm::ListLi<ndebug> list_li_node;
         ::pltxt2htm::ListLiCheckbox<ndebug> list_li_checkbox_node;
+        ::pltxt2htm::HtmlCode<ndebug> html_code_node;
         ::pltxt2htm::HtmlBlockquote<ndebug> html_blockquote_node;
 
         // html table node
@@ -390,6 +391,11 @@ public:
     constexpr PlTxtNode(::pltxt2htm::HtmlDel<ndebug>&& node) noexcept
         : html_del_node(::std::move(node)),
           node_kind{::pltxt2htm::NodeKind::html_del} {
+    }
+
+    constexpr PlTxtNode(::pltxt2htm::HtmlCode<ndebug>&& node) noexcept
+        : html_code_node(::std::move(node)),
+          node_kind{::pltxt2htm::NodeKind::html_code} {
     }
 
     constexpr PlTxtNode(::pltxt2htm::HtmlSup<ndebug>&& node) noexcept
@@ -1062,6 +1068,10 @@ public:
             new (::std::addressof(html_blockquote_node))::pltxt2htm::HtmlBlockquote(other.html_blockquote_node);
             break;
         }
+        case ::pltxt2htm::NodeKind::html_code: {
+            new (::std::addressof(html_code_node))::pltxt2htm::HtmlCode(other.html_code_node);
+            break;
+        }
         case ::pltxt2htm::NodeKind::html_col: {
             new (::std::addressof(html_col_node))::pltxt2htm::HtmlCol(other.html_col_node);
             break;
@@ -1627,6 +1637,10 @@ public:
         case ::pltxt2htm::NodeKind::html_blockquote: {
             new (::std::addressof(html_blockquote_node))::pltxt2htm::HtmlBlockquote(
                 ::std::move(other.html_blockquote_node));
+            break;
+        }
+        case ::pltxt2htm::NodeKind::html_code: {
+            new (::std::addressof(html_code_node))::pltxt2htm::HtmlCode(::std::move(other.html_code_node));
             break;
         }
         case ::pltxt2htm::NodeKind::html_col: {
@@ -2202,6 +2216,10 @@ public:
             html_blockquote_node.~HtmlBlockquote();
             break;
         }
+        case ::pltxt2htm::NodeKind::html_code: {
+            html_code_node.~HtmlCode();
+            break;
+        }
         case ::pltxt2htm::NodeKind::html_col: {
             html_col_node.~HtmlCol();
             break;
@@ -2691,6 +2709,9 @@ public:
         case ::pltxt2htm::NodeKind::html_blockquote: {
             return self.html_blockquote_node == other.html_blockquote_node;
         }
+        case ::pltxt2htm::NodeKind::html_code: {
+            return self.html_code_node == other.html_code_node;
+        }
         case ::pltxt2htm::NodeKind::html_col: {
             return self.html_col_node == other.html_col_node;
         }
@@ -3153,6 +3174,13 @@ public:
         bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::html_blockquote};
         pltxt2htm_assert(is_type, u8"node kind mismatch");
         return ::std::forward_like<decltype(self)>(self.html_blockquote_node);
+    }
+
+    [[nodiscard]]
+    constexpr auto as_html_code(this auto&& self) noexcept -> decltype(auto) {
+        bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::html_code};
+        pltxt2htm_assert(is_type, u8"node kind mismatch");
+        return ::std::forward_like<decltype(self)>(self.html_code_node);
     }
 
     [[nodiscard]]

--- a/include/pltxt2htm/ast/ast.hh
+++ b/include/pltxt2htm/ast/ast.hh
@@ -71,8 +71,6 @@ class PlTxtNode {
         ::pltxt2htm::ListOl<ndebug> list_ol_node;
         ::pltxt2htm::ListLi<ndebug> list_li_node;
         ::pltxt2htm::ListLiCheckbox<ndebug> list_li_checkbox_node;
-        ::pltxt2htm::HtmlCode<ndebug> html_code_node;
-        ::pltxt2htm::HtmlPre<ndebug> html_pre_node;
         ::pltxt2htm::HtmlBlockquote<ndebug> html_blockquote_node;
 
         // html table node
@@ -457,16 +455,6 @@ public:
     constexpr PlTxtNode(::pltxt2htm::ListLiCheckbox<ndebug>&& node) noexcept
         : list_li_checkbox_node(::std::move(node)),
           node_kind{::pltxt2htm::NodeKind::list_li_checkbox} {
-    }
-
-    constexpr PlTxtNode(::pltxt2htm::HtmlCode<ndebug>&& node) noexcept
-        : html_code_node(::std::move(node)),
-          node_kind{::pltxt2htm::NodeKind::html_code} {
-    }
-
-    constexpr PlTxtNode(::pltxt2htm::HtmlPre<ndebug>&& node) noexcept
-        : html_pre_node(::std::move(node)),
-          node_kind{::pltxt2htm::NodeKind::html_pre} {
     }
 
     constexpr PlTxtNode(::pltxt2htm::HtmlBlockquote<ndebug>&& node) noexcept
@@ -1070,14 +1058,6 @@ public:
             new (::std::addressof(list_li_checkbox_node))::pltxt2htm::ListLiCheckbox(other.list_li_checkbox_node);
             break;
         }
-        case ::pltxt2htm::NodeKind::html_code: {
-            new (::std::addressof(html_code_node))::pltxt2htm::HtmlCode(other.html_code_node);
-            break;
-        }
-        case ::pltxt2htm::NodeKind::html_pre: {
-            new (::std::addressof(html_pre_node))::pltxt2htm::HtmlPre(other.html_pre_node);
-            break;
-        }
         case ::pltxt2htm::NodeKind::html_blockquote: {
             new (::std::addressof(html_blockquote_node))::pltxt2htm::HtmlBlockquote(other.html_blockquote_node);
             break;
@@ -1642,14 +1622,6 @@ public:
         case ::pltxt2htm::NodeKind::list_li_checkbox: {
             new (::std::addressof(list_li_checkbox_node))::pltxt2htm::ListLiCheckbox(
                 ::std::move(other.list_li_checkbox_node));
-            break;
-        }
-        case ::pltxt2htm::NodeKind::html_code: {
-            new (::std::addressof(html_code_node))::pltxt2htm::HtmlCode(::std::move(other.html_code_node));
-            break;
-        }
-        case ::pltxt2htm::NodeKind::html_pre: {
-            new (::std::addressof(html_pre_node))::pltxt2htm::HtmlPre(::std::move(other.html_pre_node));
             break;
         }
         case ::pltxt2htm::NodeKind::html_blockquote: {
@@ -2226,14 +2198,6 @@ public:
             list_li_checkbox_node.~ListLiCheckbox();
             break;
         }
-        case ::pltxt2htm::NodeKind::html_code: {
-            html_code_node.~HtmlCode();
-            break;
-        }
-        case ::pltxt2htm::NodeKind::html_pre: {
-            html_pre_node.~HtmlPre();
-            break;
-        }
         case ::pltxt2htm::NodeKind::html_blockquote: {
             html_blockquote_node.~HtmlBlockquote();
             break;
@@ -2724,12 +2688,6 @@ public:
         case ::pltxt2htm::NodeKind::list_li_checkbox: {
             return self.list_li_checkbox_node == other.list_li_checkbox_node;
         }
-        case ::pltxt2htm::NodeKind::html_code: {
-            return self.html_code_node == other.html_code_node;
-        }
-        case ::pltxt2htm::NodeKind::html_pre: {
-            return self.html_pre_node == other.html_pre_node;
-        }
         case ::pltxt2htm::NodeKind::html_blockquote: {
             return self.html_blockquote_node == other.html_blockquote_node;
         }
@@ -3188,20 +3146,6 @@ public:
         bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::list_li_checkbox};
         pltxt2htm_assert(is_type, u8"node kind mismatch");
         return ::std::forward_like<decltype(self)>(self.list_li_checkbox_node);
-    }
-
-    [[nodiscard]]
-    constexpr auto as_html_code(this auto&& self) noexcept -> decltype(auto) {
-        bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::html_code};
-        pltxt2htm_assert(is_type, u8"node kind mismatch");
-        return ::std::forward_like<decltype(self)>(self.html_code_node);
-    }
-
-    [[nodiscard]]
-    constexpr auto as_html_pre(this auto&& self) noexcept -> decltype(auto) {
-        bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::html_pre};
-        pltxt2htm_assert(is_type, u8"node kind mismatch");
-        return ::std::forward_like<decltype(self)>(self.html_pre_node);
     }
 
     [[nodiscard]]

--- a/include/pltxt2htm/ast/ast.hh
+++ b/include/pltxt2htm/ast/ast.hh
@@ -3170,17 +3170,17 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto as_html_blockquote(this auto&& self) noexcept -> decltype(auto) {
-        bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::html_blockquote};
-        pltxt2htm_assert(is_type, u8"node kind mismatch");
-        return ::std::forward_like<decltype(self)>(self.html_blockquote_node);
-    }
-
-    [[nodiscard]]
     constexpr auto as_html_code(this auto&& self) noexcept -> decltype(auto) {
         bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::html_code};
         pltxt2htm_assert(is_type, u8"node kind mismatch");
         return ::std::forward_like<decltype(self)>(self.html_code_node);
+    }
+
+    [[nodiscard]]
+    constexpr auto as_html_blockquote(this auto&& self) noexcept -> decltype(auto) {
+        bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::html_blockquote};
+        pltxt2htm_assert(is_type, u8"node kind mismatch");
+        return ::std::forward_like<decltype(self)>(self.html_blockquote_node);
     }
 
     [[nodiscard]]

--- a/include/pltxt2htm/ast/ast.hh
+++ b/include/pltxt2htm/ast/ast.hh
@@ -127,7 +127,7 @@ class PlTxtNode {
         ::pltxt2htm::MdEscapeRightBrace md_escape_right_brace_node;
         ::pltxt2htm::MdEscapeTilde md_escape_tilde_node;
         ::pltxt2htm::MdHr md_hr_node;
-        ::pltxt2htm::Code<ndebug> code_node;
+        ::pltxt2htm::CodeFence<ndebug> code_fence_node;
         ::pltxt2htm::MdCodeSpan1Backtick<ndebug> md_code_span_1_backtick_node;
         ::pltxt2htm::MdCodeSpan2Backtick<ndebug> md_code_span_2_backtick_node;
         ::pltxt2htm::MdCodeSpan3Backtick<ndebug> md_code_span_3_backtick_node;
@@ -718,9 +718,9 @@ public:
           node_kind{::pltxt2htm::NodeKind::md_hr} {
     }
 
-    constexpr PlTxtNode(::pltxt2htm::Code<ndebug>&& node) noexcept
-        : code_node(::std::move(node)),
-          node_kind{::pltxt2htm::NodeKind::code} {
+    constexpr PlTxtNode(::pltxt2htm::CodeFence<ndebug>&& node) noexcept
+        : code_fence_node(::std::move(node)),
+          node_kind{::pltxt2htm::NodeKind::code_fence} {
     }
 
     constexpr PlTxtNode(::pltxt2htm::MdCodeSpan1Backtick<ndebug>&& node) noexcept
@@ -1287,8 +1287,8 @@ public:
             new (::std::addressof(md_hr_node))::pltxt2htm::MdHr(other.md_hr_node);
             break;
         }
-        case ::pltxt2htm::NodeKind::code: {
-            new (::std::addressof(code_node))::pltxt2htm::Code<ndebug>(other.code_node);
+        case ::pltxt2htm::NodeKind::code_fence: {
+            new (::std::addressof(code_fence_node))::pltxt2htm::CodeFence<ndebug>(other.code_fence_node);
             break;
         }
         case ::pltxt2htm::NodeKind::md_code_span_1_backtick: {
@@ -1873,8 +1873,8 @@ public:
             new (::std::addressof(md_hr_node))::pltxt2htm::MdHr(::std::move(other.md_hr_node));
             break;
         }
-        case ::pltxt2htm::NodeKind::code: {
-            new (::std::addressof(code_node))::pltxt2htm::Code<ndebug>(::std::move(other.code_node));
+        case ::pltxt2htm::NodeKind::code_fence: {
+            new (::std::addressof(code_fence_node))::pltxt2htm::CodeFence<ndebug>(::std::move(other.code_fence_node));
             break;
         }
         case ::pltxt2htm::NodeKind::md_code_span_1_backtick: {
@@ -2420,8 +2420,8 @@ public:
             md_hr_node.~MdHr();
             break;
         }
-        case ::pltxt2htm::NodeKind::code: {
-            code_node.~Code();
+        case ::pltxt2htm::NodeKind::code_fence: {
+            code_fence_node.~CodeFence();
             break;
         }
         case ::pltxt2htm::NodeKind::md_code_span_1_backtick: {
@@ -2862,8 +2862,8 @@ public:
         case ::pltxt2htm::NodeKind::md_hr: {
             return self.md_hr_node == other.md_hr_node;
         }
-        case ::pltxt2htm::NodeKind::code: {
-            return self.code_node == other.code_node;
+        case ::pltxt2htm::NodeKind::code_fence: {
+            return self.code_fence_node == other.code_fence_node;
         }
         case ::pltxt2htm::NodeKind::md_code_span_1_backtick: {
             return self.md_code_span_1_backtick_node == other.md_code_span_1_backtick_node;
@@ -3534,10 +3534,10 @@ public:
     }
 
     [[nodiscard]]
-    constexpr auto as_code(this auto&& self) noexcept -> decltype(auto) {
-        bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::code};
+    constexpr auto as_code_fence(this auto&& self) noexcept -> decltype(auto) {
+        bool const is_type{self.node_kind == ::pltxt2htm::NodeKind::code_fence};
         pltxt2htm_assert(is_type, u8"node kind mismatch");
-        return ::std::forward_like<decltype(self)>(self.code_node);
+        return ::std::forward_like<decltype(self)>(self.code_fence_node);
     }
 
     [[nodiscard]]

--- a/include/pltxt2htm/ast/impl/basic_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/basic_node_decl.hh
@@ -169,7 +169,7 @@ public:
  * @details Contains code content and an optional language identifier.
  */
 template<::pltxt2htm::Contracts ndebug>
-class Code {
+class CodeFence {
     ::pltxt2htm::Ast<ndebug> subast;
     ::exception::optional<::fast_io::u8string> lang;
 
@@ -179,17 +179,17 @@ public:
      * @param subast The code content as an AST.
      * @param lang Optional language string.
      */
-    constexpr explicit Code(::pltxt2htm::Ast<ndebug>&& subast_,
-                            ::exception::optional<::fast_io::u8string>&& lang_) noexcept;
-    constexpr Code(::pltxt2htm::Code<ndebug> const&) noexcept;
-    constexpr Code(::pltxt2htm::Code<ndebug>&&) noexcept;
-    constexpr ~Code() noexcept;
-    constexpr auto operator=(::pltxt2htm::Code<ndebug> const&) noexcept -> ::pltxt2htm::Code<ndebug>& = delete;
-    constexpr auto operator=(this ::pltxt2htm::Code<ndebug>& self, ::pltxt2htm::Code<ndebug>&&) noexcept
-        -> ::pltxt2htm::Code<ndebug>&;
+    constexpr explicit CodeFence(::pltxt2htm::Ast<ndebug>&& subast_,
+                                 ::exception::optional<::fast_io::u8string>&& lang_) noexcept;
+    constexpr CodeFence(::pltxt2htm::CodeFence<ndebug> const&) noexcept;
+    constexpr CodeFence(::pltxt2htm::CodeFence<ndebug>&&) noexcept;
+    constexpr ~CodeFence() noexcept;
+    constexpr auto operator=(::pltxt2htm::CodeFence<ndebug> const&) noexcept -> ::pltxt2htm::CodeFence<ndebug>& = delete;
+    constexpr auto operator=(this ::pltxt2htm::CodeFence<ndebug>& self, ::pltxt2htm::CodeFence<ndebug>&&) noexcept
+        -> ::pltxt2htm::CodeFence<ndebug>&;
 
     [[nodiscard]]
-    constexpr auto operator==(this Code const& self, Code const& other) noexcept -> bool;
+    constexpr auto operator==(this CodeFence const& self, CodeFence const& other) noexcept -> bool;
 
     [[nodiscard]]
     constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {

--- a/include/pltxt2htm/ast/impl/basic_node_def.inc
+++ b/include/pltxt2htm/ast/impl/basic_node_def.inc
@@ -26,25 +26,25 @@ constexpr auto ::pltxt2htm::Text<ndebug>::operator==(this ::pltxt2htm::Text<ndeb
                                                      ::pltxt2htm::Text<ndebug> const&) noexcept -> bool = default;
 
 template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::Code<ndebug>::Code(::pltxt2htm::Ast<ndebug>&& subast_,
-                                          ::exception::optional<::fast_io::u8string>&& lang_) noexcept
+constexpr ::pltxt2htm::CodeFence<ndebug>::CodeFence(::pltxt2htm::Ast<ndebug>&& subast_,
+                                                   ::exception::optional<::fast_io::u8string>&& lang_) noexcept
     : subast(::std::move(subast_)),
       lang(::std::move(lang_)) {
 }
 
 template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::Code<ndebug>::Code(::pltxt2htm::Code<ndebug> const&) noexcept = default;
+constexpr ::pltxt2htm::CodeFence<ndebug>::CodeFence(::pltxt2htm::CodeFence<ndebug> const&) noexcept = default;
 template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::Code<ndebug>::Code(::pltxt2htm::Code<ndebug>&&) noexcept = default;
+constexpr ::pltxt2htm::CodeFence<ndebug>::CodeFence(::pltxt2htm::CodeFence<ndebug>&&) noexcept = default;
 template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::Code<ndebug>::~Code() noexcept = default;
+constexpr ::pltxt2htm::CodeFence<ndebug>::~CodeFence() noexcept = default;
 template<::pltxt2htm::Contracts ndebug>
-constexpr auto ::pltxt2htm::Code<ndebug>::operator=(this ::pltxt2htm::Code<ndebug>& self,
-                                                    ::pltxt2htm::Code<ndebug>&&) noexcept
-    -> ::pltxt2htm::Code<ndebug>& = default;
+constexpr auto ::pltxt2htm::CodeFence<ndebug>::operator=(this ::pltxt2htm::CodeFence<ndebug>& self,
+                                                        ::pltxt2htm::CodeFence<ndebug>&&) noexcept
+    -> ::pltxt2htm::CodeFence<ndebug>& = default;
 
 template<::pltxt2htm::Contracts ndebug>
-constexpr auto ::pltxt2htm::Code<ndebug>::operator==(this ::pltxt2htm::Code<ndebug> const&,
-                                                     ::pltxt2htm::Code<ndebug> const&) noexcept -> bool = default;
+constexpr auto ::pltxt2htm::CodeFence<ndebug>::operator==(this ::pltxt2htm::CodeFence<ndebug> const&,
+                                                         ::pltxt2htm::CodeFence<ndebug> const&) noexcept -> bool = default;
 
 } // namespace pltxt2htm

--- a/include/pltxt2htm/ast/impl/html_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/html_node_decl.hh
@@ -454,6 +454,31 @@ public:
 };
 
 /**
+ * @brief HTML &lt;code&gt; inline code node
+ */
+template<::pltxt2htm::Contracts ndebug>
+class HtmlCode {
+    ::pltxt2htm::Ast<ndebug> subast;
+
+public:
+    constexpr explicit HtmlCode(::pltxt2htm::Ast<ndebug>&& subast_) noexcept;
+    constexpr HtmlCode(::pltxt2htm::HtmlCode<ndebug> const&) noexcept;
+    constexpr HtmlCode(::pltxt2htm::HtmlCode<ndebug>&&) noexcept;
+    constexpr ~HtmlCode() noexcept;
+    constexpr auto operator=(::pltxt2htm::HtmlCode<ndebug> const&) noexcept -> ::pltxt2htm::HtmlCode<ndebug>& = delete;
+    constexpr auto operator=(this ::pltxt2htm::HtmlCode<ndebug>& self, ::pltxt2htm::HtmlCode<ndebug>&&) noexcept
+        -> ::pltxt2htm::HtmlCode<ndebug>&;
+
+    [[nodiscard]]
+    constexpr auto operator==(this HtmlCode const&, HtmlCode const&) noexcept -> bool;
+
+    [[nodiscard]]
+    constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.subast);
+    }
+};
+
+/**
  * @brief HTML &lt;span style="color:...;font-size:...;vertical-align:..."&gt; node
  * @details Represents an HTML span element with color/font-size/vertical-align style attributes.
  *          color stores the CSS color value (e.g. "red" or "#FF0000").
@@ -583,31 +608,6 @@ public:
     [[nodiscard]]
     constexpr auto get_internal(this HtmlA const& self) noexcept -> bool {
         return self.internal;
-    }
-};
-
-/**
- * @brief HTML &lt;code&gt; inline code node
- */
-template<::pltxt2htm::Contracts ndebug>
-class HtmlCode {
-    ::pltxt2htm::Ast<ndebug> subast;
-
-public:
-    constexpr explicit HtmlCode(::pltxt2htm::Ast<ndebug>&& subast_) noexcept;
-    constexpr HtmlCode(::pltxt2htm::HtmlCode<ndebug> const&) noexcept;
-    constexpr HtmlCode(::pltxt2htm::HtmlCode<ndebug>&&) noexcept;
-    constexpr ~HtmlCode() noexcept;
-    constexpr auto operator=(::pltxt2htm::HtmlCode<ndebug> const&) noexcept -> ::pltxt2htm::HtmlCode<ndebug>& = delete;
-    constexpr auto operator=(this ::pltxt2htm::HtmlCode<ndebug>& self, ::pltxt2htm::HtmlCode<ndebug>&&) noexcept
-        -> ::pltxt2htm::HtmlCode<ndebug>&;
-
-    [[nodiscard]]
-    constexpr auto operator==(this HtmlCode const&, HtmlCode const&) noexcept -> bool;
-
-    [[nodiscard]]
-    constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
-        return ::std::forward_like<decltype(self)>(self.subast);
     }
 };
 

--- a/include/pltxt2htm/ast/impl/html_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/html_node_decl.hh
@@ -587,6 +587,31 @@ public:
 };
 
 /**
+ * @brief HTML &lt;code&gt; inline code node
+ */
+template<::pltxt2htm::Contracts ndebug>
+class HtmlCode {
+    ::pltxt2htm::Ast<ndebug> subast;
+
+public:
+    constexpr explicit HtmlCode(::pltxt2htm::Ast<ndebug>&& subast_) noexcept;
+    constexpr HtmlCode(::pltxt2htm::HtmlCode<ndebug> const&) noexcept;
+    constexpr HtmlCode(::pltxt2htm::HtmlCode<ndebug>&&) noexcept;
+    constexpr ~HtmlCode() noexcept;
+    constexpr auto operator=(::pltxt2htm::HtmlCode<ndebug> const&) noexcept -> ::pltxt2htm::HtmlCode<ndebug>& = delete;
+    constexpr auto operator=(this ::pltxt2htm::HtmlCode<ndebug>& self, ::pltxt2htm::HtmlCode<ndebug>&&) noexcept
+        -> ::pltxt2htm::HtmlCode<ndebug>&;
+
+    [[nodiscard]]
+    constexpr auto operator==(this HtmlCode const&, HtmlCode const&) noexcept -> bool;
+
+    [[nodiscard]]
+    constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
+        return ::std::forward_like<decltype(self)>(self.subast);
+    }
+};
+
+/**
  * @brief HTML &lt;blockquote&gt; block quotation node
  */
 template<::pltxt2htm::Contracts ndebug>

--- a/include/pltxt2htm/ast/impl/html_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/html_node_decl.hh
@@ -454,63 +454,6 @@ public:
 };
 
 /**
- * @brief HTML &lt;code&gt; inline code node
- */
-template<::pltxt2htm::Contracts ndebug>
-class HtmlCode {
-    ::pltxt2htm::Ast<ndebug> subast;
-    ::exception::optional<::fast_io::u8string> language;
-
-public:
-    constexpr explicit HtmlCode(::pltxt2htm::Ast<ndebug>&& subast_,
-                                ::exception::optional<::fast_io::u8string>&& language_) noexcept;
-    constexpr HtmlCode(::pltxt2htm::HtmlCode<ndebug> const&) noexcept;
-    constexpr HtmlCode(::pltxt2htm::HtmlCode<ndebug>&&) noexcept;
-    constexpr ~HtmlCode() noexcept;
-    constexpr auto operator=(::pltxt2htm::HtmlCode<ndebug> const&) noexcept -> ::pltxt2htm::HtmlCode<ndebug>& = delete;
-    constexpr auto operator=(this ::pltxt2htm::HtmlCode<ndebug>& self, ::pltxt2htm::HtmlCode<ndebug>&&) noexcept
-        -> ::pltxt2htm::HtmlCode<ndebug>&;
-
-    [[nodiscard]]
-    constexpr auto operator==(this HtmlCode const&, HtmlCode const&) noexcept -> bool;
-
-    [[nodiscard]]
-    constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
-        return ::std::forward_like<decltype(self)>(self.subast);
-    }
-
-    [[nodiscard]]
-    constexpr auto get_language(this auto&& self) noexcept -> decltype(auto) {
-        return ::std::forward_like<decltype(self)>(self.language);
-    }
-};
-
-/**
- * @brief HTML &lt;pre&gt; preformatted text node
- */
-template<::pltxt2htm::Contracts ndebug>
-class HtmlPre {
-    ::pltxt2htm::Ast<ndebug> subast;
-
-public:
-    constexpr explicit HtmlPre(::pltxt2htm::Ast<ndebug>&& subast_) noexcept;
-    constexpr HtmlPre(::pltxt2htm::HtmlPre<ndebug> const&) noexcept;
-    constexpr HtmlPre(::pltxt2htm::HtmlPre<ndebug>&&) noexcept;
-    constexpr ~HtmlPre() noexcept;
-    constexpr auto operator=(::pltxt2htm::HtmlPre<ndebug> const&) noexcept -> ::pltxt2htm::HtmlPre<ndebug>& = delete;
-    constexpr auto operator=(this ::pltxt2htm::HtmlPre<ndebug>& self, ::pltxt2htm::HtmlPre<ndebug>&&) noexcept
-        -> ::pltxt2htm::HtmlPre<ndebug>&;
-
-    [[nodiscard]]
-    constexpr auto operator==(this HtmlPre const&, HtmlPre const&) noexcept -> bool;
-
-    [[nodiscard]]
-    constexpr auto get_subast(this auto&& self) noexcept -> decltype(auto) {
-        return ::std::forward_like<decltype(self)>(self.subast);
-    }
-};
-
-/**
  * @brief HTML &lt;span style="color:...;font-size:...;vertical-align:..."&gt; node
  * @details Represents an HTML span element with color/font-size/vertical-align style attributes.
  *          color stores the CSS color value (e.g. "red" or "#FF0000").

--- a/include/pltxt2htm/ast/impl/html_node_def.inc
+++ b/include/pltxt2htm/ast/impl/html_node_def.inc
@@ -289,49 +289,6 @@ constexpr auto ::pltxt2htm::HtmlMark<ndebug>::operator==(this ::pltxt2htm::HtmlM
     -> bool = default;
 
 template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::HtmlCode<ndebug>::HtmlCode(::pltxt2htm::Ast<ndebug>&& subast_,
-                                                  ::exception::optional<::fast_io::u8string>&& language_) noexcept
-    : subast(::std::move(subast_)),
-      language(::std::move(language_)) {
-}
-
-template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::HtmlCode<ndebug>::HtmlCode(::pltxt2htm::HtmlCode<ndebug> const&) noexcept = default;
-template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::HtmlCode<ndebug>::HtmlCode(::pltxt2htm::HtmlCode<ndebug>&&) noexcept = default;
-template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::HtmlCode<ndebug>::~HtmlCode() noexcept = default;
-template<::pltxt2htm::Contracts ndebug>
-constexpr auto ::pltxt2htm::HtmlCode<ndebug>::operator=(this ::pltxt2htm::HtmlCode<ndebug>& self,
-                                                        ::pltxt2htm::HtmlCode<ndebug>&&) noexcept
-    -> ::pltxt2htm::HtmlCode<ndebug>& = default;
-
-template<::pltxt2htm::Contracts ndebug>
-constexpr auto ::pltxt2htm::HtmlCode<ndebug>::operator==(this ::pltxt2htm::HtmlCode<ndebug> const&,
-                                                         ::pltxt2htm::HtmlCode<ndebug> const&) noexcept
-    -> bool = default;
-
-template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::HtmlPre<ndebug>::HtmlPre(::pltxt2htm::Ast<ndebug>&& subast_) noexcept
-    : subast(::std::move(subast_)) {
-}
-
-template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::HtmlPre<ndebug>::HtmlPre(::pltxt2htm::HtmlPre<ndebug> const&) noexcept = default;
-template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::HtmlPre<ndebug>::HtmlPre(::pltxt2htm::HtmlPre<ndebug>&&) noexcept = default;
-template<::pltxt2htm::Contracts ndebug>
-constexpr ::pltxt2htm::HtmlPre<ndebug>::~HtmlPre() noexcept = default;
-template<::pltxt2htm::Contracts ndebug>
-constexpr auto ::pltxt2htm::HtmlPre<ndebug>::operator=(this ::pltxt2htm::HtmlPre<ndebug>& self,
-                                                       ::pltxt2htm::HtmlPre<ndebug>&&) noexcept
-    -> ::pltxt2htm::HtmlPre<ndebug>& = default;
-
-template<::pltxt2htm::Contracts ndebug>
-constexpr auto ::pltxt2htm::HtmlPre<ndebug>::operator==(this ::pltxt2htm::HtmlPre<ndebug> const&,
-                                                        ::pltxt2htm::HtmlPre<ndebug> const&) noexcept -> bool = default;
-
-template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::HtmlBlockquote<ndebug>::HtmlBlockquote(::pltxt2htm::Ast<ndebug>&& subast_) noexcept
     : subast(::std::move(subast_)) {
 }

--- a/include/pltxt2htm/ast/impl/html_node_def.inc
+++ b/include/pltxt2htm/ast/impl/html_node_def.inc
@@ -289,6 +289,26 @@ constexpr auto ::pltxt2htm::HtmlMark<ndebug>::operator==(this ::pltxt2htm::HtmlM
     -> bool = default;
 
 template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::HtmlCode<ndebug>::HtmlCode(::pltxt2htm::Ast<ndebug>&& subast_) noexcept
+    : subast(::std::move(subast_)) {
+}
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::HtmlCode<ndebug>::HtmlCode(::pltxt2htm::HtmlCode<ndebug> const&) noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::HtmlCode<ndebug>::HtmlCode(::pltxt2htm::HtmlCode<ndebug>&&) noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr ::pltxt2htm::HtmlCode<ndebug>::~HtmlCode() noexcept = default;
+template<::pltxt2htm::Contracts ndebug>
+constexpr auto ::pltxt2htm::HtmlCode<ndebug>::operator=(this ::pltxt2htm::HtmlCode<ndebug>& self,
+                                                        ::pltxt2htm::HtmlCode<ndebug>&&) noexcept
+    -> ::pltxt2htm::HtmlCode<ndebug>& = default;
+
+template<::pltxt2htm::Contracts ndebug>
+constexpr auto ::pltxt2htm::HtmlCode<ndebug>::operator==(this ::pltxt2htm::HtmlCode<ndebug> const&,
+                                                         ::pltxt2htm::HtmlCode<ndebug> const&) noexcept -> bool = default;
+
+template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::HtmlBlockquote<ndebug>::HtmlBlockquote(::pltxt2htm::Ast<ndebug>&& subast_) noexcept
     : subast(::std::move(subast_)) {
 }

--- a/include/pltxt2htm/ast/node_kind.hh
+++ b/include/pltxt2htm/ast/node_kind.hh
@@ -97,7 +97,8 @@ enum class NodeKind : unsigned {
     list_li, ///< List item: &lt;li&gt;...&lt;/li&gt; or Markdown list item
     list_li_checkbox, ///< Checkbox list item (Markdown - [ ] / - [x])
 
-    // HTML quote elements
+    // HTML code and quote elements
+    html_code, ///< Inline code: &lt;code&gt;...&lt;/code&gt;
     html_blockquote, ///< Block quote: &lt;blockquote&gt;...&lt;/blockquote&gt;
 
     // HTML table elements

--- a/include/pltxt2htm/ast/node_kind.hh
+++ b/include/pltxt2htm/ast/node_kind.hh
@@ -97,9 +97,7 @@ enum class NodeKind : unsigned {
     list_li, ///< List item: &lt;li&gt;...&lt;/li&gt; or Markdown list item
     list_li_checkbox, ///< Checkbox list item (Markdown - [ ] / - [x])
 
-    // HTML code and quote elements
-    html_code, ///< Inline code: &lt;code&gt;...&lt;/code&gt;
-    html_pre, ///< Preformatted text: &lt;pre&gt;...&lt;/pre&gt;
+    // HTML quote elements
     html_blockquote, ///< Block quote: &lt;blockquote&gt;...&lt;/blockquote&gt;
 
     // HTML table elements

--- a/include/pltxt2htm/ast/node_kind.hh
+++ b/include/pltxt2htm/ast/node_kind.hh
@@ -159,7 +159,7 @@ enum class NodeKind : unsigned {
     md_hr, ///< Thematic break/horizontal rule: ---, ***, ___
 
     // Markdown code blocks (fenced code)
-    code, ///< Code fence: ``` or ~~~
+    code_fence, ///< Code fence: ``` or ~~~
 
     // Markdown inline code spans
     md_code_span_1_backtick, ///< Inline code with 1 backtick: `code`

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -1514,10 +1514,11 @@ entry:
                 result.push_back(u8'~');
                 continue;
             }
-            case ::pltxt2htm::NodeKind::code: {
+            case ::pltxt2htm::NodeKind::code_fence: {
                 result.append(u8"<font=\"PhysicsLab-NerdFont SDF\">\n");
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_code().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::code, 0));
+                call_stack.push(
+                    ::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_code_fence().get_subast(),
+                                                                      ::pltxt2htm::NodeKind::code_fence, 0));
                 ++current_index;
                 goto entry;
             }
@@ -1807,7 +1808,7 @@ entry:
                 result.append(u8"</margin>\n");
                 goto entry;
             }
-            case ::pltxt2htm::NodeKind::code: {
+            case ::pltxt2htm::NodeKind::code_fence: {
                 result.append(u8"\n</font>");
                 goto entry;
             }

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -1179,20 +1179,6 @@ entry:
                 result.append(u8"<font=\"PhysicsLab-NerdFont SDF\"> ");
                 goto entry;
             }
-            case ::pltxt2htm::NodeKind::html_code: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_code().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::html_code, 0));
-                ++current_index;
-                result.append(u8"<size=20>\uff1c</size>code");
-                auto const& language = node.as_html_code().get_language();
-                if (language.has_value()) {
-                    result.append(u8" class=\"");
-                    result.append(language.template value<ndebug == ::pltxt2htm::Contracts::ignore>());
-                    result.push_back(u8'\"');
-                }
-                result.append(u8"<size=20>\uff1e</size>");
-                goto entry;
-            }
             case ::pltxt2htm::NodeKind::md_latex_inline: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
                     node.as_md_latex_inline().get_subast(), ::pltxt2htm::NodeKind::md_latex_inline, 0));
@@ -1205,28 +1191,6 @@ entry:
                     node.as_md_latex_block().get_subast(), ::pltxt2htm::NodeKind::md_latex_block, 0));
                 ++current_index;
                 result.append(u8"$$");
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::html_pre: {
-                auto const& pre_subast = node.as_html_pre().get_subast();
-                bool const is_code_block = pre_subast.size() == 1 &&
-                                           ::pltxt2htm::details::vector_index<ndebug>(pre_subast, 0).get_node_kind() ==
-                                               ::pltxt2htm::NodeKind::html_code;
-                if (is_code_block) {
-                    auto const& code_subast =
-                        ::pltxt2htm::details::vector_index<ndebug>(pre_subast, 0).as_html_code().get_subast();
-                    call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                        code_subast, ::pltxt2htm::NodeKind::html_pre, 0,
-                        ::pltxt2htm::details::BackendContextWithHtmlPreInfo{.is_code_block = true}));
-                    ++current_index;
-                    result.append(u8"<font=\"PhysicsLab-NerdFont SDF\">\n");
-                    goto entry;
-                }
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                    pre_subast, ::pltxt2htm::NodeKind::html_pre, 0,
-                    ::pltxt2htm::details::BackendContextWithHtmlPreInfo{.is_code_block = false}));
-                ++current_index;
-                result.append(u8"<size=20>\uff1c</size>pre<size=20>\uff1e</size>");
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_block_quotes: {
@@ -1768,25 +1732,12 @@ entry:
                 result.append(u8" </font>");
                 goto entry;
             }
-            case ::pltxt2htm::NodeKind::html_code: {
-                result.append(u8"<size=20>\uff1c</size>/code<size=20>\uff1e</size>");
-                goto entry;
-            }
             case ::pltxt2htm::NodeKind::md_latex_inline: {
                 result.push_back(u8'$');
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_latex_block: {
                 result.append(u8"$$");
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::html_pre: {
-                if (top_frame.get_html_pre_info().is_code_block) {
-                    result.append(u8"\n</font>");
-                }
-                else {
-                    result.append(u8"<size=20>\uff1c</size>/pre<size=20>\uff1e</size>");
-                }
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_block_quotes: {

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -967,6 +967,13 @@ entry:
                 result.append(u8"<s>");
                 goto entry;
             }
+            case ::pltxt2htm::NodeKind::html_code: {
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_code().get_subast(),
+                                                                                  ::pltxt2htm::NodeKind::html_code, 0));
+                ++current_index;
+                result.append(u8"<font=\"PhysicsLab-NerdFont SDF\"> ");
+                goto entry;
+            }
             case ::pltxt2htm::NodeKind::pl_s: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_pl_s().get_subast(),
                                                                                   ::pltxt2htm::NodeKind::pl_s, 0));
@@ -1698,6 +1705,10 @@ entry:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::pl_s: {
                 result.append(u8"</s>");
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_code: {
+                result.append(u8" </font>");
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_sup: {

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -276,7 +276,6 @@ constexpr auto plweb_text_backend(::pltxt2htm::Ast<ndebug> const& ast_init, ::fa
     -> ::fast_io::u8string {
     ::fast_io::u8string result{};
     ::fast_io::stack<::pltxt2htm::details::BackendFrameContext<ndebug>> call_stack{};
-    ::std::size_t pre_depth{};
     call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(ast_init, ::pltxt2htm::NodeKind::text, 0));
 
 entry:
@@ -907,7 +906,7 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::line_break: {
-                if (pre_depth > 0 || nested_tag_type == ::pltxt2htm::NodeKind::code) {
+                if (nested_tag_type == ::pltxt2htm::NodeKind::code) {
                     result.push_back(u8'\n');
                 }
                 else {
@@ -1145,20 +1144,6 @@ entry:
                 result.append(u8"<code>");
                 goto entry;
             }
-            case ::pltxt2htm::NodeKind::html_code: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_code().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::html_code, 0));
-                ++current_index;
-                result.append(u8"<code");
-                auto const& language = node.as_html_code().get_language();
-                if (language.has_value()) {
-                    result.append(u8" class=\"");
-                    result.append(language.template value<ndebug == ::pltxt2htm::Contracts::ignore>());
-                    result.push_back(u8'\"');
-                }
-                result.push_back(u8'>');
-                goto entry;
-            }
             case ::pltxt2htm::NodeKind::md_latex_inline: {
                 if constexpr (mode == PlWebTextBackendMode::roundtrip) {
                     continue;
@@ -1182,14 +1167,6 @@ entry:
                     result.append(u8"$$");
                     goto entry;
                 }
-            }
-            case ::pltxt2htm::NodeKind::html_pre: {
-                ++pre_depth;
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_pre().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::html_pre, 0));
-                ++current_index;
-                result.append(u8"<pre>");
-                goto entry;
             }
             case ::pltxt2htm::NodeKind::md_block_quotes: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
@@ -1774,9 +1751,7 @@ entry:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::md_code_span_2_backtick:
                 [[fallthrough]];
-            case ::pltxt2htm::NodeKind::md_code_span_3_backtick:
-                [[fallthrough]];
-            case ::pltxt2htm::NodeKind::html_code: {
+            case ::pltxt2htm::NodeKind::md_code_span_3_backtick: {
                 result.append(u8"</code>");
                 goto entry;
             }
@@ -1790,11 +1765,6 @@ entry:
                 pltxt2htm_assert(mode != PlWebTextBackendMode::roundtrip,
                                  u8"Unexpected md_latex_block node in roundtrip mode");
                 result.append(u8"$$");
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::html_pre: {
-                --pre_depth;
-                result.append(u8"</pre>");
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::md_block_quotes:

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -1016,6 +1016,13 @@ entry:
                 result.append(u8"<del>");
                 goto entry;
             }
+            case ::pltxt2htm::NodeKind::html_code: {
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_code().get_subast(),
+                                                                                  ::pltxt2htm::NodeKind::html_code, 0));
+                ++current_index;
+                result.append(u8"<code>");
+                goto entry;
+            }
             case ::pltxt2htm::NodeKind::pl_u: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_pl_u().get_subast(),
                                                                                   ::pltxt2htm::NodeKind::pl_u, 0));
@@ -1690,6 +1697,10 @@ entry:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::html_del: {
                 result.append(u8"</del>");
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_code: {
+                result.append(u8"</code>");
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::pl_u: {

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -906,7 +906,7 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::line_break: {
-                if (nested_tag_type == ::pltxt2htm::NodeKind::code) {
+                if (nested_tag_type == ::pltxt2htm::NodeKind::code_fence) {
                     result.push_back(u8'\n');
                 }
                 else {
@@ -1522,8 +1522,8 @@ entry:
                 result.push_back(u8'~');
                 continue;
             }
-            case ::pltxt2htm::NodeKind::code: {
-                auto const& opt_language = node.as_code().get_language();
+            case ::pltxt2htm::NodeKind::code_fence: {
+                auto const& opt_language = node.as_code_fence().get_language();
                 if (opt_language.has_value()) {
                     auto const& language = opt_language.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                     result.append(u8"<pre><code class=\"language-");
@@ -1534,8 +1534,8 @@ entry:
                 else {
                     result.append(u8"<pre><code>");
                 }
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_code().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::code, 0));
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_code_fence().get_subast(),
+                                                                                  ::pltxt2htm::NodeKind::code_fence, 0));
                 ++current_index;
                 goto entry;
             }
@@ -1832,7 +1832,7 @@ entry:
                 result.append(u8"</colgroup>");
                 goto entry;
             }
-            case ::pltxt2htm::NodeKind::code: {
+            case ::pltxt2htm::NodeKind::code_fence: {
                 result.append(u8"</code></pre>");
                 goto entry;
             }

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -617,12 +617,6 @@ entry:
                 ++current_index;
                 goto entry;
             }
-            case ::pltxt2htm::NodeKind::html_code: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_code().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
             case ::pltxt2htm::NodeKind::md_latex_inline: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
                     node.as_md_latex_inline().get_subast(), ::pltxt2htm::NodeKind::text, 0));
@@ -667,12 +661,6 @@ entry:
             }
             case ::pltxt2htm::NodeKind::md_atx_h6: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_md_atx_h6().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::html_pre: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_pre().get_subast(),
                                                                                   ::pltxt2htm::NodeKind::text, 0));
                 ++current_index;
                 goto entry;

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -551,6 +551,12 @@ entry:
                 ++current_index;
                 goto entry;
             }
+            case ::pltxt2htm::NodeKind::html_code: {
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_code().get_subast(),
+                                                                                  ::pltxt2htm::NodeKind::text, 0));
+                ++current_index;
+                goto entry;
+            }
             case ::pltxt2htm::NodeKind::html_mark: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_mark().get_subast(),
                                                                                   ::pltxt2htm::NodeKind::text, 0));

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -773,8 +773,8 @@ entry:
                 ++current_index;
                 goto entry;
             }
-            case ::pltxt2htm::NodeKind::code: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_code().get_subast(),
+            case ::pltxt2htm::NodeKind::code_fence: {
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_code_fence().get_subast(),
                                                                                   ::pltxt2htm::NodeKind::text, 0));
                 ++current_index;
                 goto entry;

--- a/include/pltxt2htm/details/backend/frame_context.hh
+++ b/include/pltxt2htm/details/backend/frame_context.hh
@@ -51,15 +51,6 @@ public:
 };
 
 /**
- * @brief Context for <pre> frames: remembers whether the pre directly wraps a <code>
- *        (the `<pre><code>` code-block pattern).
- */
-class BackendContextWithHtmlPreInfo {
-public:
-    bool is_code_block{}; ///< Whether the pre is a `<pre><code>` code block.
-};
-
-/**
  * @brief Tagged-union variant of backend context payloads.
  * @details Dispatched on `kind` (::pltxt2htm::NodeKind) – used inside
  *          ::pltxt2htm::details::BackendFrameContext.
@@ -71,7 +62,6 @@ public:
         ::pltxt2htm::details::BackendContextWithOlInfo ol_info;
         ::pltxt2htm::details::BackendContextWithHtmlSpanInfo html_span_info;
         ::pltxt2htm::details::BackendContextWithAlignInfo align_info;
-        ::pltxt2htm::details::BackendContextWithHtmlPreInfo html_pre_info;
     };
 
     ::pltxt2htm::NodeKind kind;
@@ -96,12 +86,6 @@ public:
     constexpr BackendContextVariant(::pltxt2htm::NodeKind const kind_,
                                     ::pltxt2htm::details::BackendContextWithAlignInfo align_info_context) noexcept
         : align_info{::std::move(align_info_context)},
-          kind{kind_} {
-    }
-
-    constexpr BackendContextVariant(::pltxt2htm::NodeKind const kind_,
-                                    ::pltxt2htm::details::BackendContextWithHtmlPreInfo html_pre_info_context) noexcept
-        : html_pre_info{::std::move(html_pre_info_context)},
           kind{kind_} {
     }
 
@@ -155,14 +139,6 @@ public:
           current_index{current_index_} {
     }
 
-    constexpr BackendFrameContext(::pltxt2htm::Ast<ndebug> const& ast_, ::pltxt2htm::NodeKind const nested_tag_type,
-                                  ::std::size_t current_index_,
-                                  ::pltxt2htm::details::BackendContextWithHtmlPreInfo html_pre_info_context) noexcept
-        : context_data{nested_tag_type, ::std::move(html_pre_info_context)},
-          ast(::std::addressof(ast_)),
-          current_index{current_index_} {
-    }
-
     constexpr BackendFrameContext(::pltxt2htm::details::BackendFrameContext<ndebug> const&) noexcept = default;
     constexpr BackendFrameContext(::pltxt2htm::details::BackendFrameContext<ndebug>&&) noexcept = default;
 
@@ -196,13 +172,6 @@ public:
         bool const is_align_type{self.context_data.kind == ::pltxt2htm::NodeKind::html_p};
         pltxt2htm_assert(is_align_type, u8"context kind mismatch");
         return self.context_data.align_info;
-    }
-
-    [[nodiscard]]
-    constexpr auto get_html_pre_info(this auto const& self) noexcept -> BackendContextWithHtmlPreInfo {
-        bool const is_pre_type{self.context_data.kind == ::pltxt2htm::NodeKind::html_pre};
-        pltxt2htm_assert(is_pre_type, u8"context kind mismatch");
-        return self.context_data.html_pre_info;
     }
 
     [[nodiscard]]

--- a/include/pltxt2htm/details/parser/frame_context.hh
+++ b/include/pltxt2htm/details/parser/frame_context.hh
@@ -78,15 +78,6 @@ public:
 };
 
 /**
- * @brief Context for HTML <code> tag frames during parsing; stores class attribute.
- */
-class ParserFrameContextWithHtmlCodeInfo {
-public:
-    ::fast_io::u8string_view pltext;
-    ::exception::optional<::fast_io::u8string> language;
-};
-
-/**
  * @brief Context for URL frames during parsing; stores the raw text and parsed URL.
  */
 class ParserFrameContextWithUrlInfo {
@@ -255,7 +246,6 @@ public:
         align_info,
         html_span_info,
         html_div_info,
-        html_code_info,
         md_block_quotes,
         list_info,
         list_li_checkbox,
@@ -274,7 +264,6 @@ public:
         ::pltxt2htm::details::ParserFrameContextWithHtmlDivInfo html_div_info;
         ::pltxt2htm::details::ParserFrameContextWithHtmlMarkInfo html_mark_info;
         ::pltxt2htm::details::ParserFrameContextWithPlMarkInfo pl_mark_info;
-        ::pltxt2htm::details::ParserFrameContextWithHtmlCodeInfo html_code_info;
         ::pltxt2htm::details::ParserFrameContextWithUrlInfo url_info;
         ::pltxt2htm::details::ParserFrameContextWithHtmlATagInfo html_a_tag_info;
         ::pltxt2htm::details::ParserFrameContextWithPlSizeTagInfo pl_size_tag;
@@ -345,15 +334,6 @@ public:
         : pl_mark_info{::std::move(pl_mark_context)},
 #ifdef PLTXT2HTM_CONTEXT_BRANCH_INSTRUMENT
           context_branch{ContextBranch::pl_mark_info},
-#endif
-          kind{node_kind_} {
-    }
-
-    constexpr FrontendContextVariant(::pltxt2htm::details::ParserFrameContextWithHtmlCodeInfo&& html_code_context,
-                                     ::pltxt2htm::NodeKind node_kind_) noexcept
-        : html_code_info{::std::move(html_code_context)},
-#ifdef PLTXT2HTM_CONTEXT_BRANCH_INSTRUMENT
-          context_branch{ContextBranch::html_code_info},
 #endif
           kind{node_kind_} {
     }
@@ -537,11 +517,6 @@ public:
             ::std::construct_at(::std::addressof(this->pl_mark_info), ::std::move(other.pl_mark_info));
             return;
         }
-        case ::pltxt2htm::NodeKind::html_code: {
-            pltxt2htm_assert_context_branch(*this, ContextBranch::html_code_info);
-            ::std::construct_at(::std::addressof(this->html_code_info), ::std::move(other.html_code_info));
-            return;
-        }
         case ::pltxt2htm::NodeKind::md_block_quotes: {
             pltxt2htm_assert_context_branch(*this, ContextBranch::md_block_quotes);
             ::std::construct_at(::std::addressof(this->md_block_quotes), ::std::move(other.md_block_quotes));
@@ -592,8 +567,6 @@ public:
         case ::pltxt2htm::NodeKind::html_em:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_strong:
-            [[fallthrough]];
-        case ::pltxt2htm::NodeKind::html_pre:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_blockquote:
             [[fallthrough]];
@@ -870,11 +843,6 @@ public:
             ::std::destroy_at(::std::addressof(this->pl_mark_info));
             return;
         }
-        case ::pltxt2htm::NodeKind::html_code: {
-            pltxt2htm_assert_context_branch(*this, ContextBranch::html_code_info);
-            ::std::destroy_at(::std::addressof(this->html_code_info));
-            return;
-        }
         case ::pltxt2htm::NodeKind::md_block_quotes: {
             pltxt2htm_assert_context_branch(*this, ContextBranch::md_block_quotes);
             ::std::destroy_at(::std::addressof(this->md_block_quotes));
@@ -920,8 +888,6 @@ public:
         case ::pltxt2htm::NodeKind::html_em:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_strong:
-            [[fallthrough]];
-        case ::pltxt2htm::NodeKind::html_pre:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_blockquote:
             [[fallthrough]];
@@ -1241,8 +1207,6 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_strong:
             [[fallthrough]];
-        case ::pltxt2htm::NodeKind::html_pre:
-            [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_blockquote:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_table:
@@ -1378,11 +1342,6 @@ public:
             pltxt2htm_assert_context_branch(
                 context_data_ref, ::pltxt2htm::details::FrontendContextVariant<ndebug>::ContextBranch::pl_mark_info);
             return context_data_ref.pl_mark_info.pltext;
-        }
-        case ::pltxt2htm::NodeKind::html_code: {
-            pltxt2htm_assert_context_branch(
-                context_data_ref, ::pltxt2htm::details::FrontendContextVariant<ndebug>::ContextBranch::html_code_info);
-            return context_data_ref.html_code_info.pltext;
         }
         case ::pltxt2htm::NodeKind::html_a: {
             pltxt2htm_assert_context_branch(
@@ -1630,14 +1589,6 @@ public:
         bool const is_pl_mark_type{context_data_ref.kind == ::pltxt2htm::NodeKind::pl_mark};
         pltxt2htm_assert(is_pl_mark_type, u8"context kind mismatch");
         return ::std::forward_like<decltype(self)>(context_data_ref.pl_mark_info.background_color);
-    }
-
-    [[nodiscard]]
-    constexpr auto get_html_code_language(this auto&& self) noexcept -> decltype(auto) {
-        auto&& context_data_ref = self.context_data;
-        bool const is_html_code_type{context_data_ref.kind == ::pltxt2htm::NodeKind::html_code};
-        pltxt2htm_assert(is_html_code_type, u8"context kind mismatch");
-        return ::std::forward_like<decltype(self)>(context_data_ref.html_code_info.language);
     }
 
     [[nodiscard]]

--- a/include/pltxt2htm/details/parser/frame_context.hh
+++ b/include/pltxt2htm/details/parser/frame_context.hh
@@ -648,7 +648,7 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_note:
             [[fallthrough]];
-        case ::pltxt2htm::NodeKind::code:
+        case ::pltxt2htm::NodeKind::code_fence:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_code_span_1_backtick:
             [[fallthrough]];
@@ -976,7 +976,7 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_note:
             [[fallthrough]];
-        case ::pltxt2htm::NodeKind::code:
+        case ::pltxt2htm::NodeKind::code_fence:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_code_span_1_backtick:
             [[fallthrough]];
@@ -1245,7 +1245,7 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_atx_h6:
             [[fallthrough]];
-        case ::pltxt2htm::NodeKind::code:
+        case ::pltxt2htm::NodeKind::code_fence:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::md_code_span_1_backtick:
             [[fallthrough]];

--- a/include/pltxt2htm/details/parser/frame_context.hh
+++ b/include/pltxt2htm/details/parser/frame_context.hh
@@ -568,6 +568,8 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_strong:
             [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_code:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_blockquote:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_table:
@@ -889,6 +891,8 @@ public:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_strong:
             [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_code:
+            [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_blockquote:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_table:
@@ -1206,6 +1210,8 @@ public:
         case ::pltxt2htm::NodeKind::html_em:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_strong:
+            [[fallthrough]];
+        case ::pltxt2htm::NodeKind::html_code:
             [[fallthrough]];
         case ::pltxt2htm::NodeKind::html_blockquote:
             [[fallthrough]];

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -2568,7 +2568,7 @@ entry:
                     }
                     case ::pltxt2htm::NodeKind::md_block_quotes:
                         [[fallthrough]];
-                    case ::pltxt2htm::NodeKind::code:
+                    case ::pltxt2htm::NodeKind::code_fence:
                         [[fallthrough]];
                     case ::pltxt2htm::NodeKind::md_del:
                         [[fallthrough]];
@@ -3312,7 +3312,7 @@ entry:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::md_hr:
                 [[fallthrough]];
-            case ::pltxt2htm::NodeKind::code:
+            case ::pltxt2htm::NodeKind::code_fence:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::html_note:
                 [[fallthrough]];

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -135,6 +135,16 @@ constexpr auto find_next_block_after_line_break(
             return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{
                 .advance_count = current_index + advance_count, .new_frame_been_pushed_into_call_stack = false};
         }
+        // Check for an HTML <pre><code>...</code></pre> code block at a block position.
+        if (auto opt_pre_code_block = ::pltxt2htm::details::try_parse_html_pre_code_block<ndebug>(
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+            opt_pre_code_block.has_value()) {
+            auto&& [node, advance_count] =
+                opt_pre_code_block.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+            result.push_back(::std::move(node));
+            return ::pltxt2htm::details::FindNextBlockAfterLineBreakResult{
+                .advance_count = current_index + advance_count, .new_frame_been_pushed_into_call_stack = false};
+        }
         if (auto opt_block_quote = ::pltxt2htm::details::try_parse_md_block_quotes<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_block_quote.has_value()) {
@@ -1028,22 +1038,6 @@ entry:
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
                     }
-                    if (auto opt_code_tag = ::pltxt2htm::details::try_parse_code_tag<ndebug>(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_code_tag.has_value()) {
-                        // parsing html <code> tag (bare or with class="language-...")
-                        auto&& [tag_len, lang] =
-                            opt_code_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-                        current_index += tag_len + 2;
-                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithHtmlCodeInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
-                                    ::std::move(lang)},
-                                ::pltxt2htm::NodeKind::html_code},
-                            ::pltxt2htm::Ast<ndebug>{}));
-                        goto entry;
-                    }
                     if (auto opt_tag_len = ::pltxt2htm::details::try_parse_caption_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
                             ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
@@ -1314,18 +1308,8 @@ entry:
                 case u8'p':
                     [[fallthrough]];
                 case u8'P': {
-                    if (auto opt_pre_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"re">(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_pre_tag_len.has_value()) {
-                        current_index += opt_pre_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
-                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
-                                ::pltxt2htm::NodeKind::html_pre},
-                            ::pltxt2htm::Ast<ndebug>{}));
-                        goto entry;
-                    }
+                    // <pre> is only recognized as part of a block-level <pre><code> block;
+                    // inline occurrences are plain literal text.
                     result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
                     ++current_index;
                     continue;
@@ -2369,46 +2353,6 @@ entry:
                         ++current_index;
                         continue;
                     }
-                    case ::pltxt2htm::NodeKind::html_code: {
-                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"code">(
-                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                            opt_tag_len.has_value()) {
-                            // parsing end tag </code> successed
-                            ::std::size_t const staged_index{current_index};
-                            auto& code_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                            ::pltxt2htm::HtmlCode staged_node(::std::move(result),
-                                                              ::std::move(code_frame.get_html_code_language()));
-                            call_stack.pop();
-                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
-                            parent_frame.current_index +=
-                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
-                                3;
-                            goto entry;
-                        }
-                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
-                        ++current_index;
-                        continue;
-                    }
-                    case ::pltxt2htm::NodeKind::html_pre: {
-                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"pre">(
-                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                            opt_tag_len.has_value()) {
-                            // parsing end tag </pre> successed
-                            ::std::size_t const staged_index{current_index};
-                            ::pltxt2htm::HtmlPre staged_node(::std::move(result));
-                            call_stack.pop();
-                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
-                            parent_frame.current_index +=
-                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
-                                3;
-                            goto entry;
-                        }
-                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
-                        ++current_index;
-                        continue;
-                    }
                     case ::pltxt2htm::NodeKind::html_table: {
                         if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"table">(
                                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
@@ -3049,17 +2993,6 @@ entry:
                 auto const align = frame.get_cell_align();
                 parent_ast.push_back(
                     ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdTd<ndebug>{::std::move(subast), align}));
-                parent_index += staged_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::html_code: {
-                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                    ::pltxt2htm::HtmlCode<ndebug>{::std::move(subast), ::std::move(frame.get_html_code_language())}));
-                parent_index += staged_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::html_pre: {
-                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlPre<ndebug>{::std::move(subast)}));
                 parent_index += staged_index;
                 goto entry;
             }

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -1310,25 +1310,6 @@ entry:
                     continue;
                 }
 
-                case u8'o':
-                    [[fallthrough]];
-                case u8'O': {
-                    // <ol> is a block-level list; inline occurrences are plain literal text.
-                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
-                    ++current_index;
-                    continue;
-                }
-
-                case u8'p':
-                    [[fallthrough]];
-                case u8'P': {
-                    // <pre> is only recognized as part of a block-level <pre><code> block;
-                    // inline occurrences are plain literal text.
-                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
-                    ++current_index;
-                    continue;
-                }
-
                 case u8's':
                     [[fallthrough]];
                 case u8'S': {

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -1021,17 +1021,19 @@ entry:
                 case u8'c':
                     [[fallthrough]];
                 case u8'C': {
-                    // parsing: inline <code>$1</code> element (renders like a Markdown code span,
-                    // no language/class support)
-                    if (auto opt_code_tag = ::pltxt2htm::details::try_parse_html_code_tag<ndebug>(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
-                        opt_code_tag.has_value()) {
-                        auto&& [advance_count, subast] =
-                            opt_code_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-                        current_index += advance_count;
-                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                            ::pltxt2htm::MdCodeSpan1Backtick<ndebug>{::std::move(subast)}));
-                        continue;
+                    // parsing: <code>$1</code> inline element (no language/class support)
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"ode">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // parsing start tag <code> successed
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::html_code},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
                     }
                     // parsing: <color=$1>$2</color>
                     if (auto opt_color_tag = ::pltxt2htm::details::try_parse_color_tag<ndebug>(
@@ -2227,6 +2229,25 @@ entry:
                         ++current_index;
                         continue;
                     }
+                    case ::pltxt2htm::NodeKind::html_code: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"code">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </code> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlCode staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
                     case ::pltxt2htm::NodeKind::html_note:
                         [[unlikely]] {
                             pltxt2htm_unreachable(u8"Unexpected html_note node during end-tag parsing");
@@ -2938,6 +2959,11 @@ entry:
             }
             case ::pltxt2htm::NodeKind::html_del: {
                 parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlDel<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_code: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlCode<ndebug>{::std::move(subast)}));
                 parent_index += staged_index;
                 goto entry;
             }

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -1021,6 +1021,18 @@ entry:
                 case u8'c':
                     [[fallthrough]];
                 case u8'C': {
+                    // parsing: inline <code>$1</code> element (renders like a Markdown code span,
+                    // no language/class support)
+                    if (auto opt_code_tag = ::pltxt2htm::details::try_parse_html_code_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                        opt_code_tag.has_value()) {
+                        auto&& [advance_count, subast] =
+                            opt_code_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += advance_count;
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                            ::pltxt2htm::MdCodeSpan1Backtick<ndebug>{::std::move(subast)}));
+                        continue;
+                    }
                     // parsing: <color=$1>$2</color>
                     if (auto opt_color_tag = ::pltxt2htm::details::try_parse_color_tag<ndebug>(
                             u8string_view_subview<ndebug>(pltext, current_index + 2));

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -3375,6 +3375,71 @@ struct TryParseMdCodeFenceResult {
     ::std::size_t advance_count; ///< Number of characters consumed.
 };
 
+/**
+ * @brief Parse a block-level HTML <pre><code>...</code></pre> code block into a Code node.
+ *
+ * This function attempts to parse the full `<pre><code>` block: a bare `<pre>` tag,
+ * optionally followed by spaces/tabs and a `<code>` tag (bare or with a
+ * `class="language-..."` attribute). The content up to the matching `</code></pre>`
+ * is parsed as plain text and stored in a ::pltxt2htm::Code node.
+ *
+ * @tparam ndebug When set to Contracts::ignore, runtime assertions are disabled for performance.
+ * @param[in] pltext Input text starting at "<pre>".
+ * @return The parsed Code node and continuation index on success; nullopt on any deviation.
+ * @note The `<pre>` tag must be bare (no attributes) and `<code>` must immediately
+ *       follow it (allowing only spaces/tabs in between).
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_html_pre_code_block(::fast_io::u8string_view pltext) noexcept
+    -> ::exception::optional<::pltxt2htm::details::TryParseMdCodeFenceResult<ndebug>> {
+    // <pre> must be a bare tag (no attributes).
+    auto opt_pre_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<pre">(pltext);
+    if (opt_pre_tag_len.has_value() == false) {
+        return ::exception::nullopt;
+    }
+    ::std::size_t pos{opt_pre_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1};
+
+    // allow spaces/tabs between <pre> and <code>
+    while (pos < pltext.size() && (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8' ' ||
+                                   ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) == u8'\t')) {
+        ++pos;
+    }
+    if (pos + 1 >= pltext.size()) {
+        return ::exception::nullopt;
+    }
+    if (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos) != u8'<') {
+        return ::exception::nullopt;
+    }
+    char8_t const code_first_chr{::pltxt2htm::details::u8string_view_index<ndebug>(pltext, pos + 1)};
+    if (code_first_chr != u8'c' && code_first_chr != u8'C') {
+        return ::exception::nullopt;
+    }
+    auto opt_code_tag = ::pltxt2htm::details::try_parse_code_tag<ndebug>(
+        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, pos + 2));
+    if (opt_code_tag.has_value() == false) {
+        return ::exception::nullopt;
+    }
+    auto&& [code_tag_len, language] = opt_code_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+    pos += 2 + code_tag_len;
+
+    // parse content until the closing </code></pre>
+    constexpr auto end_string = ::pltxt2htm::details::U8LiteralString{u8"</code></pre>"};
+    auto&& [advance_count, ast] = ::pltxt2htm::details::simply_parse_pltext<ndebug, end_string>(
+        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, pos));
+    pos += advance_count;
+
+    // <code class="language-..."> stores the full class value; Code stores only the suffix
+    // after the "language-" prefix (the backends prepend it again when rendering).
+    ::exception::optional<::fast_io::u8string> opt_lang{::exception::nullopt};
+    if (language.has_value()) {
+        auto const& full_language = language.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+        opt_lang = ::fast_io::u8string{full_language.data() + 9, full_language.data() + full_language.size()};
+    }
+    return ::pltxt2htm::details::TryParseMdCodeFenceResult<ndebug>{
+        .node = ::pltxt2htm::Code<ndebug>{::std::move(ast), ::std::move(opt_lang)}, .advance_count = pos};
+}
+
 [[nodiscard]]
 constexpr bool is_allowed_in_language(char8_t const chr) noexcept {
     return (chr >= u8'a' && chr <= u8'z') || (chr >= u8'A' && chr <= u8'Z') || (chr >= u8'0' && chr <= u8'9') ||

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -3778,37 +3778,6 @@ constexpr auto try_parse_md_code_span(::fast_io::u8string_view pltext) noexcept
                                                                   .subast = ::std::move(ast)};
 }
 
-/**
- * @brief Parse an inline HTML `<code>` element as a code span.
- *
- * This function parses a bare `<code>` tag (no attributes, so no language/class
- * support) followed by its content, ending at the first `</code>` end tag. The
- * content is parsed as plain text, mirroring how Markdown code spans work.
- *
- * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
- * @param[in] pltext The input text to parse, starting at the opening `<code>` tag.
- * @return The parsed result containing the code content AST and continuation index, or nullopt if parsing fails.
- */
-template<::pltxt2htm::Contracts ndebug>
-[[nodiscard]]
-constexpr auto try_parse_html_code_tag(::fast_io::u8string_view pltext) noexcept
-    -> ::exception::optional<::pltxt2htm::details::TryParseMdCodeSpanResult<ndebug>> {
-    // <code> must be a bare tag (no attributes).
-    auto opt_code_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<code">(pltext);
-    if (opt_code_tag_len.has_value() == false) {
-        return ::exception::nullopt;
-    }
-    ::std::size_t pos{opt_code_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1};
-
-    // parse content until the closing </code>
-    constexpr auto end_string = ::pltxt2htm::details::U8LiteralString{u8"</code>"};
-    auto&& [advance_count, ast] = ::pltxt2htm::details::simply_parse_pltext<ndebug, end_string>(
-        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, pos));
-    pos += advance_count;
-
-    return ::pltxt2htm::details::TryParseMdCodeSpanResult<ndebug>{.advance_count = pos, .subast = ::std::move(ast)};
-}
-
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseMdLatexResult {
     ::std::size_t advance_count; ///< Number of characters consumed (includes both delimiters).

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -3778,6 +3778,37 @@ constexpr auto try_parse_md_code_span(::fast_io::u8string_view pltext) noexcept
                                                                   .subast = ::std::move(ast)};
 }
 
+/**
+ * @brief Parse an inline HTML `<code>` element as a code span.
+ *
+ * This function parses a bare `<code>` tag (no attributes, so no language/class
+ * support) followed by its content, ending at the first `</code>` end tag. The
+ * content is parsed as plain text, mirroring how Markdown code spans work.
+ *
+ * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
+ * @param[in] pltext The input text to parse, starting at the opening `<code>` tag.
+ * @return The parsed result containing the code content AST and continuation index, or nullopt if parsing fails.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto try_parse_html_code_tag(::fast_io::u8string_view pltext) noexcept
+    -> ::exception::optional<::pltxt2htm::details::TryParseMdCodeSpanResult<ndebug>> {
+    // <code> must be a bare tag (no attributes).
+    auto opt_code_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"<code">(pltext);
+    if (opt_code_tag_len.has_value() == false) {
+        return ::exception::nullopt;
+    }
+    ::std::size_t pos{opt_code_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1};
+
+    // parse content until the closing </code>
+    constexpr auto end_string = ::pltxt2htm::details::U8LiteralString{u8"</code>"};
+    auto&& [advance_count, ast] = ::pltxt2htm::details::simply_parse_pltext<ndebug, end_string>(
+        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, pos));
+    pos += advance_count;
+
+    return ::pltxt2htm::details::TryParseMdCodeSpanResult<ndebug>{.advance_count = pos, .subast = ::std::move(ast)};
+}
+
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseMdLatexResult {
     ::std::size_t advance_count; ///< Number of characters consumed (includes both delimiters).

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -3376,16 +3376,16 @@ struct TryParseMdCodeFenceResult {
 };
 
 /**
- * @brief Parse a block-level HTML <pre><code>...</code></pre> code block into a Code node.
+ * @brief Parse a block-level HTML <pre><code>...</code></pre> code block into a CodeFence node.
  *
  * This function attempts to parse the full `<pre><code>` block: a bare `<pre>` tag,
  * optionally followed by spaces/tabs and a `<code>` tag (bare or with a
  * `class="language-..."` attribute). The content up to the matching `</code></pre>`
- * is parsed as plain text and stored in a ::pltxt2htm::Code node.
+ * is parsed as plain text and stored in a ::pltxt2htm::CodeFence node.
  *
  * @tparam ndebug When set to Contracts::ignore, runtime assertions are disabled for performance.
  * @param[in] pltext Input text starting at "<pre>".
- * @return The parsed Code node and continuation index on success; nullopt on any deviation.
+ * @return The parsed CodeFence node and continuation index on success; nullopt on any deviation.
  * @note The `<pre>` tag must be bare (no attributes) and `<code>` must immediately
  *       follow it (allowing only spaces/tabs in between).
  */
@@ -3429,7 +3429,7 @@ constexpr auto try_parse_html_pre_code_block(::fast_io::u8string_view pltext) no
         ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, pos));
     pos += advance_count;
 
-    // <code class="language-..."> stores the full class value; Code stores only the suffix
+    // <code class="language-..."> stores the full class value; CodeFence stores only the suffix
     // after the "language-" prefix (the backends prepend it again when rendering).
     ::exception::optional<::fast_io::u8string> opt_lang{::exception::nullopt};
     if (language.has_value()) {
@@ -3437,7 +3437,7 @@ constexpr auto try_parse_html_pre_code_block(::fast_io::u8string_view pltext) no
         opt_lang = ::fast_io::u8string{full_language.data() + 9, full_language.data() + full_language.size()};
     }
     return ::pltxt2htm::details::TryParseMdCodeFenceResult<ndebug>{
-        .node = ::pltxt2htm::Code<ndebug>{::std::move(ast), ::std::move(opt_lang)}, .advance_count = pos};
+        .node = ::pltxt2htm::CodeFence<ndebug>{::std::move(ast), ::std::move(opt_lang)}, .advance_count = pos};
 }
 
 [[nodiscard]]
@@ -3512,7 +3512,7 @@ constexpr auto try_parse_md_code_fence_(::fast_io::u8string_view pltext) noexcep
                     opt_lang = ::std::move(lang);
                 }
                 return ::pltxt2htm::details::TryParseMdCodeFenceResult<ndebug>{
-                    .node = ::pltxt2htm::Code<ndebug>{::pltxt2htm::Ast<ndebug>{}, ::std::move(opt_lang)},
+                    .node = ::pltxt2htm::CodeFence<ndebug>{::pltxt2htm::Ast<ndebug>{}, ::std::move(opt_lang)},
                     .advance_count = current_index + 3,
                 };
             }
@@ -3578,7 +3578,7 @@ constexpr auto try_parse_md_code_fence_(::fast_io::u8string_view pltext) noexcep
         opt_lang = ::std::move(lang);
     }
     return ::pltxt2htm::details::TryParseMdCodeFenceResult<ndebug>{
-        .node = ::pltxt2htm::Code<ndebug>{::std::move(ast), ::std::move(opt_lang)}, .advance_count = current_index};
+        .node = ::pltxt2htm::CodeFence<ndebug>{::std::move(ast), ::std::move(opt_lang)}, .advance_count = current_index};
 }
 
 /**

--- a/include/pltxt2htm/experimental/html_parser.hh
+++ b/include/pltxt2htm/experimental/html_parser.hh
@@ -400,6 +400,18 @@ entry:
                 case u8'c':
                     [[fallthrough]];
                 case u8'C': {
+                    // parsing: inline <code>$1</code> element (renders like a Markdown code span,
+                    // no language/class support)
+                    if (auto opt_code_tag = ::pltxt2htm::details::try_parse_html_code_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                        opt_code_tag.has_value()) {
+                        auto&& [advance_count, subast] =
+                            opt_code_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += advance_count;
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                            ::pltxt2htm::MdCodeSpan1Backtick<ndebug>{::std::move(subast)}));
+                        continue;
+                    }
                     if (auto opt_tag_len = ::pltxt2htm::details::try_parse_caption_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
                             ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());

--- a/include/pltxt2htm/experimental/html_parser.hh
+++ b/include/pltxt2htm/experimental/html_parser.hh
@@ -400,17 +400,19 @@ entry:
                 case u8'c':
                     [[fallthrough]];
                 case u8'C': {
-                    // parsing: inline <code>$1</code> element (renders like a Markdown code span,
-                    // no language/class support)
-                    if (auto opt_code_tag = ::pltxt2htm::details::try_parse_html_code_tag<ndebug>(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
-                        opt_code_tag.has_value()) {
-                        auto&& [advance_count, subast] =
-                            opt_code_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-                        current_index += advance_count;
-                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                            ::pltxt2htm::MdCodeSpan1Backtick<ndebug>{::std::move(subast)}));
-                        continue;
+                    // parsing: <code>$1</code> inline element (no language/class support)
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"ode">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // parsing start tag <code> successed
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::html_code},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
                     }
                     if (auto opt_tag_len = ::pltxt2htm::details::try_parse_caption_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
@@ -978,6 +980,25 @@ entry:
                         ++current_index;
                         continue;
                     }
+                    case ::pltxt2htm::NodeKind::html_code: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"code">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlCode staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(
+                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlCode<ndebug>{::std::move(staged_node)}));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
                     case ::pltxt2htm::NodeKind::pl_u: {
                         if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"u">(
                                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
@@ -1386,6 +1407,10 @@ entry:
             }
             case ::pltxt2htm::NodeKind::html_del: {
                 parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlDel<ndebug>{::std::move(subast)}));
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_code: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlCode<ndebug>{::std::move(subast)}));
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::pl_u: {

--- a/include/pltxt2htm/experimental/html_parser.hh
+++ b/include/pltxt2htm/experimental/html_parser.hh
@@ -53,6 +53,16 @@ constexpr auto find_next_block_after_line_break(
             current_index += opt_hr_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
             continue;
         }
+        // Check for an HTML <pre><code>...</code></pre> code block at a block position.
+        if (auto opt_pre_code_block = ::pltxt2htm::details::try_parse_html_pre_code_block<ndebug>(
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+            opt_pre_code_block.has_value()) {
+            auto&& [node, advance_count] =
+                opt_pre_code_block.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+            result.push_back(::std::move(node));
+            return ::pltxt2htm::experimental::details::FindNextBlockAfterLineBreakResult{
+                .advance_count = current_index + advance_count, .new_frame_been_pushed_into_call_stack = false};
+        }
         if (auto opt_p_tag = ::pltxt2htm::details::try_parse_p_tag<ndebug>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
             opt_p_tag.has_value()) {
@@ -390,22 +400,6 @@ entry:
                 case u8'c':
                     [[fallthrough]];
                 case u8'C': {
-                    if (auto opt_code_tag = ::pltxt2htm::details::try_parse_code_tag<ndebug>(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_code_tag.has_value()) {
-                        // parsing html <code> tag (bare or with class="language-...")
-                        auto&& [tag_len, lang] =
-                            opt_code_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-                        current_index += tag_len + 2;
-                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithHtmlCodeInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
-                                    ::std::move(lang)},
-                                ::pltxt2htm::NodeKind::html_code},
-                            ::pltxt2htm::Ast<ndebug>{}));
-                        goto entry;
-                    }
                     if (auto opt_tag_len = ::pltxt2htm::details::try_parse_caption_tag<ndebug>(
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
                             ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
@@ -551,18 +545,6 @@ entry:
                 case u8'p':
                     [[fallthrough]];
                 case u8'P': {
-                    if (auto opt_pre_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"re">(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                        opt_pre_tag_len.has_value()) {
-                        current_index += opt_pre_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
-                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
-                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
-                                ::pltxt2htm::NodeKind::html_pre},
-                            ::pltxt2htm::Ast<ndebug>{}));
-                        goto entry;
-                    }
                     result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
                     ++current_index;
                     continue;
@@ -1122,46 +1104,6 @@ entry:
                         ++current_index;
                         continue;
                     }
-                    case ::pltxt2htm::NodeKind::html_code: {
-                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"code">(
-                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                            opt_tag_len.has_value()) {
-                            ::std::size_t const staged_index{current_index};
-                            auto& code_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                            ::pltxt2htm::HtmlCode staged_node(::std::move(result),
-                                                              ::std::move(code_frame.get_html_code_language()));
-                            call_stack.pop();
-                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                                ::pltxt2htm::HtmlCode<ndebug>{::std::move(staged_node)}));
-                            parent_frame.current_index +=
-                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
-                                3;
-                            goto entry;
-                        }
-                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
-                        ++current_index;
-                        continue;
-                    }
-                    case ::pltxt2htm::NodeKind::html_pre: {
-                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"pre">(
-                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
-                            opt_tag_len.has_value()) {
-                            ::std::size_t const staged_index{current_index};
-                            ::pltxt2htm::HtmlPre staged_node(::std::move(result));
-                            call_stack.pop();
-                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                            parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlPre<ndebug>{::std::move(staged_node)}));
-                            parent_frame.current_index +=
-                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
-                                3;
-                            goto entry;
-                        }
-                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
-                        ++current_index;
-                        continue;
-                    }
                     case ::pltxt2htm::NodeKind::html_blockquote: {
                         if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"blockquote">(
                                 ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
@@ -1472,15 +1414,6 @@ entry:
             }
             case ::pltxt2htm::NodeKind::list_li: {
                 parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::ListLi<ndebug>{::std::move(subast)}));
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::html_code: {
-                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
-                    ::pltxt2htm::HtmlCode<ndebug>{::std::move(subast), ::std::move(frame.get_html_code_language())}));
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::html_pre: {
-                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlPre<ndebug>{::std::move(subast)}));
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_blockquote: {

--- a/include/pltxt2htm/experimental/html_parser.hh
+++ b/include/pltxt2htm/experimental/html_parser.hh
@@ -515,15 +515,6 @@ entry:
                     continue;
                 }
 
-                case u8'l':
-                    [[fallthrough]];
-                case u8'L': {
-                    // <li> is only valid inside a block-level <ul>/<ol>; elsewhere it is literal.
-                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
-                    ++current_index;
-                    continue;
-                }
-
                 case u8'm':
                     [[fallthrough]];
                 case u8'M': {
@@ -542,23 +533,6 @@ entry:
                             ::pltxt2htm::Ast<ndebug>{}));
                         goto entry;
                     }
-                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
-                    ++current_index;
-                    continue;
-                }
-
-                case u8'o':
-                    [[fallthrough]];
-                case u8'O': {
-                    // <ol> is a block-level list; inline occurrences are plain literal text.
-                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
-                    ++current_index;
-                    continue;
-                }
-
-                case u8'p':
-                    [[fallthrough]];
-                case u8'P': {
                     result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
                     ++current_index;
                     continue;

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -1088,6 +1088,25 @@ entry:
                 ++current_iter;
                 continue;
             }
+            case ::pltxt2htm::NodeKind::html_code: {
+                auto&& nested_tag_type = ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type();
+                auto&& subast = node.as_html_code().get_subast();
+                bool const is_different_tag{nested_tag_type != ::pltxt2htm::NodeKind::html_code};
+                if (is_different_tag) {
+                    if (subast.empty()) {
+                        ast.erase(current_iter);
+                        continue;
+                    }
+                    call_stack.push(
+                        ::pltxt2htm::details::OptimizerFrameContext<typename ::pltxt2htm::Ast<ndebug>::iterator,
+                                                                    ndebug>(
+                            ::std::addressof(subast), ::pltxt2htm::NodeKind::html_code, subast.begin()));
+                    goto entry;
+                }
+                node = ::pltxt2htm::PlTxtNode<ndebug>{::pltxt2htm::Text<ndebug>{::std::move(subast)}};
+                ++current_iter;
+                continue;
+            }
             case ::pltxt2htm::NodeKind::html_mark: {
                 auto&& nested_tag_type = ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type();
                 auto&& subast = node.as_html_mark().get_subast();

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -1322,20 +1322,6 @@ entry:
                         ::std::addressof(subast), ::pltxt2htm::NodeKind::md_code_span_3_backtick, subast.begin()));
                 goto entry;
             }
-            case ::pltxt2htm::NodeKind::html_code: {
-                auto&& subast = node.as_html_code().get_subast();
-                call_stack.push(
-                    ::pltxt2htm::details::OptimizerFrameContext<typename ::pltxt2htm::Ast<ndebug>::iterator, ndebug>(
-                        ::std::addressof(subast), ::pltxt2htm::NodeKind::html_code, subast.begin()));
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::html_pre: {
-                auto&& subast = node.as_html_pre().get_subast();
-                call_stack.push(
-                    ::pltxt2htm::details::OptimizerFrameContext<typename ::pltxt2htm::Ast<ndebug>::iterator, ndebug>(
-                        ::std::addressof(subast), ::pltxt2htm::NodeKind::html_pre, subast.begin()));
-                goto entry;
-            }
             case ::pltxt2htm::NodeKind::html_blockquote: {
                 auto&& subast = node.as_html_blockquote().get_subast();
                 call_stack.push(

--- a/include/pltxt2htm/optimizer.hh
+++ b/include/pltxt2htm/optimizer.hh
@@ -1582,7 +1582,7 @@ entry:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::md_escape_tilde:
                 [[fallthrough]];
-            case ::pltxt2htm::NodeKind::code: {
+            case ::pltxt2htm::NodeKind::code_fence: {
                 ++current_iter;
                 continue;
             }

--- a/tests/test_ast_operator_eq.cc
+++ b/tests/test_ast_operator_eq.cc
@@ -179,7 +179,7 @@ int main() {
         ::exception::assert_true<false>(a == b);
     }
 
-    // Code without language
+    // CodeFence without language
     {
         ::pltxt2htm::Ast<nd::quick_enforce> ast_a{};
         ast_a.emplace_back(::pltxt2htm::U8Char{u8'a'});
@@ -187,14 +187,14 @@ int main() {
         ::pltxt2htm::Ast<nd::quick_enforce> ast_b{};
         ast_b.emplace_back(::pltxt2htm::U8Char{u8'a'});
 
-        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Code<nd::quick_enforce>(
+        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::CodeFence<nd::quick_enforce>(
             ::std::move(ast_a), ::exception::optional<::fast_io::u8string>(::exception::nullopt)));
-        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Code<nd::quick_enforce>(
+        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::CodeFence<nd::quick_enforce>(
             ::std::move(ast_b), ::exception::optional<::fast_io::u8string>(::exception::nullopt)));
         ::exception::assert_true<false>(a == b);
     }
 
-    // Code with same language
+    // CodeFence with same language
     {
         ::pltxt2htm::Ast<nd::quick_enforce> ast_a{};
         ast_a.emplace_back(::pltxt2htm::U8Char{u8'a'});
@@ -202,14 +202,14 @@ int main() {
         ::pltxt2htm::Ast<nd::quick_enforce> ast_b{};
         ast_b.emplace_back(::pltxt2htm::U8Char{u8'a'});
 
-        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Code<nd::quick_enforce>(
+        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::CodeFence<nd::quick_enforce>(
             ::std::move(ast_a), ::exception::optional<::fast_io::u8string>(::fast_io::u8string{u8"cpp"})));
-        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Code<nd::quick_enforce>(
+        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::CodeFence<nd::quick_enforce>(
             ::std::move(ast_b), ::exception::optional<::fast_io::u8string>(::fast_io::u8string{u8"cpp"})));
         ::exception::assert_true<false>(a == b);
     }
 
-    // Code with different languages
+    // CodeFence with different languages
     {
         ::pltxt2htm::Ast<nd::quick_enforce> ast_a{};
         ast_a.emplace_back(::pltxt2htm::U8Char{u8'a'});
@@ -217,74 +217,74 @@ int main() {
         ::pltxt2htm::Ast<nd::quick_enforce> ast_b{};
         ast_b.emplace_back(::pltxt2htm::U8Char{u8'a'});
 
-        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Code<nd::quick_enforce>(
+        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::CodeFence<nd::quick_enforce>(
             ::std::move(ast_a), ::exception::optional<::fast_io::u8string>(::fast_io::u8string{u8"cpp"})));
-        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Code<nd::quick_enforce>(
+        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::CodeFence<nd::quick_enforce>(
             ::std::move(ast_b), ::exception::optional<::fast_io::u8string>(::fast_io::u8string{u8"python"})));
         ::exception::assert_false<false>(a == b);
     }
 
-    // Code: one has language, other does not
+    // CodeFence: one has language, the other does not
     {
         ::pltxt2htm::Ast<nd::quick_enforce> ast_a{};
 
         ::pltxt2htm::Ast<nd::quick_enforce> ast_b{};
 
-        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Code<nd::quick_enforce>(
+        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::CodeFence<nd::quick_enforce>(
             ::std::move(ast_a), ::exception::optional<::fast_io::u8string>(::fast_io::u8string{u8"cpp"})));
-        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Code<nd::quick_enforce>(
+        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::CodeFence<nd::quick_enforce>(
             ::std::move(ast_b), ::exception::optional<::fast_io::u8string>(::exception::nullopt)));
         ::exception::assert_false<false>(a == b);
     }
 
-    // Code without language
+    // CodeFence without language
     {
         ::pltxt2htm::Ast<nd::quick_enforce> ast_a{};
 
         ::pltxt2htm::Ast<nd::quick_enforce> ast_b{};
 
-        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Code<nd::quick_enforce>(
+        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::CodeFence<nd::quick_enforce>(
             ::std::move(ast_a), ::exception::optional<::fast_io::u8string>(::exception::nullopt)));
-        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Code<nd::quick_enforce>(
+        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::CodeFence<nd::quick_enforce>(
             ::std::move(ast_b), ::exception::optional<::fast_io::u8string>(::exception::nullopt)));
         ::exception::assert_true<false>(a == b);
     }
 
-    // Code with same language
+    // CodeFence with same language
     {
         ::pltxt2htm::Ast<nd::quick_enforce> ast_a{};
 
         ::pltxt2htm::Ast<nd::quick_enforce> ast_b{};
 
-        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Code<nd::quick_enforce>(
+        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::CodeFence<nd::quick_enforce>(
             ::std::move(ast_a), ::exception::optional<::fast_io::u8string>(::fast_io::u8string{u8"cpp"})));
-        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Code<nd::quick_enforce>(
+        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::CodeFence<nd::quick_enforce>(
             ::std::move(ast_b), ::exception::optional<::fast_io::u8string>(::fast_io::u8string{u8"cpp"})));
         ::exception::assert_true<false>(a == b);
     }
 
-    // Code with different languages
+    // CodeFence with different languages
     {
         ::pltxt2htm::Ast<nd::quick_enforce> ast_a{};
 
         ::pltxt2htm::Ast<nd::quick_enforce> ast_b{};
 
-        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Code<nd::quick_enforce>(
+        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::CodeFence<nd::quick_enforce>(
             ::std::move(ast_a), ::exception::optional<::fast_io::u8string>(::fast_io::u8string{u8"cpp"})));
-        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Code<nd::quick_enforce>(
+        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::CodeFence<nd::quick_enforce>(
             ::std::move(ast_b), ::exception::optional<::fast_io::u8string>(::fast_io::u8string{u8"python"})));
         ::exception::assert_false<false>(a == b);
     }
 
-    // Code: one has language, other does not
+    // CodeFence: one has language, the other does not
     {
         ::pltxt2htm::Ast<nd::quick_enforce> ast_a{};
 
         ::pltxt2htm::Ast<nd::quick_enforce> ast_b{};
 
-        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Code<nd::quick_enforce>(
+        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::CodeFence<nd::quick_enforce>(
             ::std::move(ast_a), ::exception::optional<::fast_io::u8string>(::fast_io::u8string{u8"cpp"})));
-        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Code<nd::quick_enforce>(
+        auto const b = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::CodeFence<nd::quick_enforce>(
             ::std::move(ast_b), ::exception::optional<::fast_io::u8string>(::exception::nullopt)));
         ::exception::assert_false<false>(a == b);
     }
@@ -652,7 +652,7 @@ int main() {
 
         ::pltxt2htm::Ast<nd::quick_enforce> ast_b{};
 
-        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Code<nd::quick_enforce>(
+        auto const a = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::CodeFence<nd::quick_enforce>(
             ::std::move(ast_a), ::exception::optional<::fast_io::u8string>(::fast_io::u8string{u8"cpp"})));
         auto const b =
             ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Text<nd::quick_enforce>(::std::move(ast_b)));

--- a/tests/test_common_parser.cc
+++ b/tests/test_common_parser.cc
@@ -237,8 +237,8 @@ int main() {
     {
         auto html =
             ::pltxt2htm_test::pltxt2common_htmld(u8"<code>code</code><pre>pre</pre><blockquote>quote</blockquote>");
-        auto answer = ::fast_io::u8string_view{
-            u8"&lt;code&gt;code&lt;/code&gt;&lt;pre&gt;pre&lt;/pre&gt;&lt;blockquote&gt;quote&lt;/blockquote&gt;"};
+        auto answer =
+            ::fast_io::u8string_view{u8"code&lt;pre&gt;pre&lt;/pre&gt;&lt;blockquote&gt;quote&lt;/blockquote&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_common_parser.cc
+++ b/tests/test_common_parser.cc
@@ -237,7 +237,8 @@ int main() {
     {
         auto html =
             ::pltxt2htm_test::pltxt2common_htmld(u8"<code>code</code><pre>pre</pre><blockquote>quote</blockquote>");
-        auto answer = ::fast_io::u8string_view{u8"codepre&lt;blockquote&gt;quote&lt;/blockquote&gt;"};
+        auto answer = ::fast_io::u8string_view{
+            u8"&lt;code&gt;code&lt;/code&gt;&lt;pre&gt;pre&lt;/pre&gt;&lt;blockquote&gt;quote&lt;/blockquote&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_deep_copy.cc
+++ b/tests/test_deep_copy.cc
@@ -80,12 +80,12 @@ int main() {
         ::exception::assert_true<false>(original == copy);
     }
 
-    // Copy of a node with optional language (Code)
+    // Copy of a node with optional language (CodeFence)
     {
         ::pltxt2htm::Ast<nd::quick_enforce> ast{};
         ast.emplace_back(::pltxt2htm::U8Char{u8'x'});
 
-        auto const original = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::Code<nd::quick_enforce>(
+        auto const original = ::pltxt2htm::PlTxtNode<nd::quick_enforce>(::pltxt2htm::CodeFence<nd::quick_enforce>(
             ::std::move(ast), ::exception::optional<::fast_io::u8string>(::fast_io::u8string{u8"cpp"})));
 
         auto const copy = original;

--- a/tests/test_html_code_tag.cc
+++ b/tests/test_html_code_tag.cc
@@ -1,44 +1,44 @@
 #include "precompile.hh"
 
 int main() {
-    // bare <code> renders as an inline code span (same as Markdown code span)
+    // bare <code> renders as an inline <code> element (like other inline HTML tags)
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code>text</code>");
         auto answer = ::fast_io::u8string_view{u8"<code>text</code>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
-    // opening tag allows spaces before '>'; the closing tag must be exactly </code> (case-insensitive)
+    // opening and closing tags allow spaces before '>' (case-insensitive)
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<CODE    >text</CODE  >");
-        auto answer = ::fast_io::u8string_view{u8"<code>text&lt;/CODE&nbsp;&nbsp;&gt;</code>"};
+        auto answer = ::fast_io::u8string_view{u8"<code>text</code>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
-    // content is parsed as plain text (no nested inline tags, like a code span)
+    // content is parsed as inline markup (nested tags are processed normally)
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code><color=red>text</color></code>");
-        auto answer = ::fast_io::u8string_view{u8"<code>&lt;color=red&gt;text&lt;/color&gt;</code>"};
+        auto answer = ::fast_io::u8string_view{u8"<code><span style=\"color:red;\">text</span></code>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code><color=red>text</code></color>");
-        auto answer = ::fast_io::u8string_view{u8"<code>&lt;color=red&gt;text</code>&lt;/color&gt;"};
+        auto answer = ::fast_io::u8string_view{u8"<code><span style=\"color:red;\">text&lt;/code&gt;</span></code>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
-    // the first </code> closes the span; nested <code> is treated as literal text
+    // nested <code> is flattened (same-tag optimization, like other inline HTML tags)
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code>text<code>text</code></code>");
-        auto answer = ::fast_io::u8string_view{u8"<code>text&lt;code&gt;text</code>&lt;/code&gt;"};
+        auto answer = ::fast_io::u8string_view{u8"<code>texttext</code>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
-    // unclosed <code> auto-closes at end of input
+    // unclosed <code> auto-closes at end of input; empty content is dropped
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code>");
-        auto answer = ::fast_io::u8string_view{u8"<code></code>"};
+        auto answer = ::fast_io::u8string_view{u8""};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -49,9 +49,10 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
     }
 
+    // empty <code></code> is dropped
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"t<code></code>t");
-        auto answer = ::fast_io::u8string_view{u8"t<code></code>t"};
+        auto answer = ::fast_io::u8string_view{u8"tt"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_html_code_tag.cc
+++ b/tests/test_html_code_tag.cc
@@ -1,42 +1,48 @@
 #include "precompile.hh"
 
 int main() {
+    // bare <code> renders as an inline code span (same as Markdown code span)
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code>text</code>");
-        auto answer = ::fast_io::u8string_view{u8"&lt;code&gt;text&lt;/code&gt;"};
+        auto answer = ::fast_io::u8string_view{u8"<code>text</code>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
+    // opening tag allows spaces before '>'; the closing tag must be exactly </code> (case-insensitive)
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<CODE    >text</CODE  >");
-        auto answer = ::fast_io::u8string_view{u8"&lt;CODE&nbsp;&nbsp;&nbsp;&nbsp;&gt;text&lt;/CODE&nbsp;&nbsp;&gt;"};
+        auto answer = ::fast_io::u8string_view{u8"<code>text&lt;/CODE&nbsp;&nbsp;&gt;</code>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
+    // content is parsed as plain text (no nested inline tags, like a code span)
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code><color=red>text</color></code>");
-        auto answer = ::fast_io::u8string_view{u8"&lt;code&gt;<span style=\"color:red;\">text</span>&lt;/code&gt;"};
+        auto answer = ::fast_io::u8string_view{u8"<code>&lt;color=red&gt;text&lt;/color&gt;</code>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code><color=red>text</code></color>");
-        auto answer = ::fast_io::u8string_view{u8"&lt;code&gt;<span style=\"color:red;\">text&lt;/code&gt;</span>"};
+        auto answer = ::fast_io::u8string_view{u8"<code>&lt;color=red&gt;text</code>&lt;/color&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
+    // the first </code> closes the span; nested <code> is treated as literal text
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code>text<code>text</code></code>");
-        auto answer = ::fast_io::u8string_view{u8"&lt;code&gt;text&lt;code&gt;text&lt;/code&gt;&lt;/code&gt;"};
+        auto answer = ::fast_io::u8string_view{u8"<code>text&lt;code&gt;text</code>&lt;/code&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
+    // unclosed <code> auto-closes at end of input
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code>");
-        auto answer = ::fast_io::u8string_view{u8"&lt;code&gt;"};
+        auto answer = ::fast_io::u8string_view{u8"<code></code>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
+    // incomplete <code (no '>') stays literal escaped text
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code");
         auto answer = ::fast_io::u8string_view{u8"&lt;code"};
@@ -45,7 +51,7 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"t<code></code>t");
-        auto answer = ::fast_io::u8string_view{u8"t&lt;code&gt;&lt;/code&gt;t"};
+        auto answer = ::fast_io::u8string_view{u8"t<code></code>t"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -105,9 +111,7 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"ab<code>test</code>cd");
-        auto answer = ::fast_io::u8string_view{
-            u8"ab<size=20>\uff1c</size>code<size=20>\uff1e</size>test<size=20>\uff1c</size>/code<size=20>\uff1e</"
-            u8"size>cd"};
+        auto answer = ::fast_io::u8string_view{u8"ab<font=\"PhysicsLab-NerdFont SDF\"> test </font>cd"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_html_code_tag.cc
+++ b/tests/test_html_code_tag.cc
@@ -3,37 +3,37 @@
 int main() {
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code>text</code>");
-        auto answer = ::fast_io::u8string_view{u8"<code>text</code>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;code&gt;text&lt;/code&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<CODE    >text</CODE  >");
-        auto answer = ::fast_io::u8string_view{u8"<code>text</code>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;CODE&nbsp;&nbsp;&nbsp;&nbsp;&gt;text&lt;/CODE&nbsp;&nbsp;&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code><color=red>text</color></code>");
-        auto answer = ::fast_io::u8string_view{u8"<code><span style=\"color:red;\">text</span></code>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;code&gt;<span style=\"color:red;\">text</span>&lt;/code&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code><color=red>text</code></color>");
-        auto answer = ::fast_io::u8string_view{u8"<code><span style=\"color:red;\">text&lt;/code&gt;</span></code>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;code&gt;<span style=\"color:red;\">text&lt;/code&gt;</span>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code>text<code>text</code></code>");
-        auto answer = ::fast_io::u8string_view{u8"<code>text<code>text</code></code>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;code&gt;text&lt;code&gt;text&lt;/code&gt;&lt;/code&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code>");
-        auto answer = ::fast_io::u8string_view{u8"<code></code>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;code&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -45,24 +45,24 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"t<code></code>t");
-        auto answer = ::fast_io::u8string_view{u8"t<code></code>t"};
+        auto answer = ::fast_io::u8string_view{u8"t&lt;code&gt;&lt;/code&gt;t"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
-    // --- <code class="language-..."> tests ---
+    // --- standalone <code class="language-..."> stays literal escaped text ---
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code class=\"language-bash\">echo</code>");
-        auto answer = ::fast_io::u8string_view{u8"<code class=\"language-bash\">echo</code>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;code&nbsp;class=&quot;language-bash&quot;&gt;echo&lt;/code&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code class=\"language-cpp\">fn()</code>");
-        auto answer = ::fast_io::u8string_view{u8"<code class=\"language-cpp\">fn()</code>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;code&nbsp;class=&quot;language-cpp&quot;&gt;fn()&lt;/code&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code class='language-c++'>fn()</code>");
-        auto answer = ::fast_io::u8string_view{u8"<code class=\"language-c++\">fn()</code>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;code&nbsp;class=&apos;language-c++&apos;&gt;fn()&lt;/code&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
     // case-sensitive: Language- vs language-
@@ -83,19 +83,19 @@ int main() {
         auto answer = ::fast_io::u8string_view{u8"&lt;code&nbsp;class=&quot;&quot;&gt;echo&lt;/code&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
-    // unknown attribute (style) — should fall back
+    // unknown attribute (style)
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code style=\"color:red\">echo</code>");
         auto answer = ::fast_io::u8string_view{u8"&lt;code&nbsp;style=&quot;color:red&quot;&gt;echo&lt;/code&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
-    // language- with empty language suffix — should fall back
+    // language- with empty language suffix
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code class=\"language-\">echo</code>");
         auto answer = ::fast_io::u8string_view{u8"&lt;code&nbsp;class=&quot;language-&quot;&gt;echo&lt;/code&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
-    // reject language suffix characters that can break out of the class attribute
+    // attribute injection attempts stay escaped
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<code class='language-\" onmouseover=\"alert(1)'>x</code>");
         auto answer = ::fast_io::u8string_view{
@@ -114,8 +114,8 @@ int main() {
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"<code class=\"language-cpp\">code</code>");
         auto answer = ::fast_io::u8string_view{
-            u8"<size=20>\uff1c</size>code class=\"language-cpp\"<size=20>\uff1e</size>code<size=20>\uff1c</size>/code"
-            u8"<size=20>\uff1e</size>"};
+            u8"<size=20>\uff1c</size>code\u00A0class=\"language-cpp\"<size=20>\uff1e</size>code<size=20>\uff1c</size>/"
+            u8"code<size=20>\uff1e</size>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_html_parser.cc
+++ b/tests/test_html_parser.cc
@@ -104,12 +104,27 @@ int main() {
     }
     {
         auto html = ::pltxt2htm_test::pltxt4htmlunittest(u8"<code>code</code>");
-        auto answer = ::fast_io::u8string_view{u8"<code>code</code>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;code&gt;code&lt;/code&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
     {
         auto html = ::pltxt2htm_test::pltxt4htmlunittest(u8"<pre>pre</pre>");
-        auto answer = ::fast_io::u8string_view{u8"<pre>pre</pre>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;pre&gt;pre&lt;/pre&gt;"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4htmlunittest(u8"<pre><code>code</code></pre>");
+        auto answer = ::fast_io::u8string_view{u8"<pre><code>code</code></pre>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4htmlunittest(u8"<pre><code class=\"language-cpp\">int x;</code></pre>");
+        auto answer = ::fast_io::u8string_view{u8"<pre><code class=\"language-cpp\">int&nbsp;x;</code></pre>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4htmlunittest(u8"ab<pre><code>c</code></pre>de");
+        auto answer = ::fast_io::u8string_view{u8"ab&lt;pre&gt;&lt;code&gt;c&lt;/code&gt;&lt;/pre&gt;de"};
         pltxt2htm_test_assert_equal(html, answer);
     }
     {
@@ -317,7 +332,7 @@ int main() {
             u8"<p><span style=\"color:red\"><a href=\"https://example.com\"><code>text");
         auto answer = ::fast_io::u8string_view{
             u8"<p style=\"text-align:left\"><span style=\"color:red;\"><a "
-            u8"href=\"https://example.com\"><code>text</code></a></span></p>"};
+            u8"href=\"https://example.com\">&lt;code&gt;text</a></span></p>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -335,7 +350,7 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt4htmlunittest(u8"<del><pre>text");
-        auto answer = ::fast_io::u8string_view{u8"<del><pre>text</pre></del>"};
+        auto answer = ::fast_io::u8string_view{u8"<del>&lt;pre&gt;text</del>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -392,8 +407,8 @@ int main() {
             u8"style=\"text-align:left\">&lt;/x&gt;</p><h1>&lt;/x&gt;</h1><h2>&lt;/x&gt;</h2><h3>&lt;/x&gt;</"
             u8"h3><h4>&lt;/x&gt;</h4>"
             u8"<h5>&lt;/x&gt;</h5><h6>&lt;/x&gt;</h6><del>&lt;/x&gt;</del><em>&lt;/x&gt;</em>"
-            u8"<strong>&lt;/x&gt;</strong><code>&lt;/x&gt;</code><pre>&lt;/x&gt;</pre>"
-            u8"<blockquote>&lt;/x&gt;</blockquote>"};
+            u8"<strong>&lt;/x&gt;</strong>&lt;code&gt;&lt;/x&gt;&lt;/code&gt;&lt;pre&gt;&lt;/x&gt;&lt;/pre&gt;"
+            u8"&lt;blockquote&gt;&lt;/x&gt;&lt;/blockquote&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_html_parser.cc
+++ b/tests/test_html_parser.cc
@@ -104,7 +104,7 @@ int main() {
     }
     {
         auto html = ::pltxt2htm_test::pltxt4htmlunittest(u8"<code>code</code>");
-        auto answer = ::fast_io::u8string_view{u8"&lt;code&gt;code&lt;/code&gt;"};
+        auto answer = ::fast_io::u8string_view{u8"<code>code</code>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
     {
@@ -124,7 +124,7 @@ int main() {
     }
     {
         auto html = ::pltxt2htm_test::pltxt4htmlunittest(u8"ab<pre><code>c</code></pre>de");
-        auto answer = ::fast_io::u8string_view{u8"ab&lt;pre&gt;&lt;code&gt;c&lt;/code&gt;&lt;/pre&gt;de"};
+        auto answer = ::fast_io::u8string_view{u8"ab&lt;pre&gt;<code>c</code>&lt;/pre&gt;de"};
         pltxt2htm_test_assert_equal(html, answer);
     }
     {
@@ -332,7 +332,7 @@ int main() {
             u8"<p><span style=\"color:red\"><a href=\"https://example.com\"><code>text");
         auto answer = ::fast_io::u8string_view{
             u8"<p style=\"text-align:left\"><span style=\"color:red;\"><a "
-            u8"href=\"https://example.com\">&lt;code&gt;text</a></span></p>"};
+            u8"href=\"https://example.com\"><code>text</code></a></span></p>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -407,7 +407,7 @@ int main() {
             u8"style=\"text-align:left\">&lt;/x&gt;</p><h1>&lt;/x&gt;</h1><h2>&lt;/x&gt;</h2><h3>&lt;/x&gt;</"
             u8"h3><h4>&lt;/x&gt;</h4>"
             u8"<h5>&lt;/x&gt;</h5><h6>&lt;/x&gt;</h6><del>&lt;/x&gt;</del><em>&lt;/x&gt;</em>"
-            u8"<strong>&lt;/x&gt;</strong>&lt;code&gt;&lt;/x&gt;&lt;/code&gt;&lt;pre&gt;&lt;/x&gt;&lt;/pre&gt;"
+            u8"<strong>&lt;/x&gt;</strong><code>&lt;/x&gt;</code>&lt;pre&gt;&lt;/x&gt;&lt;/pre&gt;"
             u8"&lt;blockquote&gt;&lt;/x&gt;&lt;/blockquote&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }

--- a/tests/test_html_pre_tag.cc
+++ b/tests/test_html_pre_tag.cc
@@ -1,10 +1,11 @@
 #include "precompile.hh"
 
 int main() {
+    // bare <pre> is literal escaped text now
     {
         auto pltext = ::fast_io::u8string_view{u8"<pre>text</pre>"};
         auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
-        auto answer = ::fast_io::u8string_view{u8"<pre>text</pre>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;pre&gt;text&lt;/pre&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
         auto plunity_richtext_answer = ::fast_io::u8string_view{
@@ -12,7 +13,7 @@ int main() {
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
-    // <pre><code> renders as a NerdFont code block (same as markdown code fence)
+    // <pre><code> renders as a code block (same as markdown code fence)
     {
         auto pltext = ::fast_io::u8string_view{u8"<pre><code>test</code></pre>"};
         auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
@@ -45,11 +46,11 @@ int main() {
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
-    // <pre> wrapping anything other than a lone <code> keeps the escaped passthrough form
+    // <pre> wrapping anything other than <code> is literal escaped text
     {
         auto pltext = ::fast_io::u8string_view{u8"<pre><b>bold</b></pre>"};
         auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
-        auto answer = ::fast_io::u8string_view{u8"<pre><strong>bold</strong></pre>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;pre&gt;<strong>bold</strong>&lt;/pre&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
         auto plunity_richtext_answer = ::fast_io::u8string_view{
@@ -58,11 +59,11 @@ int main() {
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
-    // <pre>\n<code> (whitespace before code) is NOT a lone-code pre -> escaped form
+    // <pre>\n<code> (newline before code) is NOT a code block -> literal escaped form
     {
         auto pltext = ::fast_io::u8string_view{u8"<pre>\n<code>test</code>\n</pre>"};
         auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
-        auto answer = ::fast_io::u8string_view{u8"<pre>\n<code>test</code>\n</pre>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;pre&gt;<br>&lt;code&gt;test&lt;/code&gt;<br>&lt;/pre&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
         auto plunity_richtext_answer = ::fast_io::u8string_view{
@@ -74,31 +75,31 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<PRE    >text</PRE  >");
-        auto answer = ::fast_io::u8string_view{u8"<pre>text</pre>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;PRE&nbsp;&nbsp;&nbsp;&nbsp;&gt;text&lt;/PRE&nbsp;&nbsp;&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<pre><color=red>text</color></pre>");
-        auto answer = ::fast_io::u8string_view{u8"<pre><span style=\"color:red;\">text</span></pre>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;pre&gt;<span style=\"color:red;\">text</span>&lt;/pre&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<pre><color=red>text</pre></color>");
-        auto answer = ::fast_io::u8string_view{u8"<pre><span style=\"color:red;\">text&lt;/pre&gt;</span></pre>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;pre&gt;<span style=\"color:red;\">text&lt;/pre&gt;</span>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<pre>text<pre>text</pre></pre>");
-        auto answer = ::fast_io::u8string_view{u8"<pre>text<pre>text</pre></pre>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;pre&gt;text&lt;pre&gt;text&lt;/pre&gt;&lt;/pre&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<pre>");
-        auto answer = ::fast_io::u8string_view{u8"<pre></pre>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;pre&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -110,35 +111,56 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"t<pre></pre>t");
-        auto answer = ::fast_io::u8string_view{u8"t<pre></pre>t"};
+        auto answer = ::fast_io::u8string_view{u8"t&lt;pre&gt;&lt;/pre&gt;t"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
-    // \n inside <pre> should be preserved as \n, not converted to <br>
+    // \n inside a bare <pre> becomes <br> (literal text)
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<pre>line1\nline2</pre>");
-        auto answer = ::fast_io::u8string_view{u8"<pre>line1\nline2</pre>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;pre&gt;line1<br>line2&lt;/pre&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
-    // \n inside <pre><code> should also preserve \n
+    // \n inside <pre><code> is preserved as \n
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<pre><code>line1\nline2</code></pre>");
         auto answer = ::fast_io::u8string_view{u8"<pre><code>line1\nline2</code></pre>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
-    // \n inside <pre><color> should preserve \n
+    // \n inside literal-escaped <pre><color> becomes <br>
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<pre><color=red>line1\nline2</color></pre>");
-        auto answer = ::fast_io::u8string_view{u8"<pre><span style=\"color:red;\">line1\nline2</span></pre>"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;pre&gt;<span style=\"color:red;\">line1<br>line2</span>&lt;/pre&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
-    // \n outside <pre> should still become <br>
+    // \n outside <pre> still becomes <br>
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"line1\nline2");
         auto answer = ::fast_io::u8string_view{u8"line1<br>line2"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    // inline <pre><code> mid-text is literal escaped text
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"ab<pre><code>c</code></pre>de");
+        auto answer = ::fast_io::u8string_view{u8"ab&lt;pre&gt;&lt;code&gt;c&lt;/code&gt;&lt;/pre&gt;de"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    // <pre><code> after a line break is a code block
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"x\n<pre><code>c</code></pre>");
+        auto answer = ::fast_io::u8string_view{u8"x<br><pre><code>c</code></pre>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    // spaces/tabs between <pre> and <code> are allowed
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<pre>  <code>c</code></pre>");
+        auto answer = ::fast_io::u8string_view{u8"<pre><code>c</code></pre>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_html_pre_tag.cc
+++ b/tests/test_html_pre_tag.cc
@@ -59,16 +59,16 @@ int main() {
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
 
-    // <pre>\n<code> (newline before code) is NOT a code block -> literal escaped form
+    // <pre>\n<code> (newline before code) is NOT a code block: <pre> is literal, <code> is an inline code span
     {
         auto pltext = ::fast_io::u8string_view{u8"<pre>\n<code>test</code>\n</pre>"};
         auto html = ::pltxt2htm_test::pltxt4unittest(pltext);
-        auto answer = ::fast_io::u8string_view{u8"&lt;pre&gt;<br>&lt;code&gt;test&lt;/code&gt;<br>&lt;/pre&gt;"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;pre&gt;<br><code>test</code><br>&lt;/pre&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
         auto plunity_richtext = ::pltxt2htm_test::pltxt2plunity_introduction(pltext);
         auto plunity_richtext_answer = ::fast_io::u8string_view{
             u8"<size=20>\uff1c</size>pre<size=20>\uff1e</size>\n"
-            u8"<size=20>\uff1c</size>code<size=20>\uff1e</size>test<size=20>\uff1c</size>/code<size=20>\uff1e</size>\n"
+            u8"<font=\"PhysicsLab-NerdFont SDF\"> test </font>\n"
             u8"<size=20>\uff1c</size>/pre<size=20>\uff1e</size>"};
         pltxt2htm_test_assert_equal(plunity_richtext, plunity_richtext_answer);
     }
@@ -132,7 +132,8 @@ int main() {
     // \n inside literal-escaped <pre><color> becomes <br>
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<pre><color=red>line1\nline2</color></pre>");
-        auto answer = ::fast_io::u8string_view{u8"&lt;pre&gt;<span style=\"color:red;\">line1<br>line2</span>&lt;/pre&gt;"};
+        auto answer =
+            ::fast_io::u8string_view{u8"&lt;pre&gt;<span style=\"color:red;\">line1<br>line2</span>&lt;/pre&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -143,10 +144,10 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
     }
 
-    // inline <pre><code> mid-text is literal escaped text
+    // inline <pre><code> mid-text: <pre> is literal, <code> is an inline code span
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"ab<pre><code>c</code></pre>de");
-        auto answer = ::fast_io::u8string_view{u8"ab&lt;pre&gt;&lt;code&gt;c&lt;/code&gt;&lt;/pre&gt;de"};
+        auto answer = ::fast_io::u8string_view{u8"ab&lt;pre&gt;<code>c</code>&lt;/pre&gt;de"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_rm_tail_space.cc
+++ b/tests/test_rm_tail_space.cc
@@ -81,7 +81,7 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<p><code>t \nt \n</code> </p>");
-        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:left\">&lt;code&gt;t<br>t<br>&lt;/code&gt;</p>"};
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:left\"><code>t<br>t<br></code></p>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_rm_tail_space.cc
+++ b/tests/test_rm_tail_space.cc
@@ -81,7 +81,7 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"<p><code>t \nt \n</code> </p>");
-        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:left\"><code>t<br>t<br></code></p>"};
+        auto answer = ::fast_io::u8string_view{u8"<p style=\"text-align:left\">&lt;code&gt;t<br>t<br>&lt;/code&gt;</p>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 


### PR DESCRIPTION
Parse the block-level <pre><code>...</code></pre> pattern directly into the md code fence Code node and remove the HtmlCode/HtmlPre node classes. Bare <pre> and standalone <code> tags are now literal escaped text. Mirror the change in the experimental HTML parser and update tests.