### PR TITLE
feat: add inline-only parser for title/plain text rendering

### DIFF
--- a/cxxmodule/pltxt2htm/pltxt2htm.cppm
+++ b/cxxmodule/pltxt2htm/pltxt2htm.cppm
@@ -11,6 +11,7 @@ using ::pltxt2htm::pltxt2common_html;
 using ::pltxt2htm::pltxt2fixedadv_html;
 using ::pltxt2htm::pltxt2plunity_introduction;
 using ::pltxt2htm::parse_pltxt;
+using ::pltxt2htm::inline_parse_pltxt;
 using ::pltxt2htm::optimize_ast;
 using ::pltxt2htm::pltxt4unittest;
 

--- a/include/pltxt2htm/ast/impl/basic_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/basic_node_decl.hh
@@ -184,7 +184,8 @@ public:
     constexpr CodeFence(::pltxt2htm::CodeFence<ndebug> const&) noexcept;
     constexpr CodeFence(::pltxt2htm::CodeFence<ndebug>&&) noexcept;
     constexpr ~CodeFence() noexcept;
-    constexpr auto operator=(::pltxt2htm::CodeFence<ndebug> const&) noexcept -> ::pltxt2htm::CodeFence<ndebug>& = delete;
+    constexpr auto operator=(::pltxt2htm::CodeFence<ndebug> const&) noexcept
+        -> ::pltxt2htm::CodeFence<ndebug>& = delete;
     constexpr auto operator=(this ::pltxt2htm::CodeFence<ndebug>& self, ::pltxt2htm::CodeFence<ndebug>&&) noexcept
         -> ::pltxt2htm::CodeFence<ndebug>&;
 

--- a/include/pltxt2htm/ast/impl/basic_node_def.inc
+++ b/include/pltxt2htm/ast/impl/basic_node_def.inc
@@ -27,7 +27,7 @@ constexpr auto ::pltxt2htm::Text<ndebug>::operator==(this ::pltxt2htm::Text<ndeb
 
 template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::CodeFence<ndebug>::CodeFence(::pltxt2htm::Ast<ndebug>&& subast_,
-                                                   ::exception::optional<::fast_io::u8string>&& lang_) noexcept
+                                                    ::exception::optional<::fast_io::u8string>&& lang_) noexcept
     : subast(::std::move(subast_)),
       lang(::std::move(lang_)) {
 }
@@ -40,11 +40,12 @@ template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::CodeFence<ndebug>::~CodeFence() noexcept = default;
 template<::pltxt2htm::Contracts ndebug>
 constexpr auto ::pltxt2htm::CodeFence<ndebug>::operator=(this ::pltxt2htm::CodeFence<ndebug>& self,
-                                                        ::pltxt2htm::CodeFence<ndebug>&&) noexcept
+                                                         ::pltxt2htm::CodeFence<ndebug>&&) noexcept
     -> ::pltxt2htm::CodeFence<ndebug>& = default;
 
 template<::pltxt2htm::Contracts ndebug>
 constexpr auto ::pltxt2htm::CodeFence<ndebug>::operator==(this ::pltxt2htm::CodeFence<ndebug> const&,
-                                                         ::pltxt2htm::CodeFence<ndebug> const&) noexcept -> bool = default;
+                                                          ::pltxt2htm::CodeFence<ndebug> const&) noexcept
+    -> bool = default;
 
 } // namespace pltxt2htm

--- a/include/pltxt2htm/ast/impl/html_node_def.inc
+++ b/include/pltxt2htm/ast/impl/html_node_def.inc
@@ -306,7 +306,8 @@ constexpr auto ::pltxt2htm::HtmlCode<ndebug>::operator=(this ::pltxt2htm::HtmlCo
 
 template<::pltxt2htm::Contracts ndebug>
 constexpr auto ::pltxt2htm::HtmlCode<ndebug>::operator==(this ::pltxt2htm::HtmlCode<ndebug> const&,
-                                                         ::pltxt2htm::HtmlCode<ndebug> const&) noexcept -> bool = default;
+                                                         ::pltxt2htm::HtmlCode<ndebug> const&) noexcept
+    -> bool = default;
 
 template<::pltxt2htm::Contracts ndebug>
 constexpr ::pltxt2htm::HtmlBlockquote<ndebug>::HtmlBlockquote(::pltxt2htm::Ast<ndebug>&& subast_) noexcept

--- a/include/pltxt2htm/ast/impl/physics_lab_node_decl.hh
+++ b/include/pltxt2htm/ast/impl/physics_lab_node_decl.hh
@@ -169,7 +169,7 @@ public:
     constexpr auto operator=(::pltxt2htm::PlExperiments<ndebug> const&) noexcept
         -> ::pltxt2htm::PlExperiments<ndebug>& = delete;
     constexpr auto operator=(this ::pltxt2htm::PlExperiments<ndebug>& self,
-                            ::pltxt2htm::PlExperiments<ndebug>&&) noexcept -> ::pltxt2htm::PlExperiments<ndebug>&;
+                             ::pltxt2htm::PlExperiments<ndebug>&&) noexcept -> ::pltxt2htm::PlExperiments<ndebug>&;
 
     [[nodiscard]]
     constexpr auto operator==(this PlExperiments const&, PlExperiments const&) noexcept -> bool;
@@ -203,7 +203,7 @@ public:
     constexpr auto operator=(::pltxt2htm::PlDiscussions<ndebug> const&) noexcept
         -> ::pltxt2htm::PlDiscussions<ndebug>& = delete;
     constexpr auto operator=(this ::pltxt2htm::PlDiscussions<ndebug>& self,
-                            ::pltxt2htm::PlDiscussions<ndebug>&&) noexcept -> ::pltxt2htm::PlDiscussions<ndebug>&;
+                             ::pltxt2htm::PlDiscussions<ndebug>&&) noexcept -> ::pltxt2htm::PlDiscussions<ndebug>&;
 
     [[nodiscard]]
     constexpr auto operator==(this PlDiscussions const&, PlDiscussions const&) noexcept -> bool;

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -1543,8 +1543,9 @@ entry:
             }
             case ::pltxt2htm::NodeKind::code_fence: {
                 result.append(u8"<font=\"PhysicsLab-NerdFont SDF\">\n");
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                    node.as_code_fence().get_subast(), ::pltxt2htm::NodeKind::code_fence, 0));
+                call_stack.push(
+                    ::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_code_fence().get_subast(),
+                                                                      ::pltxt2htm::NodeKind::code_fence, 0));
                 ++current_index;
                 goto entry;
             }

--- a/include/pltxt2htm/details/backend/for_plunity_text.hh
+++ b/include/pltxt2htm/details/backend/for_plunity_text.hh
@@ -1543,9 +1543,8 @@ entry:
             }
             case ::pltxt2htm::NodeKind::code_fence: {
                 result.append(u8"<font=\"PhysicsLab-NerdFont SDF\">\n");
-                call_stack.push(
-                    ::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_code_fence().get_subast(),
-                                                                      ::pltxt2htm::NodeKind::code_fence, 0));
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                    node.as_code_fence().get_subast(), ::pltxt2htm::NodeKind::code_fence, 0));
                 ++current_index;
                 goto entry;
             }

--- a/include/pltxt2htm/details/backend/for_plweb_text.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_text.hh
@@ -1567,8 +1567,8 @@ entry:
                 else {
                     result.append(u8"<pre><code>");
                 }
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_code_fence().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::code_fence, 0));
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
+                    node.as_code_fence().get_subast(), ::pltxt2htm::NodeKind::code_fence, 0));
                 ++current_index;
                 goto entry;
             }

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -457,14 +457,14 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::pl_experiments: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                    node.as_pl_experiments().get_subast(), ::pltxt2htm::NodeKind::text, 0));
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_pl_experiments().get_subast(),
+                                                                                  ::pltxt2htm::NodeKind::text, 0));
                 ++current_index;
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::pl_discussions: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                    node.as_pl_discussions().get_subast(), ::pltxt2htm::NodeKind::text, 0));
+                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_pl_discussions().get_subast(),
+                                                                                  ::pltxt2htm::NodeKind::text, 0));
                 ++current_index;
                 goto entry;
             }

--- a/include/pltxt2htm/details/backend/for_plweb_title.hh
+++ b/include/pltxt2htm/details/backend/for_plweb_title.hh
@@ -428,8 +428,9 @@ entry:
             }
             case ::pltxt2htm::NodeKind::md_hr:
                 [[fallthrough]];
-            case ::pltxt2htm::NodeKind::html_hr:
-                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::html_hr: {
+                pltxt2htm_unreachable(u8"Unexpected block node kind in title backend");
+            }
             case ::pltxt2htm::NodeKind::html_note:
                 [[fallthrough]];
             case ::pltxt2htm::NodeKind::html_col:
@@ -509,53 +510,22 @@ entry:
                 ++current_index;
                 goto entry;
             }
-            case ::pltxt2htm::NodeKind::html_div: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_div().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::html_p: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_p().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::html_h1: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_h1().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::html_h2: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_h2().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::html_h3: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_h3().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::html_h4: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_h4().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::html_h5: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_h5().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
+            case ::pltxt2htm::NodeKind::html_div:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::html_p:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::html_h1:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::html_h2:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::html_h3:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::html_h4:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::html_h5:
+                [[fallthrough]];
             case ::pltxt2htm::NodeKind::html_h6: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_h6().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
+                pltxt2htm_unreachable(u8"Unexpected block node kind in title backend");
             }
             case ::pltxt2htm::NodeKind::md_del: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_md_del().get_subast(),
@@ -611,35 +581,14 @@ entry:
                 ++current_index;
                 goto entry;
             }
-            case ::pltxt2htm::NodeKind::list_ul: {
-                auto const& list_ul = node.as_list_ul();
-                bool const is_empty{list_ul.get_subast().empty()};
-                pltxt2htm_assert(is_empty == false, u8"List container must not be empty");
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(list_ul.get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::list_ol: {
-                auto const& list_ol = node.as_list_ol();
-                bool const is_empty{list_ol.get_subast().empty()};
-                pltxt2htm_assert(is_empty == false, u8"List container must not be empty");
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(list_ol.get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::list_li_checkbox: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                    node.as_list_li_checkbox().get_subast(), ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
+            case ::pltxt2htm::NodeKind::list_ul:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::list_ol:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::list_li_checkbox:
+                [[fallthrough]];
             case ::pltxt2htm::NodeKind::list_li: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_list_li().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
+                pltxt2htm_unreachable(u8"Unexpected block node kind in title backend");
             }
             case ::pltxt2htm::NodeKind::md_latex_inline: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
@@ -653,83 +602,33 @@ entry:
                 ++current_index;
                 goto entry;
             }
-            case ::pltxt2htm::NodeKind::md_atx_h1: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_md_atx_h1().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::md_atx_h2: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_md_atx_h2().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::md_atx_h3: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_md_atx_h3().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::md_atx_h4: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_md_atx_h4().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::md_atx_h5: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_md_atx_h5().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::md_atx_h6: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_md_atx_h6().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
+            case ::pltxt2htm::NodeKind::md_atx_h1:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_atx_h2:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_atx_h3:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_atx_h4:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_atx_h5:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_atx_h6:
+                [[fallthrough]];
             case ::pltxt2htm::NodeKind::html_blockquote: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                    node.as_html_blockquote().get_subast(), ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
+                pltxt2htm_unreachable(u8"Unexpected block node kind in title backend");
             }
-            case ::pltxt2htm::NodeKind::md_table: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_md_table().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::md_thead: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_md_thead().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::md_tbody: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_md_tbody().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::md_tr: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_md_tr().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
-            case ::pltxt2htm::NodeKind::md_th: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_md_th().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
+            case ::pltxt2htm::NodeKind::md_table:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_thead:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_tbody:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_tr:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_th:
+                [[fallthrough]];
             case ::pltxt2htm::NodeKind::md_td: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_md_td().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
+                pltxt2htm_unreachable(u8"Unexpected block node kind in title backend");
             }
             case ::pltxt2htm::NodeKind::html_table: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_html_table().get_subast(),
@@ -785,17 +684,10 @@ entry:
                 ++current_index;
                 goto entry;
             }
-            case ::pltxt2htm::NodeKind::md_block_quotes: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(
-                    node.as_md_block_quotes().get_subast(), ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
-            }
+            case ::pltxt2htm::NodeKind::md_block_quotes:
+                [[fallthrough]];
             case ::pltxt2htm::NodeKind::code_fence: {
-                call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(node.as_code_fence().get_subast(),
-                                                                                  ::pltxt2htm::NodeKind::text, 0));
-                ++current_index;
-                goto entry;
+                pltxt2htm_unreachable(u8"Unexpected block node kind in title backend");
             }
             case ::pltxt2htm::NodeKind::md_code_span_1_backtick: {
                 call_stack.push(::pltxt2htm::details::BackendFrameContext<ndebug>(

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -1239,8 +1239,7 @@ entry:
                     // parsing: <internal=$1>$2</internal>
                     if (auto opt_internal_tag = ::pltxt2htm::details::try_parse_non_nestable_equal_sign_tag<
                             ndebug, u8"nternal", ::pltxt2htm::details::is_ascii_graphic>(
-                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
-                            call_stack);
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2), call_stack);
                         opt_internal_tag.has_value()) {
                         auto&& [tag_len, value] =
                             opt_internal_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
@@ -3079,7 +3078,8 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_code: {
-                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlCode<ndebug>{::std::move(subast)}));
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlCode<ndebug>{::std::move(subast)}));
                 parent_index += staged_index;
                 goto entry;
             }

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -3583,7 +3583,8 @@ constexpr auto try_parse_md_code_fence_(::fast_io::u8string_view pltext) noexcep
         opt_lang = ::std::move(lang);
     }
     return ::pltxt2htm::details::TryParseMdCodeFenceResult<ndebug>{
-        .node = ::pltxt2htm::CodeFence<ndebug>{::std::move(ast), ::std::move(opt_lang)}, .advance_count = current_index};
+        .node = ::pltxt2htm::CodeFence<ndebug>{::std::move(ast), ::std::move(opt_lang)},
+        .advance_count = current_index};
 }
 
 /**
@@ -3614,7 +3615,7 @@ constexpr auto try_parse_md_code_fence(::fast_io::u8string_view pltext) noexcept
 #else
     // Above code equals to below code
     if (auto opt_code_fence_tilde = ::pltxt2htm::details::try_parse_md_code_fence_<ndebug, false>(pltext);
-             opt_code_fence_tilde.has_value()) {
+        opt_code_fence_tilde.has_value()) {
         return opt_code_fence_tilde;
     }
     return ::exception::nullopt;

--- a/include/pltxt2htm/experimental/html_parser.hh
+++ b/include/pltxt2htm/experimental/html_parser.hh
@@ -962,8 +962,8 @@ entry:
                             ::pltxt2htm::HtmlCode staged_node(::std::move(result));
                             call_stack.pop();
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
-                            parent_frame.subast.push_back(
-                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlCode<ndebug>{::std::move(staged_node)}));
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                                ::pltxt2htm::HtmlCode<ndebug>{::std::move(staged_node)}));
                             parent_frame.current_index +=
                                 staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
                                 3;
@@ -1384,7 +1384,8 @@ entry:
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::html_code: {
-                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlCode<ndebug>{::std::move(subast)}));
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlCode<ndebug>{::std::move(subast)}));
                 goto entry;
             }
             case ::pltxt2htm::NodeKind::pl_u: {

--- a/include/pltxt2htm/inline_parser.hh
+++ b/include/pltxt2htm/inline_parser.hh
@@ -26,17 +26,6 @@
 namespace pltxt2htm::details {
 
 /**
- * @brief Return type of inline_parse_pltxt.
- * @tparam ndebug Contract checking mode.
- */
-template<::pltxt2htm::Contracts ndebug>
-struct InlineParsePlTxtResult {
-    ::pltxt2htm::Ast<ndebug> subast; ///< Parsed AST for the bottom frame.
-    ///< Bytes consumed from the bottom frame's pltext.
-    ::std::size_t consumed_bytes{};
-};
-
-/**
  * @brief Check whether a code-span content is a valid inline code span.
  * @details The inline-only parser renders fenced code blocks (`` ```...``` ``) as
  *          literal text, so a code span whose content is empty or spans multiple
@@ -59,16 +48,34 @@ constexpr auto is_inline_code_span_content(::fast_io::u8string_view content) noe
     return true;
 }
 
+} // namespace pltxt2htm::details
+
+namespace pltxt2htm {
+
 /**
- * @brief Parse pl-text to nodes (inline constructs only).
- * @tparam ndebug Contract checking mode; `::pltxt2htm::Contracts::ignore` disables checks.
- * @param call_stack: use `call_stack` + `goto entry` to avoid stack overflow.
- * @return The parsed ast and how many bytes of the bottom frame's pltext were consumed.
+ * @brief Parse pl-text into an Abstract Syntax Tree (AST), inline constructs only.
+ * @details This is the inline-only counterpart of ::pltxt2htm::parse_pltxt.  It
+ *          parses only inline syntax; block-level syntax is preserved as literal
+ *          text.  A single text frame is pushed on an explicit call stack and the
+ *          `goto entry` trampoline keeps nested-tag handling free of recursion.
+ * @tparam ndebug Contract-checking mode for parsing, using `::pltxt2htm::Contracts`
+ *                 values such as `::pltxt2htm::Contracts::quick_enforce` or
+ *                 `::pltxt2htm::Contracts::ignore`
+ * @param[in] input_pltext The Physics-Lab text content to parse
+ * @return An AST representing the parsed inline structure of the input text
  */
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
-constexpr auto inline_parse_pltxt(::fast_io::stack<::pltxt2htm::details::ParserFrameContext<ndebug>>& call_stack) noexcept
-    -> InlineParsePlTxtResult<ndebug> {
+constexpr auto inline_parse_pltxt(::fast_io::u8string_view input_pltext) noexcept -> ::pltxt2htm::Ast<ndebug> {
+    using namespace ::pltxt2htm::details;
+    // This stack is used to track nested tag contexts during parsing
+    ::fast_io::stack<::pltxt2htm::details::ParserFrameContext<ndebug>> call_stack{};
+
+    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+        ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+            ::pltxt2htm::details::ParserFrameContextWithPltextInfo{input_pltext}, ::pltxt2htm::NodeKind::text},
+        ::pltxt2htm::Ast<ndebug>{}));
+
 entry:
     while (true) {
 
@@ -1454,11 +1461,7 @@ entry:
                             ::pltxt2htm::PlAlign staged_node(::std::move(result), frame.get_align());
                             call_stack.pop();
                             if (call_stack.empty()) {
-                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
-                                    .subast = ::std::move(staged_node.get_subast()),
-                                    .consumed_bytes =
-                                        staged_index +
-                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                                return ::std::move(staged_node.get_subast());
                             }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
@@ -1502,11 +1505,7 @@ entry:
                                                               frame.get_pl_margin_tag_right());
                             call_stack.pop();
                             if (call_stack.empty()) {
-                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
-                                    .subast = ::std::move(staged_node.get_subast()),
-                                    .consumed_bytes =
-                                        staged_index +
-                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                                return ::std::move(staged_node.get_subast());
                             }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
@@ -1529,11 +1528,7 @@ entry:
                                                              frame.get_html_div_right());
                             call_stack.pop();
                             if (call_stack.empty()) {
-                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
-                                    .subast = ::std::move(staged_node.get_subast()),
-                                    .consumed_bytes =
-                                        staged_index +
-                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                                return ::std::move(staged_node.get_subast());
                             }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
@@ -1594,11 +1589,7 @@ entry:
                             ::pltxt2htm::HtmlP staged_node(::std::move(result), align);
                             call_stack.pop();
                             if (call_stack.empty()) {
-                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
-                                    .subast = ::std::move(staged_node.get_subast()),
-                                    .consumed_bytes =
-                                        staged_index +
-                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                                return ::std::move(staged_node.get_subast());
                             }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
@@ -1620,11 +1611,7 @@ entry:
                             ::pltxt2htm::HtmlH1 staged_node(::std::move(result));
                             call_stack.pop();
                             if (call_stack.empty()) {
-                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
-                                    .subast = ::std::move(staged_node.get_subast()),
-                                    .consumed_bytes =
-                                        staged_index +
-                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                                return ::std::move(staged_node.get_subast());
                             }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
@@ -1646,11 +1633,7 @@ entry:
                             ::pltxt2htm::HtmlH2 staged_node(::std::move(result));
                             call_stack.pop();
                             if (call_stack.empty()) {
-                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
-                                    .subast = ::std::move(staged_node.get_subast()),
-                                    .consumed_bytes =
-                                        staged_index +
-                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                                return ::std::move(staged_node.get_subast());
                             }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
@@ -1672,11 +1655,7 @@ entry:
                             ::pltxt2htm::HtmlH3 staged_node(::std::move(result));
                             call_stack.pop();
                             if (call_stack.empty()) {
-                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
-                                    .subast = ::std::move(staged_node.get_subast()),
-                                    .consumed_bytes =
-                                        staged_index +
-                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                                return ::std::move(staged_node.get_subast());
                             }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
@@ -1698,11 +1677,7 @@ entry:
                             ::pltxt2htm::HtmlH4 staged_node(::std::move(result));
                             call_stack.pop();
                             if (call_stack.empty()) {
-                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
-                                    .subast = ::std::move(staged_node.get_subast()),
-                                    .consumed_bytes =
-                                        staged_index +
-                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                                return ::std::move(staged_node.get_subast());
                             }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
@@ -1724,11 +1699,7 @@ entry:
                             ::pltxt2htm::HtmlH5 staged_node(::std::move(result));
                             call_stack.pop();
                             if (call_stack.empty()) {
-                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
-                                    .subast = ::std::move(staged_node.get_subast()),
-                                    .consumed_bytes =
-                                        staged_index +
-                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                                return ::std::move(staged_node.get_subast());
                             }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
@@ -1750,11 +1721,7 @@ entry:
                             ::pltxt2htm::HtmlH6 staged_node(::std::move(result));
                             call_stack.pop();
                             if (call_stack.empty()) {
-                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
-                                    .subast = ::std::move(staged_node.get_subast()),
-                                    .consumed_bytes =
-                                        staged_index +
-                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                                return ::std::move(staged_node.get_subast());
                             }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
@@ -2125,11 +2092,7 @@ entry:
                             ::pltxt2htm::HtmlBlockquote staged_node(::std::move(result));
                             call_stack.pop();
                             if (call_stack.empty()) {
-                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
-                                    .subast = ::std::move(staged_node.get_subast()),
-                                    .consumed_bytes =
-                                        staged_index +
-                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                                return ::std::move(staged_node.get_subast());
                             }
                             auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
                             parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
@@ -2349,8 +2312,7 @@ entry:
                 // <b>e</b>xample
                 // ```
                 // Text without any tag in the end will hit this branch.
-                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{.subast = ::std::move(frame.subast),
-                                                                      .consumed_bytes = staged_index};
+                return ::std::move(frame.subast);
             }
             // Considering the following markdown:
             // ```md
@@ -2888,41 +2850,6 @@ entry:
             pltxt2htm_unreachable(u8"Unreachable after block-node-in-inline switch");
         }
     }
-}
-
-} // namespace pltxt2htm::details
-
-namespace pltxt2htm {
-
-/**
- * @brief Parse pl-text into an Abstract Syntax Tree (AST), inline constructs only.
- * @details This is the inline-only counterpart of ::pltxt2htm::parse_pltxt.  It
- *          pushes a single text frame and parses only inline syntax; block-level
- *          syntax is preserved as literal text.
- * @tparam ndebug Contract-checking mode for parsing, using `::pltxt2htm::Contracts`
- *                 values such as `::pltxt2htm::Contracts::quick_enforce` or
- *                 `::pltxt2htm::Contracts::ignore`
- * @param[in] pltext The Physics-Lab text content to parse
- * @return An AST representing the parsed inline structure of the input text
- * @see pltxt2htm::details::inline_parse_pltxt for the internal implementation
- */
-template<::pltxt2htm::Contracts ndebug>
-[[nodiscard]]
-constexpr auto inline_parse_pltxt(::fast_io::u8string_view pltext) noexcept -> ::pltxt2htm::Ast<ndebug> {
-    // This stack is used to track nested tag contexts during parsing
-    ::fast_io::stack<::pltxt2htm::details::ParserFrameContext<ndebug>> call_stack{};
-
-    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
-        ::pltxt2htm::details::FrontendContextVariant<ndebug>{
-            ::pltxt2htm::details::ParserFrameContextWithPltextInfo{pltext}, ::pltxt2htm::NodeKind::text},
-        ::pltxt2htm::Ast<ndebug>{}));
-
-    auto&& [subast, consumed_bytes] = ::pltxt2htm::details::inline_parse_pltxt<ndebug>(call_stack);
-
-    bool const call_stack_is_empty{call_stack.empty()};
-    pltxt2htm_assert(call_stack_is_empty, u8"call_stack is not empty");
-
-    return ::std::move(subast);
 }
 
 } // namespace pltxt2htm

--- a/include/pltxt2htm/inline_parser.hh
+++ b/include/pltxt2htm/inline_parser.hh
@@ -67,7 +67,6 @@ namespace pltxt2htm {
 template<::pltxt2htm::Contracts ndebug>
 [[nodiscard]]
 constexpr auto inline_parse_pltxt(::fast_io::u8string_view input_pltext) noexcept -> ::pltxt2htm::Ast<ndebug> {
-    using namespace ::pltxt2htm::details;
     // This stack is used to track nested tag contexts during parsing
     ::fast_io::stack<::pltxt2htm::details::ParserFrameContext<ndebug>> call_stack{};
 
@@ -506,7 +505,7 @@ entry:
                     }
                     // parsing: <color=$1>$2</color>
                     if (auto opt_color_tag = ::pltxt2htm::details::try_parse_color_tag<ndebug>(
-                            u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
                         opt_color_tag.has_value()) {
                         auto&& [tag_len, color] =
                             opt_color_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();

--- a/include/pltxt2htm/inline_parser.hh
+++ b/include/pltxt2htm/inline_parser.hh
@@ -1,0 +1,2930 @@
+/**
+ * @file inline_parser.hh
+ * @brief Inline-only pl-text parser.
+ * @details Parses only inline constructs of pl-text (tags, emphasis, links, code
+ *          spans, latex, and so on) and leaves block-level syntax (md-atx headings,
+ *          md-block-quotes, md-list, md-table, code fences and HTML block tags)
+ *          untouched, so those render as literal text.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <fast_io/fast_io_dsal/list.h>
+#include <fast_io/fast_io_dsal/stack.h>
+#include <fast_io/fast_io_dsal/string.h>
+#include <fast_io/fast_io_dsal/string_view.h>
+#include <exception/exception.hh>
+#include "ast/node_kind.hh"
+#include "ast/ast.hh"
+#include "contracts.hh"
+#include "details/utils.hh"
+#include "details/parser/frame_context.hh"
+#include "details/parser/try_parse.hh"
+#include "details/push_macro.hh"
+
+namespace pltxt2htm::details {
+
+/**
+ * @brief Return type of inline_parse_pltxt.
+ * @tparam ndebug Contract checking mode.
+ */
+template<::pltxt2htm::Contracts ndebug>
+struct InlineParsePlTxtResult {
+    ::pltxt2htm::Ast<ndebug> subast; ///< Parsed AST for the bottom frame.
+    ///< Bytes consumed from the bottom frame's pltext.
+    ::std::size_t consumed_bytes{};
+};
+
+/**
+ * @brief Check whether a code-span content is a valid inline code span.
+ * @details The inline-only parser renders fenced code blocks (`` ```...``` ``) as
+ *          literal text, so a code span whose content is empty or spans multiple
+ *          lines is rejected here and falls through to literal rendering.
+ * @tparam ndebug Contract checking mode.
+ * @param[in] content The code-span content (between the opening and closing delimiters).
+ * @return True when the content is a single-line, non-empty code span.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto is_inline_code_span_content(::fast_io::u8string_view content) noexcept -> bool {
+    if (content.empty()) {
+        return false;
+    }
+    for (::std::size_t i{}; i < content.size(); ++i) {
+        if (::pltxt2htm::details::u8string_view_index<ndebug>(content, i) == u8'\n') {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * @brief Parse pl-text to nodes (inline constructs only).
+ * @tparam ndebug Contract checking mode; `::pltxt2htm::Contracts::ignore` disables checks.
+ * @param call_stack: use `call_stack` + `goto entry` to avoid stack overflow.
+ * @return The parsed ast and how many bytes of the bottom frame's pltext were consumed.
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto inline_parse_pltxt(::fast_io::stack<::pltxt2htm::details::ParserFrameContext<ndebug>>& call_stack) noexcept
+    -> InlineParsePlTxtResult<ndebug> {
+entry:
+    while (true) {
+
+        auto&& top_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+        auto&& current_index = top_frame.current_index;
+        ::fast_io::u8string_view const pltext{top_frame.get_pltext()};
+        auto&& result = top_frame.subast;
+        ::std::size_t const pltext_size{pltext.size()};
+
+
+        while (current_index < pltext_size) {
+            char8_t const chr{::pltxt2htm::details::u8string_view_index<ndebug>(pltext, current_index)};
+
+            if (chr == u8'\n') {
+                result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LineBreak{}));
+
+                ++current_index;
+                continue;
+            }
+            if (chr == u8' ') {
+                result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Space{}));
+                ++current_index;
+                continue;
+            }
+            if (chr == u8'&') {
+                if (auto const opt_entity_len = ::pltxt2htm::details::try_parse_entity_reference<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                    opt_entity_len.has_value()) {
+                    auto const entity_len = opt_entity_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::EntityReference{::fast_io::u8string{
+                        pltext.data() + current_index + 1, pltext.data() + current_index + entity_len - 1}}));
+                    current_index += entity_len;
+                    continue;
+                }
+                result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Ampersand{}));
+                ++current_index;
+                continue;
+            }
+            if (chr == u8'\'') {
+                result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::SingleQuote{}));
+                ++current_index;
+                continue;
+            }
+            if (chr == u8'\"') {
+                result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::DoubleQuote{}));
+                ++current_index;
+                continue;
+            }
+            if (chr == u8'>') {
+                result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::GreaterThan{}));
+                ++current_index;
+                continue;
+            }
+            if (chr == u8'\t') {
+                result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::Tab{}));
+                ++current_index;
+                continue;
+            }
+            if (auto opt_escape = ::pltxt2htm::details::try_parse_md_escape<ndebug>(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                opt_escape.has_value()) {
+                auto&& [node, advance_count] = opt_escape.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                result.push_back(::std::move(node));
+                current_index += advance_count;
+                continue;
+            }
+            if (::pltxt2htm::details::is_prefix_match<ndebug, u8"{project}">(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index))) {
+                constexpr auto length_of_literal_string = ::std::size_t{9};
+                result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlMacroProject{}));
+                current_index += length_of_literal_string;
+                continue;
+            }
+            if (::pltxt2htm::details::is_prefix_match<ndebug, u8"{visitor}">(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index))) {
+                constexpr auto length_of_literal_string = ::std::size_t{9};
+                result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlMacroVisitor{}));
+                current_index += length_of_literal_string;
+                continue;
+            }
+            if (::pltxt2htm::details::is_prefix_match<ndebug, u8"{author}">(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index))) {
+                constexpr auto length_of_literal_string = ::std::size_t{8};
+                result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlMacroAuthor{}));
+                current_index += length_of_literal_string;
+                continue;
+            }
+            if (::pltxt2htm::details::is_prefix_match<ndebug, u8"{coauthors}">(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index))) {
+                constexpr auto length_of_literal_string = ::std::size_t{11};
+                result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlMacroCoauthors{}));
+                current_index += length_of_literal_string;
+                continue;
+            }
+            if (auto opt_triple_emphasis_asterisk = ::pltxt2htm::details::try_parse_md_inlines<ndebug, u8"***">(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                opt_triple_emphasis_asterisk.has_value()) {
+                // parsing markdown ***example***
+                ::std::size_t const advance_count{
+                    opt_triple_emphasis_asterisk.template value<ndebug == ::pltxt2htm::Contracts::ignore>()};
+                call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                    ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                        ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 3,
+                                                                                advance_count)},
+                        ::pltxt2htm::NodeKind::md_triple_emphasis_asterisk},
+                    ::pltxt2htm::Ast<ndebug>{}));
+                current_index += advance_count + 6;
+                goto entry;
+            }
+            if (auto opt_double_emphasis_asterisk = ::pltxt2htm::details::try_parse_md_inlines<ndebug, u8"**">(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                opt_double_emphasis_asterisk.has_value()) {
+                // parsing markdown **example**
+                ::std::size_t const advance_count{
+                    opt_double_emphasis_asterisk.template value<ndebug == ::pltxt2htm::Contracts::ignore>()};
+                call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                    ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                        ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2,
+                                                                                advance_count)},
+                        ::pltxt2htm::NodeKind::md_double_emphasis_asterisk},
+                    ::pltxt2htm::Ast<ndebug>{}));
+                current_index += advance_count + 4;
+                goto entry;
+            }
+            if (auto opt_single_emphasis_asterisk = ::pltxt2htm::details::try_parse_md_inlines<ndebug, u8"*">(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                opt_single_emphasis_asterisk.has_value()) {
+                // parsing markdown *example*
+                ::std::size_t const advance_count{
+                    opt_single_emphasis_asterisk.template value<ndebug == ::pltxt2htm::Contracts::ignore>()};
+                call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                    ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                        ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 1,
+                                                                                advance_count)},
+                        ::pltxt2htm::NodeKind::md_single_emphasis_asterisk},
+                    ::pltxt2htm::Ast<ndebug>{}));
+                current_index += advance_count + 2;
+                goto entry;
+            }
+            if (auto opt_triple_emphasis_underscore = ::pltxt2htm::details::try_parse_md_inlines<ndebug, u8"___">(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                opt_triple_emphasis_underscore.has_value()) {
+                // parsing markdown ___example___
+                ::std::size_t const advance_count{
+                    opt_triple_emphasis_underscore.template value<ndebug == ::pltxt2htm::Contracts::ignore>()};
+                call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                    ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                        ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 3,
+                                                                                advance_count)},
+                        ::pltxt2htm::NodeKind::md_triple_emphasis_underscore},
+                    ::pltxt2htm::Ast<ndebug>{}));
+                current_index += advance_count + 6;
+                goto entry;
+            }
+            if (auto opt_double_emphasis_undersore = ::pltxt2htm::details::try_parse_md_inlines<ndebug, u8"__">(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                opt_double_emphasis_undersore.has_value()) {
+                // parsing markdown __example__
+                ::std::size_t const advance_count{
+                    opt_double_emphasis_undersore.template value<ndebug == ::pltxt2htm::Contracts::ignore>()};
+                call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                    ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                        ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2,
+                                                                                advance_count)},
+                        ::pltxt2htm::NodeKind::md_double_emphasis_underscore},
+                    ::pltxt2htm::Ast<ndebug>{}));
+                current_index += advance_count + 4;
+                goto entry;
+            }
+            if (auto opt_single_emphasis_undersore = ::pltxt2htm::details::try_parse_md_inlines<ndebug, u8"_">(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                opt_single_emphasis_undersore.has_value()) {
+                // parsing markdown _example_
+                ::std::size_t const advance_count{
+                    opt_single_emphasis_undersore.template value<ndebug == ::pltxt2htm::Contracts::ignore>()};
+                call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                    ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                        ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 1,
+                                                                                advance_count)},
+                        ::pltxt2htm::NodeKind::md_single_emphasis_underscore},
+                    ::pltxt2htm::Ast<ndebug>{}));
+                current_index += advance_count + 2;
+                goto entry;
+            }
+            if (auto opt_md_del = ::pltxt2htm::details::try_parse_md_inlines<ndebug, u8"~~">(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                opt_md_del.has_value()) {
+                // parsing markdown ~~example~~
+                ::std::size_t const advance_count{
+                    opt_md_del.template value<ndebug == ::pltxt2htm::Contracts::ignore>()};
+                call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                    ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                        ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2,
+                                                                                advance_count)},
+                        ::pltxt2htm::NodeKind::md_del},
+                    ::pltxt2htm::Ast<ndebug>{}));
+                current_index += advance_count + 4;
+                goto entry;
+            }
+            if (auto opt_code_span_3_backtick = ::pltxt2htm::details::try_parse_md_code_span<ndebug, u8"```">(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                opt_code_span_3_backtick.has_value()) {
+                // parsing markdown ```example```
+                auto&& [advance_count, subast] =
+                    opt_code_span_3_backtick.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                if (::pltxt2htm::details::is_inline_code_span_content<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 3,
+                                                                       advance_count - 6))) {
+                    current_index += advance_count;
+                    result.push_back(
+                        ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdCodeSpan3Backtick<ndebug>{::std::move(subast)}));
+                    continue;
+                }
+            }
+            if (auto opt_code_span_2_backtick = ::pltxt2htm::details::try_parse_md_code_span<ndebug, u8"``">(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                opt_code_span_2_backtick.has_value()) {
+                // parsing markdown ``example``
+                auto&& [advance_count, subast] =
+                    opt_code_span_2_backtick.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                if (::pltxt2htm::details::is_inline_code_span_content<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2,
+                                                                       advance_count - 4))) {
+                    current_index += advance_count;
+                    result.push_back(
+                        ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdCodeSpan2Backtick<ndebug>{::std::move(subast)}));
+                    continue;
+                }
+            }
+            if (auto opt_code_span_1_backtick = ::pltxt2htm::details::try_parse_md_code_span<ndebug, u8"`">(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                opt_code_span_1_backtick.has_value()) {
+                // parsing markdown `example`
+                auto&& [advance_count, subast] =
+                    opt_code_span_1_backtick.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                if (::pltxt2htm::details::is_inline_code_span_content<ndebug>(
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 1,
+                                                                       advance_count - 2))) {
+                    current_index += advance_count;
+                    result.push_back(
+                        ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdCodeSpan1Backtick<ndebug>{::std::move(subast)}));
+                    continue;
+                }
+            }
+            if (auto opt_md_latex_block_dollar = ::pltxt2htm::details::try_parse_md_latex_block_dollar<ndebug>(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                opt_md_latex_block_dollar.has_value()) {
+                auto&& [advance_count, subast] =
+                    opt_md_latex_block_dollar.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                current_index += advance_count;
+                result.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdLatexBlock<ndebug>{::std::move(subast)}));
+                continue;
+            }
+            if (auto opt_md_latex_inline = ::pltxt2htm::details::try_parse_md_latex_inline<ndebug>(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                opt_md_latex_inline.has_value()) {
+                auto&& [advance_count, subast] =
+                    opt_md_latex_inline.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                current_index += advance_count;
+                result.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdLatexInline<ndebug>{::std::move(subast)}));
+                continue;
+            }
+            if (auto opt_md_link = ::pltxt2htm::details::try_parse_md_link<ndebug>(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                opt_md_link.has_value()) {
+                auto&& [advance_count, url_text, url_link] =
+                    opt_md_link.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                current_index += advance_count;
+                call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                    ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                        ::pltxt2htm::details::ParserFrameContextWithUrlInfo{url_text, ::std::move(url_link)},
+                        ::pltxt2htm::NodeKind::md_link},
+                    ::pltxt2htm::Ast<ndebug>{}));
+                goto entry;
+            }
+            if (auto opt_url = ::pltxt2htm::details::try_parse_auto_url<ndebug>(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                opt_url.has_value()) {
+                // Suppress auto-link when inside a URL-link container frame (pl_link,
+                // pl_external, md_link, html_a): a bare URL there would otherwise nest
+                // an <a> inside another <a>.  The URL then falls through to literal text.
+                bool in_url_link_frame{false};
+                for (auto const& v : call_stack.container) {
+                    if (::pltxt2htm::details::is_url_link_tag_type(v.get_nested_tag_type())) {
+                        in_url_link_frame = true;
+                        break;
+                    }
+                }
+                if (in_url_link_frame == false) {
+                    auto&& [consumed_size, url_obj] =
+                        opt_url.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(url_obj)));
+                    current_index += consumed_size;
+                    continue;
+                }
+            }
+            if (auto opt_md_image = ::pltxt2htm::details::try_parse_md_image<ndebug>(
+                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
+                opt_md_image.has_value()) {
+                auto&& [advance_count, text, link] =
+                    opt_md_image.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                current_index += advance_count;
+                result.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdImage<ndebug>{::std::move(text), ::std::move(link)}));
+                continue;
+            }
+            if (chr == u8'<') {
+                // if i is a valid value, i always less than pltext_size
+                pltxt2htm_assert(current_index < pltext_size, u8"Index of parser out of bound");
+
+                if (current_index + 1 == pltext_size) {
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+
+                // a trie for tags
+                switch (::pltxt2htm::details::u8string_view_index<ndebug>(pltext, current_index + 1)) {
+                case u8'a':
+                    [[fallthrough]];
+                case u8'A': {
+                    // parsing pl <a>$1</a> tag (not html <a> tag)
+                    // Note: <align=...> (Unity TextMeshPro) is parsed only by the block-level
+                    // parser; in this inline-only parser it always renders as literal text.
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::pl_a},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    // parsing html <a href="URL"> tag
+                    if (auto a_tag = ::pltxt2htm::details::try_parse_html_a_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        a_tag.is_valid()) {
+                        auto const tag_len = a_tag.tag_len;
+                        ::pltxt2htm::Url url =
+                            ::std::move(a_tag.url.template value<ndebug == ::pltxt2htm::Contracts::ignore>());
+                        auto const internal = a_tag.internal;
+                        current_index += tag_len + 2;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithHtmlATagInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                                    ::std::move(url),
+                                    internal}}, // ::pltxt2htm::NodeKind::html_a is automatically set in ctor
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    else if (a_tag.is_invalid_url()) {
+                        // the <a href="..."> opening tag was recognized but its URL is invalid:
+                        // consume the whole span as literal text (no auto-link / tag dispatch inside).
+                        auto const tag_len = a_tag.tag_len;
+                        auto const span =
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index, tag_len + 2);
+                        auto&& [_, literal_ast] =
+                            ::pltxt2htm::details::simply_parse_pltext<ndebug,
+                                                                      ::pltxt2htm::details::U8LiteralString<0>{}>(span);
+                        result.append_range(::std::move(literal_ast));
+                        current_index += tag_len + 2;
+                        continue;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+
+                case u8'b':
+                    [[fallthrough]];
+                case u8'B': {
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // parsing pl&html <b> tag
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::pl_b},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    if (auto opt_br_tag_len = ::pltxt2htm::details::try_parse_self_closing_tag<ndebug, u8"r">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_br_tag_len.has_value()) {
+                        current_index += opt_br_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlBr{}));
+
+                        ++current_index;
+                        continue;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+
+                case u8'c':
+                    [[fallthrough]];
+                case u8'C': {
+                    // parsing: <code>$1</code> inline element (no language/class support)
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"ode">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // parsing start tag <code> successed
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::html_code},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    // parsing: <color=$1>$2</color>
+                    if (auto opt_color_tag = ::pltxt2htm::details::try_parse_color_tag<ndebug>(
+                            u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_color_tag.has_value()) {
+                        auto&& [tag_len, color] =
+                            opt_color_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 3;
+                        // parsing start tag <color> successed
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithEqualSignTagInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                                    ::fast_io::u8string{color}},
+                                ::pltxt2htm::NodeKind::pl_color},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_caption_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                            ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
+                        opt_tag_len.has_value()) {
+                        // parsing html <caption> tag
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::html_caption},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_colgroup_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                            ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
+                        opt_tag_len.has_value()) {
+                        // parsing html <colgroup> tag
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::html_colgroup},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_col_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                            ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
+                        opt_tag_len.has_value()) {
+                        // parsing html <col> self-closing tag
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 1;
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlCol{}));
+                        ++current_index;
+                        continue;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+
+                case u8'd':
+                    [[fallthrough]];
+                case u8'D': {
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"el">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // parsing <del>$1</del>
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::html_del},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    // parsing: <discussions=$1>$2</discussions>
+                    if (auto opt_discussions_tag = ::pltxt2htm::details::try_parse_non_nestable_equal_sign_tag<
+                            ndebug, u8"iscussions", ::pltxt2htm::details::is_url_value_char>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2), call_stack);
+                        opt_discussions_tag.has_value()) {
+                        auto&& [tag_len, value] =
+                            opt_discussions_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithEqualSignTagInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                                    ::fast_io::u8string{value}},
+                                ::pltxt2htm::NodeKind::pl_discussions},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    // parsing: <discussion=$1>$2</discussion>
+                    if (auto opt_discussion_tag = ::pltxt2htm::details::try_parse_non_nestable_equal_sign_tag<
+                            ndebug, u8"iscussion", ::pltxt2htm::details::is_ascii_lowercase_alphanumeric>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2), call_stack);
+                        opt_discussion_tag.has_value()) {
+                        auto&& [tag_len, id] =
+                            opt_discussion_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithEqualSignTagInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                                    ::fast_io::u8string{id}},
+                                ::pltxt2htm::NodeKind::pl_discussion},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+
+                case u8'e':
+                    [[fallthrough]];
+                case u8'E': {
+                    // parsing: <experiments=$1>$2</experiments>
+                    if (auto opt_experiments_tag = ::pltxt2htm::details::try_parse_non_nestable_equal_sign_tag<
+                            ndebug, u8"xperiments", ::pltxt2htm::details::is_url_value_char>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2), call_stack);
+                        opt_experiments_tag.has_value()) {
+                        auto&& [tag_len, value] =
+                            opt_experiments_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithEqualSignTagInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                                    ::fast_io::u8string{value}},
+                                ::pltxt2htm::NodeKind::pl_experiments},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    if (auto opt_experiment_tag = ::pltxt2htm::details::try_parse_non_nestable_equal_sign_tag<
+                            ndebug, u8"xperiment", ::pltxt2htm::details::is_ascii_lowercase_alphanumeric>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2), call_stack);
+                        opt_experiment_tag.has_value()) {
+                        // parsing: <experiment=$1>$2</experiment>
+                        auto&& [tag_len, id] =
+                            opt_experiment_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithEqualSignTagInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                                    ::fast_io::u8string{id}},
+                                ::pltxt2htm::NodeKind::pl_experiment},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    if (auto external_tag = ::pltxt2htm::details::try_parse_external_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2), call_stack);
+                        external_tag.is_valid()) {
+                        auto const tag_len = external_tag.tag_len;
+                        ::pltxt2htm::Url url =
+                            ::std::move(external_tag.url.template value<ndebug == ::pltxt2htm::Contracts::ignore>());
+                        current_index += tag_len + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithUrlInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                                    ::std::move(url)},
+                                ::pltxt2htm::NodeKind::pl_external},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    else if (external_tag.is_invalid_url()) {
+                        // the <external=...> opening tag was recognized but its URL is invalid:
+                        // consume the whole span as literal text (no auto-link / tag dispatch inside).
+                        auto const tag_len = external_tag.tag_len;
+                        auto const span =
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index, tag_len + 3);
+                        auto&& [_, literal_ast] =
+                            ::pltxt2htm::details::simply_parse_pltext<ndebug,
+                                                                      ::pltxt2htm::details::U8LiteralString<0>{}>(span);
+                        result.append_range(::std::move(literal_ast));
+                        current_index += tag_len + 3;
+                        continue;
+                    }
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"m">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::html_em},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+
+                case u8'i':
+                    [[fallthrough]];
+                case u8'I': {
+                    // parsing: <internal=$1>$2</internal>
+                    if (auto opt_internal_tag = ::pltxt2htm::details::try_parse_non_nestable_equal_sign_tag<
+                            ndebug, u8"nternal", ::pltxt2htm::details::is_ascii_graphic>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                            call_stack);
+                        opt_internal_tag.has_value()) {
+                        auto&& [tag_len, value] =
+                            opt_internal_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithEqualSignTagInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                                    ::fast_io::u8string{value}},
+                                ::pltxt2htm::NodeKind::pl_internal},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    // parsing pl&html <i>$1</i> tag
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::pl_i},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    // parsing html <img src="..." alt="..."> self-closing tag
+                    if (auto opt_img_tag = ::pltxt2htm::details::try_parse_img_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_img_tag.has_value()) {
+                        auto&& [tag_len, src, alt] =
+                            opt_img_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 1;
+                        result.push_back(
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlImg{::std::move(src), ::std::move(alt)}));
+                        ++current_index;
+                        continue;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+
+                case u8'l':
+                    [[fallthrough]];
+                case u8'L': {
+                    if (auto link_tag = ::pltxt2htm::details::try_parse_link_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2), call_stack);
+                        link_tag.is_valid()) {
+                        // parsing: <link="url">$1</link>
+                        auto const tag_len = link_tag.tag_len;
+                        ::pltxt2htm::Url url =
+                            ::std::move(link_tag.url.template value<ndebug == ::pltxt2htm::Contracts::ignore>());
+                        current_index += tag_len + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithUrlInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                                    ::std::move(url)},
+                                ::pltxt2htm::NodeKind::pl_link},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    else if (link_tag.is_invalid_url()) {
+                        // the <link="..."> opening tag was recognized but its URL is invalid:
+                        // consume the whole span as literal text (no auto-link / tag dispatch inside).
+                        auto const tag_len = link_tag.tag_len;
+                        auto const span =
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index, tag_len + 3);
+                        auto&& [_, literal_ast] =
+                            ::pltxt2htm::details::simply_parse_pltext<ndebug,
+                                                                      ::pltxt2htm::details::U8LiteralString<0>{}>(span);
+                        result.append_range(::std::move(literal_ast));
+                        current_index += tag_len + 3;
+                        continue;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+
+                case u8'm':
+                    [[fallthrough]];
+                case u8'M': {
+                    if (auto opt_mark_tag = ::pltxt2htm::details::try_parse_mark_equal_sign_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_mark_tag.has_value()) {
+                        auto&& [tag_len, background_color] =
+                            opt_mark_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        // parsing pl <mark=Xxx> tag (TMP rich text)
+                        current_index += tag_len + 2;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPlMarkInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                                    ::std::move(background_color)},
+                                ::pltxt2htm::NodeKind::pl_mark},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    if (auto opt_mark_tag = ::pltxt2htm::details::try_parse_mark_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_mark_tag.has_value()) {
+                        auto&& [tag_len, background_color] =
+                            opt_mark_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        // parsing html <mark> tag (bare or with style="background-color:...")
+                        current_index += tag_len + 2;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithHtmlMarkInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                                    ::std::move(background_color)},
+                                ::pltxt2htm::NodeKind::html_mark},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+
+                case u8's':
+                    [[fallthrough]];
+                case u8'S': {
+                    // parsing pl <size=$1>$2</size> tag
+                    if (auto opt_size_tag = ::pltxt2htm::details::try_parse_size_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_size_tag.has_value()) {
+                        auto const [tag_len, value] =
+                            opt_size_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        if (value.value == 0) {
+                            result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                            ++current_index;
+                            goto entry;
+                        }
+
+                        current_index += tag_len + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPlSizeTagInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), value},
+                                ::pltxt2htm::NodeKind::pl_size},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    // parsing <span style="color:...;font-size:..."> as html_span
+                    if (auto opt_span_tag = ::pltxt2htm::details::try_parse_span_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_span_tag.has_value()) {
+                        auto&& [tag_len, color, font_size, vertical_align] =
+                            opt_span_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 2;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithHtmlSpanInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                                    ::std::move(color), ::std::move(font_size), ::std::move(vertical_align)},
+                                ::pltxt2htm::NodeKind::html_span},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"trong">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // HTML <strong> tag
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::html_strong},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"up">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // parsing <sup>$1</sup> (HTML and Unity TextMeshPro superscript)
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::html_sup},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"ub">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // parsing <sub>$1</sub> (HTML and Unity TextMeshPro subscript)
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::html_sub},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // parsing <s>$1</s> (HTML and Unity TextMeshPro strikethrough)
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::pl_s},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+
+                case u8't':
+                    [[fallthrough]];
+                case u8'T': {
+                    // parsing: <trigger=$1>$2</trigger>
+                    if (auto opt_trigger_tag = ::pltxt2htm::details::try_parse_non_nestable_equal_sign_tag<
+                            ndebug, u8"rigger", ::pltxt2htm::details::is_ascii_graphic>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2), call_stack);
+                        opt_trigger_tag.has_value()) {
+                        auto&& [tag_len, value] =
+                            opt_trigger_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithEqualSignTagInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                                    ::fast_io::u8string{value}},
+                                ::pltxt2htm::NodeKind::pl_trigger},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"able">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::html_table},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_thead_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                            ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
+                        opt_tag_len.has_value()) {
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::html_thead},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_tbody_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                            ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
+                        opt_tag_len.has_value()) {
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::html_tbody},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_tfoot_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                            ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
+                        opt_tag_len.has_value()) {
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::html_tfoot},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_tr_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                            ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
+                        opt_tag_len.has_value()) {
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::html_tr},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    if (auto opt_th_tag = ::pltxt2htm::details::try_parse_th_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                            ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
+                        opt_th_tag.has_value()) {
+                        auto&& [tag_len, align] = opt_th_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithCellInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), align},
+                                ::pltxt2htm::NodeKind::html_th},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    if (auto opt_td_tag = ::pltxt2htm::details::try_parse_td_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2),
+                            ::pltxt2htm::details::stack_top<ndebug>(call_stack).get_nested_tag_type());
+                        opt_td_tag.has_value()) {
+                        auto&& [tag_len, align] = opt_td_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithCellInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), align},
+                                ::pltxt2htm::NodeKind::html_td},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+
+                case u8'u':
+                    [[fallthrough]];
+                case u8'U': {
+                    // parsing pl <user=$1>$2</user> tag
+                    if (auto opt_user_tag = ::pltxt2htm::details::try_parse_equal_sign_tag<
+                            ndebug, u8"ser", ::pltxt2htm::details::is_ascii_lowercase_alphanumeric>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_user_tag.has_value()) {
+                        auto&& [tag_len, id] = opt_user_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithEqualSignTagInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index),
+                                    ::fast_io::u8string{id}},
+                                ::pltxt2htm::NodeKind::pl_user},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    // <ul> is a block-level list; inline occurrences are plain literal text
+                    // (except <u> underline below).
+                    if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_tag_len.has_value()) {
+                        // parsing <u>$1</u> (HTML and Unity TextMeshPro underline)
+                        current_index += opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPltextInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index)},
+                                ::pltxt2htm::NodeKind::pl_u},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+
+                case u8'v':
+                    [[fallthrough]];
+                case u8'V': {
+                    // parsing pl <voffset=$1>$2</voffset> tag (Unity TextMeshPro rich text)
+                    if (auto opt_voffset_tag = ::pltxt2htm::details::try_parse_voffset_tag<ndebug>(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        opt_voffset_tag.has_value()) {
+                        auto const [tag_len, value] =
+                            opt_voffset_tag.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
+                        current_index += tag_len + 3;
+                        call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+                            ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+                                ::pltxt2htm::details::ParserFrameContextWithPlVoffsetTagInfo{
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), value},
+                                ::pltxt2htm::NodeKind::pl_voffset},
+                            ::pltxt2htm::Ast<ndebug>{}));
+                        goto entry;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+
+                case u8'!': {
+                    // parsing: <!--$1-->
+                    if (::pltxt2htm::details::is_prefix_match<ndebug, u8"--">(
+                            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2))) {
+                        // Find the closing -->
+                        ::std::size_t comment_end{current_index + 4}; // Position after <!--
+                        ::pltxt2htm::Ast<ndebug> subast{};
+
+                        for (; comment_end < pltext_size; ++comment_end) {
+                            if (::pltxt2htm::details::is_prefix_match<ndebug, u8"-->">(
+                                    ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, comment_end))) {
+                                break;
+                            }
+                            subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::U8Char{
+                                ::pltxt2htm::details::u8string_view_index<ndebug>(pltext, comment_end)}));
+                        }
+
+                        current_index = comment_end + 2; // Point to '>'
+                        result.push_back(
+                            ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlNote<ndebug>{::std::move(subast)}));
+                        ++current_index;
+                        continue;
+                    }
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+
+                case u8'/': {
+                    auto&& frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                    switch (frame.get_nested_tag_type()) /* -Werror=switch */ {
+                    case ::pltxt2htm::NodeKind::pl_color: {
+                        // parsing </color> or </a>
+                        ::exception::optional<::std::size_t> opt_tag_len{
+                            ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"color">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2))};
+                        if (opt_tag_len.has_value() == false) {
+                            opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"a">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        }
+                        if (opt_tag_len.has_value()) {
+                            // parsing end tag </color> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlColor staged_node(::std::move(result),
+                                                             ::std::move(frame.get_equal_sign_tag_id()));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_a: {
+                        // parsing </color> or </a>
+                        ::exception::optional<::std::size_t> opt_tag_len{
+                            ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"color">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2))};
+                        if (opt_tag_len.has_value() == false) {
+                            opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"a">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                        }
+                        if (opt_tag_len.has_value()) {
+                            // parsing end tag </a> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlA staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_span: {
+                        // parsing </span>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"span">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlSpan staged_node(
+                                ::std::move(result), ::std::move(frame.get_html_span_color()),
+                                frame.get_html_span_font_size(), frame.get_html_span_vertical_align());
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_a: {
+                        // parsing </a>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"a">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlA staged_node(::std::move(result), ::std::move(frame.get_html_a_url()),
+                                                           frame.get_html_a_internal());
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_experiment: {
+                        // parsing </experiment>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"experiment">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // Whether or not extern_index is out of range, extern for loop will handle it correctly.
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlExperiment staged_node(::std::move(result),
+                                                                  ::std::move(frame.get_equal_sign_tag_id()));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_experiments: {
+                        // parsing </experiments>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"experiments">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // Whether or not extern_index is out of range, extern for loop will handle it correctly.
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlExperiments staged_node(::std::move(result),
+                                                                   ::std::move(frame.get_equal_sign_tag_id()));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_discussion: {
+                        // parsing </discussion>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"discussion">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // Whether or not extern_index is out of range, extern for loop will handle it correctly.
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlDiscussion staged_node(::std::move(result),
+                                                                  ::std::move(frame.get_equal_sign_tag_id()));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_discussions: {
+                        // parsing </discussions>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"discussions">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // Whether or not extern_index is out of range, extern for loop will handle it correctly.
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlDiscussions staged_node(::std::move(result),
+                                                                   ::std::move(frame.get_equal_sign_tag_id()));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_external: {
+                        // parsing </external>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"external">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // Whether or not extern_index is out of range, extern for loop will handle it correctly.
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlExternal staged_node(::std::move(result),
+                                                                ::std::move(frame.get_external_tag_url()));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_link: {
+                        // parsing </link>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"link">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlLink staged_node(::std::move(result), ::std::move(frame.get_link_tag_url()));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_trigger: {
+                        // parsing </trigger>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"trigger">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlTrigger staged_node(::std::move(result),
+                                                               ::std::move(frame.get_equal_sign_tag_id()));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_internal: {
+                        // parsing </internal>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"internal">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlInternal staged_node(::std::move(result),
+                                                                ::std::move(frame.get_equal_sign_tag_id()));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_user: {
+                        // parsing </user>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"user">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlUser staged_node(::std::move(result),
+                                                            ::std::move(frame.get_equal_sign_tag_id()));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_size: {
+                        // parsing </size>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"size">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlSize staged_node(::std::move(result), frame.get_pl_size_tag_value());
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_voffset: {
+                        // parsing </voffset>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"voffset">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlVoffset staged_node(::std::move(result), frame.get_pl_voffset_tag_value());
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_align: {
+                        // parsing </align>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"align">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlAlign staged_node(::std::move(result), frame.get_align());
+                            call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_mark: {
+                        // parsing </mark>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"mark">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlMark staged_node(::std::move(result),
+                                                            ::std::move(frame.get_pl_mark_background_color()));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(
+                                ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlMark<ndebug>{::std::move(staged_node)}));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_margin: {
+                        // parsing </margin>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"margin">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlMargin staged_node(::std::move(result), frame.get_pl_margin_tag_left(),
+                                                              frame.get_pl_margin_tag_right());
+                            call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_div: {
+                        // parsing </div>
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"div">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlDiv staged_node(::std::move(result), frame.get_html_div_left(),
+                                                             frame.get_html_div_right());
+                            call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_b: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"b">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </b> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlB staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_i: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"i">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </a> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlI staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_p: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"p">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </p> successed
+                            ::std::size_t const staged_index{current_index};
+                            auto const align = frame.get_align();
+                            ::pltxt2htm::HtmlP staged_node(::std::move(result), align);
+                            call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_h1: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"h1">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </h1> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlH1 staged_node(::std::move(result));
+                            call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_h2: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"h2">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </h2> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlH2 staged_node(::std::move(result));
+                            call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_h3: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"h3">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </h3> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlH3 staged_node(::std::move(result));
+                            call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_h4: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"h4">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </h4> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlH4 staged_node(::std::move(result));
+                            call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_h5: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"h5">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </h5> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlH5 staged_node(::std::move(result));
+                            call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_h6: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"h6">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </h6> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlH6 staged_node(::std::move(result));
+                            call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_del: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"del">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </del> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlDel staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_code: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"code">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </code> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlCode staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_note:
+                        [[unlikely]] {
+                            pltxt2htm_unreachable(u8"Unexpected html_note node during end-tag parsing");
+                        }
+                    case ::pltxt2htm::NodeKind::html_em: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"em">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </em> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlEm staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_strong: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"strong">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </strong> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlStrong staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_mark: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"mark">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </mark> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlMark staged_node(::std::move(result),
+                                                              ::std::move(frame.get_html_mark_background_color()));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_u: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"u">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </u> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlU staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::pl_s: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"s">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </s> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::PlS staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_sup: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"sup">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </sup> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlSup staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_sub: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"sub">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </sub> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlSub staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_table: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"table">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </table> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlTable staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_tr: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"tr">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </tr> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlTr staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_td: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"td">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </td> successed
+                            ::std::size_t const staged_index{current_index};
+                            auto const align = frame.get_cell_align();
+                            ::pltxt2htm::HtmlTd staged_node(::std::move(result), align);
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_th: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"th">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </th> successed
+                            ::std::size_t const staged_index{current_index};
+                            auto const align = frame.get_cell_align();
+                            ::pltxt2htm::HtmlTh staged_node(::std::move(result), align);
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_thead: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"thead">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </thead> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlThead staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_tbody: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"tbody">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </tbody> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlTbody staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_tfoot: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"tfoot">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </tfoot> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlTfoot staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_caption: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"caption">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </caption> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlCaption staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_colgroup: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"colgroup">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </colgroup> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlColgroup staged_node(::std::move(result));
+                            call_stack.pop();
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::html_blockquote: {
+                        if (auto opt_tag_len = ::pltxt2htm::details::try_parse_bare_tag<ndebug, u8"blockquote">(
+                                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2));
+                            opt_tag_len.has_value()) {
+                            // parsing end tag </blockquote> successed
+                            ::std::size_t const staged_index{current_index};
+                            ::pltxt2htm::HtmlBlockquote staged_node(::std::move(result));
+                            call_stack.pop();
+                            if (call_stack.empty()) {
+                                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{
+                                    .subast = ::std::move(staged_node.get_subast()),
+                                    .consumed_bytes =
+                                        staged_index +
+                                        opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() + 3};
+                            }
+                            auto& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+                            parent_frame.subast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::std::move(staged_node)));
+                            parent_frame.current_index +=
+                                staged_index + opt_tag_len.template value<ndebug == ::pltxt2htm::Contracts::ignore>() +
+                                3;
+                            goto entry;
+                        }
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::md_block_quotes:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::code_fence:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_del:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_link:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_atx_h1:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_atx_h2:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_atx_h3:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_atx_h4:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_atx_h5:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_atx_h6:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::text:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::list_li:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::list_li_checkbox:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_single_emphasis_asterisk:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_single_emphasis_underscore:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_double_emphasis_asterisk:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_double_emphasis_underscore:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_triple_emphasis_asterisk:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_triple_emphasis_underscore:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_code_span_1_backtick:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_code_span_2_backtick:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_code_span_3_backtick:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_latex_inline:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_latex_block:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_table:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_thead:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_tbody:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_tr:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_th:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_td: {
+                        // any tag contains `</` context would hit this branch
+                        result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                        ++current_index;
+                        continue;
+                    }
+                    case ::pltxt2htm::NodeKind::u8char:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::invalid_u8char:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::line_break:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::space:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::ampersand:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::entity_reference:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::double_quote:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::single_quote:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::less_than:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::greater_than:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::tab:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_hr:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::html_br:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::html_hr:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::html_col:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::html_img:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_image:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::url:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::pl_macro_project:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::pl_macro_visitor:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::pl_macro_author:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::pl_macro_coauthors:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::list_ul:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::list_ol:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_backslash:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_exclamation:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_double_quote:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_hash:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_dollar:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_percent:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_ampersand:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_single_quote:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_left_paren:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_right_paren:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_asterisk:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_plus:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_comma:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_hyphen:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_dot:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_slash:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_colon:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_semicolon:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_less_than:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_equals:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_greater_than:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_question:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_at:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_left_bracket:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_right_bracket:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_caret:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_underscore:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_backtick:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_left_brace:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_pipe:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_right_brace:
+                        [[fallthrough]];
+                    case ::pltxt2htm::NodeKind::md_escape_tilde:
+                        [[unlikely]] {
+                            pltxt2htm_unreachable(u8"Unexpected escape node kind in inner switch");
+                        }
+                    }
+                    pltxt2htm_unreachable(u8"Unreachable after escape-node inner switch");
+                }
+
+                default: {
+                    result.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::LessThan{}));
+                    ++current_index;
+                    continue;
+                }
+                }
+
+                pltxt2htm_unreachable(u8"Unreachable after outer switch");
+            }
+            auto const advance_count = ::pltxt2htm::details::parse_utf8_code_point<ndebug>(
+                ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index), result);
+            current_index += advance_count;
+            continue;
+        }
+        {
+            ::pltxt2htm::details::ParserFrameContext<ndebug> frame(
+                ::std::move(::pltxt2htm::details::stack_top<ndebug>(call_stack)));
+            ::std::size_t const staged_index = pltext_size;
+            call_stack.pop();
+            if (call_stack.empty()) {
+                // Considering the following markdown:
+                // ```md
+                // <b>e</b>xample
+                // ```
+                // Text without any tag in the end will hit this branch.
+                return ::pltxt2htm::details::InlineParsePlTxtResult<ndebug>{.subast = ::std::move(frame.subast),
+                                                                      .consumed_bytes = staged_index};
+            }
+            // Considering the following markdown:
+            // ```md
+            // <b>example
+            // ```
+            // Any tag without a closing tag will hit this branch.
+            auto&& subast = frame.subast;
+            auto&& parent_frame = ::pltxt2htm::details::stack_top<ndebug>(call_stack);
+            auto&& parent_ast = parent_frame.subast;
+            auto&& parent_index = parent_frame.current_index;
+            switch (frame.get_nested_tag_type()) /* -Werror=switch */ {
+            case ::pltxt2htm::NodeKind::pl_color: {
+                auto&& id = frame.get_equal_sign_tag_id();
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlColor<ndebug>{::std::move(subast), ::std::move(id)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_a: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlA<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_experiment: {
+                auto&& id = frame.get_equal_sign_tag_id();
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::PlExperiment<ndebug>{::std::move(subast), ::std::move(id)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_experiments: {
+                auto&& value = frame.get_equal_sign_tag_id();
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::PlExperiments<ndebug>{::std::move(subast), ::std::move(value)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_discussion: {
+                auto&& id = frame.get_equal_sign_tag_id();
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::PlDiscussion<ndebug>{::std::move(subast), ::std::move(id)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_discussions: {
+                auto&& value = frame.get_equal_sign_tag_id();
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::PlDiscussions<ndebug>{::std::move(subast), ::std::move(value)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_user: {
+                auto&& id = frame.get_equal_sign_tag_id();
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlUser<ndebug>{::std::move(subast), ::std::move(id)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_trigger: {
+                auto&& value = frame.get_equal_sign_tag_id();
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::PlTrigger<ndebug>{::std::move(subast), ::std::move(value)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_internal: {
+                auto&& value = frame.get_equal_sign_tag_id();
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::PlInternal<ndebug>{::std::move(subast), ::std::move(value)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_external: {
+                auto&& url = frame.get_external_tag_url();
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::PlExternal<ndebug>{::std::move(subast), ::std::move(url)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_link: {
+                auto&& url = frame.get_link_tag_url();
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlLink<ndebug>{::std::move(subast), ::std::move(url)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_size: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::PlSize<ndebug>{::std::move(subast), frame.get_pl_size_tag_value()}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_voffset: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::PlVoffset<ndebug>{::std::move(subast), frame.get_pl_voffset_tag_value()}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_align: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::PlAlign<ndebug>{::std::move(subast), frame.get_align()}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_margin: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlMargin<ndebug>{
+                    ::std::move(subast), frame.get_pl_margin_tag_left(), frame.get_pl_margin_tag_right()}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_div: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlDiv<ndebug>{
+                    ::std::move(subast), frame.get_html_div_left(), frame.get_html_div_right()}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_mark: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlMark<ndebug>{
+                    ::std::move(subast), ::std::move(frame.get_pl_mark_background_color())}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_span: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlSpan<ndebug>{
+                    ::std::move(subast), ::std::move(frame.get_html_span_color()), frame.get_html_span_font_size(),
+                    frame.get_html_span_vertical_align()}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_a: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlA<ndebug>{
+                    ::std::move(subast), ::std::move(frame.get_html_a_url()), frame.get_html_a_internal()}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_strong:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::pl_b: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlB<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_i: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlI<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_p: {
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlP<ndebug>{::std::move(subast), frame.get_align()}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_h1: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlH1<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_h2: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlH2<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_h3: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlH3<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_h4: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlH4<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_h5: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlH5<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_h6: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlH6<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_del: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlDel<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_code: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlCode<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_u: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlU<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::pl_s: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::PlS<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_sup: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlSup<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_sub: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlSub<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_em: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlEm<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_mark: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlMark<ndebug>{
+                    ::std::move(subast), ::std::move(frame.get_html_mark_background_color())}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::list_ul: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::ListUl<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::list_ol: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::ListOl<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::list_li: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::ListLi<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::list_li_checkbox: {
+                auto const checked = frame.get_checked();
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::ListLiCheckbox<ndebug>{::std::move(subast), checked}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::md_th: {
+                auto const align = frame.get_cell_align();
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdTh<ndebug>{::std::move(subast), align}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::md_td: {
+                auto const align = frame.get_cell_align();
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdTd<ndebug>{::std::move(subast), align}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_table: {
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlTable<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_tr: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlTr<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_td: {
+                auto const align = frame.get_cell_align();
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlTd<ndebug>{::std::move(subast), align}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_th: {
+                auto const align = frame.get_cell_align();
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlTh<ndebug>{::std::move(subast), align}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_thead: {
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlThead<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_tbody: {
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlTbody<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_tfoot: {
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlTfoot<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_caption: {
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlCaption<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_colgroup: {
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlColgroup<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::html_blockquote: {
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::HtmlBlockquote<ndebug>{::std::move(subast)}));
+                parent_index += staged_index;
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::md_atx_h1: {
+                pltxt2htm_unreachable(u8"Unexpected block node kind in inline context");
+            }
+            case ::pltxt2htm::NodeKind::md_atx_h2: {
+                pltxt2htm_unreachable(u8"Unexpected block node kind in inline context");
+            }
+            case ::pltxt2htm::NodeKind::md_atx_h3: {
+                pltxt2htm_unreachable(u8"Unexpected block node kind in inline context");
+            }
+            case ::pltxt2htm::NodeKind::md_atx_h4: {
+                pltxt2htm_unreachable(u8"Unexpected block node kind in inline context");
+            }
+            case ::pltxt2htm::NodeKind::md_atx_h5: {
+                pltxt2htm_unreachable(u8"Unexpected block node kind in inline context");
+            }
+            case ::pltxt2htm::NodeKind::md_atx_h6: {
+                pltxt2htm_unreachable(u8"Unexpected block node kind in inline context");
+            }
+            case ::pltxt2htm::NodeKind::md_code_span_1_backtick: {
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdCodeSpan1Backtick<ndebug>{::std::move(subast)}));
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::md_code_span_2_backtick: {
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdCodeSpan2Backtick<ndebug>{::std::move(subast)}));
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::md_code_span_3_backtick: {
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdCodeSpan3Backtick<ndebug>{::std::move(subast)}));
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::md_latex_inline: {
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdLatexInline<ndebug>{::std::move(subast)}));
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::md_latex_block: {
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdLatexBlock<ndebug>{::std::move(subast)}));
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::md_single_emphasis_asterisk: {
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdSingleEmphasisAsterisk<ndebug>{::std::move(subast)}));
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::md_single_emphasis_underscore: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::MdSingleEmphasisUnderscore<ndebug>{::std::move(subast)}));
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::md_double_emphasis_asterisk: {
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdDoubleEmphasisAsterisk<ndebug>{::std::move(subast)}));
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::md_double_emphasis_underscore: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::MdDoubleEmphasisUnderscore<ndebug>{::std::move(subast)}));
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::md_triple_emphasis_asterisk: {
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdTripleEmphasisAsterisk<ndebug>{::std::move(subast)}));
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::md_triple_emphasis_underscore: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::MdTripleEmphasisUnderscore<ndebug>{::std::move(subast)}));
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::md_del: {
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdDel<ndebug>{::std::move(subast)}));
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::md_block_quotes: {
+                parent_ast.push_back(
+                    ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdBlockQuotes<ndebug>{::std::move(subast)}));
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::md_link: {
+                auto&& link_url = frame.get_md_link_url();
+                parent_ast.push_back(::pltxt2htm::PlTxtNode<ndebug>(
+                    ::pltxt2htm::MdLink<ndebug>{::std::move(subast), ::std::move(link_url)}));
+                goto entry;
+            }
+            case ::pltxt2htm::NodeKind::u8char:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::invalid_u8char:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::text:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::line_break:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::space:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::ampersand:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::entity_reference:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::double_quote:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::single_quote:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::less_than:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::greater_than:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::tab:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::html_br:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::html_hr:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::html_col:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::html_img:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_backslash:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_exclamation:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_double_quote:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_hash:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_dollar:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_percent:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_ampersand:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_single_quote:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_left_paren:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_right_paren:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_asterisk:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_plus:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_comma:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_hyphen:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_dot:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_slash:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_colon:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_semicolon:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_less_than:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_equals:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_greater_than:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_question:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_at:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_left_bracket:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_right_bracket:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_caret:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_underscore:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_backtick:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_left_brace:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_pipe:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_right_brace:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_escape_tilde:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_table:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_thead:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_tbody:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_tr:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_hr:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::code_fence:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::html_note:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::md_image:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::url:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::pl_macro_project:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::pl_macro_visitor:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::pl_macro_author:
+                [[fallthrough]];
+            case ::pltxt2htm::NodeKind::pl_macro_coauthors:
+                [[unlikely]] {
+                    pltxt2htm_unreachable(u8"Unexpected block node kind in inline context");
+                }
+            }
+            pltxt2htm_unreachable(u8"Unreachable after block-node-in-inline switch");
+        }
+    }
+}
+
+} // namespace pltxt2htm::details
+
+namespace pltxt2htm {
+
+/**
+ * @brief Parse pl-text into an Abstract Syntax Tree (AST), inline constructs only.
+ * @details This is the inline-only counterpart of ::pltxt2htm::parse_pltxt.  It
+ *          pushes a single text frame and parses only inline syntax; block-level
+ *          syntax is preserved as literal text.
+ * @tparam ndebug Contract-checking mode for parsing, using `::pltxt2htm::Contracts`
+ *                 values such as `::pltxt2htm::Contracts::quick_enforce` or
+ *                 `::pltxt2htm::Contracts::ignore`
+ * @param[in] pltext The Physics-Lab text content to parse
+ * @return An AST representing the parsed inline structure of the input text
+ * @see pltxt2htm::details::inline_parse_pltxt for the internal implementation
+ */
+template<::pltxt2htm::Contracts ndebug>
+[[nodiscard]]
+constexpr auto inline_parse_pltxt(::fast_io::u8string_view pltext) noexcept -> ::pltxt2htm::Ast<ndebug> {
+    // This stack is used to track nested tag contexts during parsing
+    ::fast_io::stack<::pltxt2htm::details::ParserFrameContext<ndebug>> call_stack{};
+
+    call_stack.push(::pltxt2htm::details::ParserFrameContext<ndebug>(
+        ::pltxt2htm::details::FrontendContextVariant<ndebug>{
+            ::pltxt2htm::details::ParserFrameContextWithPltextInfo{pltext}, ::pltxt2htm::NodeKind::text},
+        ::pltxt2htm::Ast<ndebug>{}));
+
+    auto&& [subast, consumed_bytes] = ::pltxt2htm::details::inline_parse_pltxt<ndebug>(call_stack);
+
+    bool const call_stack_is_empty{call_stack.empty()};
+    pltxt2htm_assert(call_stack_is_empty, u8"call_stack is not empty");
+
+    return ::std::move(subast);
+}
+
+} // namespace pltxt2htm
+
+#include "details/pop_macro.hh"

--- a/include/pltxt2htm/pltxt2htm.hh
+++ b/include/pltxt2htm/pltxt2htm.hh
@@ -21,6 +21,7 @@
 #include <exception/exception.hh>
 #include "contracts.hh"
 #include "parser.hh"
+#include "inline_parser.hh"
 #include "optimizer.hh"
 #include "details/backend/for_plweb_text.hh"
 #include "details/backend/for_plweb_title.hh"
@@ -124,6 +125,10 @@ constexpr auto pltxt2plunity_introduction(::fast_io::u8string_view pltext, ::fas
  *          - Bold (&lt;b&gt;) and italic (&lt;i&gt;) tags only
  *          - Basic HTML escaping and formatting
  *
+ *          The text is parsed with the inline-only parser: block-level syntax
+ *          (md-atx headings, md-block-quotes, md-list, md-table, code fences and
+ *          HTML block tags) is preserved as literal text.
+ *
  *          This function is suitable for:
  *          - Simple text formatting needs
  *          - Header rendering where complex formatting isn't needed
@@ -135,14 +140,14 @@ constexpr auto pltxt2plunity_introduction(::fast_io::u8string_view pltext, ::fas
  * @return Generated HTML string with basic formatting support
  * @retval fast_io::u8string UTF-8 string containing the generated basic HTML
  * @note This function is faster than the advanced versions but supports fewer features
- * @warning Markdown syntax and advanced HTML features are not supported in this mode
+ * @note Markdown block syntax and block-level HTML tags render as literal text in this mode
  * @warning AST optimization is disabled by default for this function
  */
 template<::pltxt2htm::Contracts ndebug = ::pltxt2htm::Contracts::quick_enforce, bool optimize = false>
 [[nodiscard]]
 constexpr auto pltxt2common_html(::fast_io::u8string_view pltext) noexcept {
     using parser_result_type = ::std::conditional_t<optimize, ::pltxt2htm::Ast<ndebug>, ::pltxt2htm::Ast<ndebug> const>;
-    parser_result_type ast{::pltxt2htm::parse_pltxt<ndebug>(pltext)};
+    parser_result_type ast{::pltxt2htm::inline_parse_pltxt<ndebug>(pltext)};
     if constexpr (optimize) {
         ::pltxt2htm::optimize_ast<ndebug>(ast);
     }

--- a/tests/test_common_parser.cc
+++ b/tests/test_common_parser.cc
@@ -218,9 +218,9 @@ int main() {
     {
         auto html =
             ::pltxt2htm_test::pltxt2common_htmld(u8"<h1>1</h1><h2>2</h2><h3>3</h3><h4>4</h4><h5>5</h5><h6>6</h6>");
-        auto answer =
-            ::fast_io::u8string_view{u8"&lt;h1&gt;1&lt;/h1&gt;&lt;h2&gt;2&lt;/h2&gt;&lt;h3&gt;3&lt;/h3&gt;"
-                                     u8"&lt;h4&gt;4&lt;/h4&gt;&lt;h5&gt;5&lt;/h5&gt;&lt;h6&gt;6&lt;/h6&gt;"};
+        auto answer = ::fast_io::u8string_view{
+            u8"&lt;h1&gt;1&lt;/h1&gt;&lt;h2&gt;2&lt;/h2&gt;&lt;h3&gt;3&lt;/h3&gt;"
+            u8"&lt;h4&gt;4&lt;/h4&gt;&lt;h5&gt;5&lt;/h5&gt;&lt;h6&gt;6&lt;/h6&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -232,7 +232,8 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt2common_htmld(u8"<ul><li>u</li></ul><ol><li>o</li></ol>");
-        auto answer = ::fast_io::u8string_view{u8"&lt;ul&gt;&lt;li&gt;u&lt;/li&gt;&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;o&lt;/li&gt;&lt;/ol&gt;"};
+        auto answer = ::fast_io::u8string_view{
+            u8"&lt;ul&gt;&lt;li&gt;u&lt;/li&gt;&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;o&lt;/li&gt;&lt;/ol&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -256,7 +257,8 @@ int main() {
     {
         auto html = ::pltxt2htm_test::pltxt2common_htmld(
             u8"<hr><input type=\"checkbox\" disabled><img src=\"a.png\" alt=\"a\"><!-- note -->");
-        auto answer = ::fast_io::u8string_view{u8"&lt;hr&gt;&lt;input&nbsp;type=&quot;checkbox&quot;&nbsp;disabled&gt;"};
+        auto answer =
+            ::fast_io::u8string_view{u8"&lt;hr&gt;&lt;input&nbsp;type=&quot;checkbox&quot;&nbsp;disabled&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -286,8 +288,7 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt2common_htmld(u8"# 1\n## 2\n### 3\n#### 4\n##### 5\n###### 6");
-        auto answer =
-            ::fast_io::u8string_view{u8"#&nbsp;1##&nbsp;2###&nbsp;3####&nbsp;4#####&nbsp;5######&nbsp;6"};
+        auto answer = ::fast_io::u8string_view{u8"#&nbsp;1##&nbsp;2###&nbsp;3####&nbsp;4#####&nbsp;5######&nbsp;6"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_common_parser.cc
+++ b/tests/test_common_parser.cc
@@ -15,7 +15,7 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt2common_htmld(u8"<h3>test");
-        auto answer = ::fast_io::u8string_view{u8"test"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;h3&gt;test"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -211,14 +211,16 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt2common_htmld(u8"<p>text</p>");
-        auto answer = ::fast_io::u8string_view{u8"text"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;p&gt;text&lt;/p&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html =
             ::pltxt2htm_test::pltxt2common_htmld(u8"<h1>1</h1><h2>2</h2><h3>3</h3><h4>4</h4><h5>5</h5><h6>6</h6>");
-        auto answer = ::fast_io::u8string_view{u8"123456"};
+        auto answer =
+            ::fast_io::u8string_view{u8"&lt;h1&gt;1&lt;/h1&gt;&lt;h2&gt;2&lt;/h2&gt;&lt;h3&gt;3&lt;/h3&gt;"
+                                     u8"&lt;h4&gt;4&lt;/h4&gt;&lt;h5&gt;5&lt;/h5&gt;&lt;h6&gt;6&lt;/h6&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -230,7 +232,7 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt2common_htmld(u8"<ul><li>u</li></ul><ol><li>o</li></ol>");
-        auto answer = ::fast_io::u8string_view{u8"uo"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;ul&gt;&lt;li&gt;u&lt;/li&gt;&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;o&lt;/li&gt;&lt;/ol&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -254,7 +256,7 @@ int main() {
     {
         auto html = ::pltxt2htm_test::pltxt2common_htmld(
             u8"<hr><input type=\"checkbox\" disabled><img src=\"a.png\" alt=\"a\"><!-- note -->");
-        auto answer = ::fast_io::u8string_view{u8"&lt;input&nbsp;type=&quot;checkbox&quot;&nbsp;disabled&gt;"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;hr&gt;&lt;input&nbsp;type=&quot;checkbox&quot;&nbsp;disabled&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -266,37 +268,38 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt2common_htmld(u8"- item");
-        auto answer = ::fast_io::u8string_view{u8"item"};
+        auto answer = ::fast_io::u8string_view{u8"-&nbsp;item"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt2common_htmld(u8"1. item");
-        auto answer = ::fast_io::u8string_view{u8"item"};
+        auto answer = ::fast_io::u8string_view{u8"1.&nbsp;item"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt2common_htmld(u8"- [x] item");
-        auto answer = ::fast_io::u8string_view{u8"item"};
+        auto answer = ::fast_io::u8string_view{u8"-&nbsp;[x]&nbsp;item"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt2common_htmld(u8"# 1\n## 2\n### 3\n#### 4\n##### 5\n###### 6");
-        auto answer = ::fast_io::u8string_view{u8"123456"};
+        auto answer =
+            ::fast_io::u8string_view{u8"#&nbsp;1##&nbsp;2###&nbsp;3####&nbsp;4#####&nbsp;5######&nbsp;6"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt2common_htmld(u8"> quote");
-        auto answer = ::fast_io::u8string_view{u8"quote"};
+        auto answer = ::fast_io::u8string_view{u8"&gt;&nbsp;quote"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
     {
         auto html = ::pltxt2htm_test::pltxt2common_htmld(u8"| h |\n|-|\n| d |");
-        auto answer = ::fast_io::u8string_view{u8"hd"};
+        auto answer = ::fast_io::u8string_view{u8"|&nbsp;h&nbsp;||-||&nbsp;d&nbsp;|"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -308,7 +311,7 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt2common_htmld(u8"```\ncode\n```\n~~~\nmore\n~~~");
-        auto answer = ::fast_io::u8string_view{u8"codemore"};
+        auto answer = ::fast_io::u8string_view{u8"```code```~~~more~~~"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -326,7 +329,7 @@ int main() {
 
     {
         auto html = ::pltxt2htm_test::pltxt2common_htmld(u8"---");
-        auto answer = ::fast_io::u8string_view{u8""};
+        auto answer = ::fast_io::u8string_view{u8"---"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_html_div_tag.cc
+++ b/tests/test_html_div_tag.cc
@@ -191,10 +191,10 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
     }
 
-    // the title backend (pltxt2common_html) keeps the div content but drops the tag itself
+    // the title backend (pltxt2common_html) renders the block-level div literally
     {
         auto html = ::pltxt2htm_test::pltxt2common_htmld(u8"<div style=\"margin-left:2em\">text</div>");
-        auto answer = ::fast_io::u8string_view{u8"text"};
+        auto answer = ::fast_io::u8string_view{u8"&lt;div&nbsp;style=&quot;margin-left:2em&quot;&gt;text&lt;/div&gt;"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_html_ul_and_li_tag.cc
+++ b/tests/test_html_ul_and_li_tag.cc
@@ -141,7 +141,8 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
     }
     {
-        auto html = ::pltxt2htm_test::pltxt4unittest(u8"<ul><li>text<ul><li>text</li></ul><ul><li>text</li></ul></li></ul>");
+        auto html =
+            ::pltxt2htm_test::pltxt4unittest(u8"<ul><li>text<ul><li>text</li></ul><ul><li>text</li></ul></li></ul>");
         auto answer = ::fast_io::u8string_view{u8"<ul><li>text<ul><li>text</li></ul><ul><li>text</li></ul></li></ul>"};
         pltxt2htm_test_assert_equal(html, answer);
     }

--- a/tests/test_md_ul_list.cc
+++ b/tests/test_md_ul_list.cc
@@ -207,12 +207,13 @@ int main() {
     // emit it only once, otherwise the emitted HTML (<ul> directly inside <ul> plus a
     // stray </li>) is rejected by the HTML list scanner and the roundtrip diverges.
     {
-        auto pltext =
-            ::fast_io::u8string_view{u8"*\t&\n\t\t\t\t*\t&*\t\t&*\t&\n\t\t*\t\n\t\t*\t\t\t~~~\t \"  & \n"};
+        auto pltext = ::fast_io::u8string_view{u8"*\t&\n\t\t\t\t*\t&*\t\t&*\t&\n\t\t*\t\n\t\t*\t\t\t~~~\t \"  & \n"};
         auto once = ::pltxt2htm_test::pltxt2roundtrip_htmld(pltext);
         auto once_answer = ::fast_io::u8string_view{
-            u8"<ul><li>&amp;<ul><li>&amp;<em>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&amp;</em>&nbsp;&nbsp;&nbsp;&nbsp;"
-            u8"&amp;</li></ul><ul><li></li><li>~~~&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;&nbsp;&nbsp;&amp;</li></ul></li></ul>"};
+            u8"<ul><li>&amp;<ul><li>&amp;<em>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&amp;</"
+            u8"em>&nbsp;&nbsp;&nbsp;&nbsp;"
+            u8"&amp;</li></ul><ul><li></li><li>~~~&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;&nbsp;&nbsp;&amp;</li></ul></"
+            u8"li></ul>"};
         pltxt2htm_test_assert_equal(once, once_answer);
         auto twice = ::pltxt2htm_test::pltxt4htmlunittest(::fast_io::u8string_view{once.data(), once.size()});
         pltxt2htm_test_assert_equal(twice, once);


### PR DESCRIPTION
Extract the inline portion of parse_pltxt into a standalone inline parser so pltxt2common_html no longer strips block-level syntax. Block constructs (md-atx headings, block quotes, lists, tables, code fences, and HTML block tags) now render as literal text, while inline tags, emphasis, links, code spans, and latex parse as before.