### PR TITLE
fix: crash and unreasonable parsing of Markdown code spans

### DIFF
--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -746,9 +746,9 @@ entry:
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
                 opt_code_span_3_backtick.has_value()) {
                 // parsing markdown ```example```
-                auto&& [advance_count, content_begin, content_size, subast] =
+                auto&& [content_size, subast] =
                     opt_code_span_3_backtick.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-                current_index += advance_count;
+                current_index += content_size + 6;
                 result.push_back(
                     ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdCodeSpan3Backtick<ndebug>{::std::move(subast)}));
                 continue;
@@ -757,9 +757,9 @@ entry:
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
                 opt_code_span_2_backtick.has_value()) {
                 // parsing markdown ``example``
-                auto&& [advance_count, content_begin, content_size, subast] =
+                auto&& [content_size, subast] =
                     opt_code_span_2_backtick.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-                current_index += advance_count;
+                current_index += content_size + 4;
                 result.push_back(
                     ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdCodeSpan2Backtick<ndebug>{::std::move(subast)}));
                 continue;
@@ -768,9 +768,9 @@ entry:
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
                 opt_code_span_1_backtick.has_value()) {
                 // parsing markdown `example`
-                auto&& [advance_count, content_begin, content_size, subast] =
+                auto&& [content_size, subast] =
                     opt_code_span_1_backtick.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-                current_index += advance_count;
+                current_index += content_size + 2;
                 result.push_back(
                     ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdCodeSpan1Backtick<ndebug>{::std::move(subast)}));
                 continue;

--- a/include/pltxt2htm/details/parser/parser.hh
+++ b/include/pltxt2htm/details/parser/parser.hh
@@ -746,7 +746,7 @@ entry:
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
                 opt_code_span_3_backtick.has_value()) {
                 // parsing markdown ```example```
-                auto&& [advance_count, subast] =
+                auto&& [advance_count, content_begin, content_size, subast] =
                     opt_code_span_3_backtick.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                 current_index += advance_count;
                 result.push_back(
@@ -757,7 +757,7 @@ entry:
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
                 opt_code_span_2_backtick.has_value()) {
                 // parsing markdown ``example``
-                auto&& [advance_count, subast] =
+                auto&& [advance_count, content_begin, content_size, subast] =
                     opt_code_span_2_backtick.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                 current_index += advance_count;
                 result.push_back(
@@ -768,7 +768,7 @@ entry:
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
                 opt_code_span_1_backtick.has_value()) {
                 // parsing markdown `example`
-                auto&& [advance_count, subast] =
+                auto&& [advance_count, content_begin, content_size, subast] =
                     opt_code_span_1_backtick.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                 current_index += advance_count;
                 result.push_back(
@@ -894,7 +894,7 @@ entry:
                         auto const tag_len = a_tag.tag_len;
                         auto const span =
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index, tag_len + 2);
-                        auto&& [_, literal_ast] =
+                        auto&& [_, literal_ast, found_end_] =
                             ::pltxt2htm::details::simply_parse_pltext<ndebug,
                                                                       ::pltxt2htm::details::U8LiteralString<0>{}>(span);
                         result.append_range(::std::move(literal_ast));
@@ -1098,7 +1098,7 @@ entry:
                         auto const tag_len = external_tag.tag_len;
                         auto const span =
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index, tag_len + 3);
-                        auto&& [_, literal_ast] =
+                        auto&& [_, literal_ast, found_end_] =
                             ::pltxt2htm::details::simply_parse_pltext<ndebug,
                                                                       ::pltxt2htm::details::U8LiteralString<0>{}>(span);
                         result.append_range(::std::move(literal_ast));
@@ -1198,7 +1198,7 @@ entry:
                         auto const tag_len = link_tag.tag_len;
                         auto const span =
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index, tag_len + 3);
-                        auto&& [_, literal_ast] =
+                        auto&& [_, literal_ast, found_end_] =
                             ::pltxt2htm::details::simply_parse_pltext<ndebug,
                                                                       ::pltxt2htm::details::U8LiteralString<0>{}>(span);
                         result.append_range(::std::move(literal_ast));

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -3306,6 +3306,7 @@ template<::pltxt2htm::Contracts ndebug>
 struct SimplyParsePLtextResult {
     ::std::size_t advance_count; ///< Number of characters consumed.
     ::pltxt2htm::Ast<ndebug> ast; ///< Parsed AST.
+    bool found_end; ///< Whether `end_string` was actually matched (only meaningful when end_string is non-empty).
 };
 
 template<::pltxt2htm::Contracts ndebug>
@@ -3392,6 +3393,7 @@ constexpr auto simply_parse_pltext(::fast_io::u8string_view pltext) noexcept
     ::pltxt2htm::Ast<ndebug> ast{};
     ::std::size_t current_index{};
     constexpr ::std::size_t end_size{end_string.size()};
+    bool found_end{};
 
     while (current_index < pltext_size) {
         char8_t const chr{::pltxt2htm::details::u8string_view_index<ndebug>(pltext, current_index)};
@@ -3400,6 +3402,7 @@ constexpr auto simply_parse_pltext(::fast_io::u8string_view pltext) noexcept
             if (::pltxt2htm::details::is_prefix_match<ndebug, end_string>(
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index))) {
                 current_index += end_size;
+                found_end = true;
                 break;
             }
         }
@@ -3468,7 +3471,7 @@ constexpr auto simply_parse_pltext(::fast_io::u8string_view pltext) noexcept
         current_index += advance_count;
         continue;
     }
-    return {.advance_count = current_index, .ast = ::std::move(ast)};
+    return {.advance_count = current_index, .ast = ::std::move(ast), .found_end = found_end};
 }
 
 template<::pltxt2htm::Contracts ndebug>
@@ -3528,8 +3531,14 @@ constexpr auto try_parse_html_pre_code_block(::fast_io::u8string_view pltext) no
 
     // parse content until the closing </code></pre>
     constexpr auto end_string = ::pltxt2htm::details::U8LiteralString{u8"</code></pre>"};
-    auto&& [advance_count, ast] = ::pltxt2htm::details::simply_parse_pltext<ndebug, end_string, process_md_escape>(
-        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, pos));
+    auto&& [advance_count, ast, found_end] =
+        ::pltxt2htm::details::simply_parse_pltext<ndebug, end_string, process_md_escape>(
+            ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, pos));
+    if (found_end == false) {
+        // No closing </code></pre> in the input: treat the whole construct as literal
+        // text instead of an unterminated code block.
+        return ::exception::nullopt;
+    }
     pos += advance_count;
 
     // <code class="language-..."> stores the full class value; CodeFence stores only the suffix
@@ -3729,7 +3738,7 @@ constexpr auto try_parse_md_code_fence_(::fast_io::u8string_view pltext) noexcep
     if (auto opt_fence_end = ::pltxt2htm::details::find_md_code_fence_end<ndebug, is_backtick>(content);
         opt_fence_end.has_value()) {
         auto&& [content_end, consumed] = opt_fence_end.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
-        auto&& [_, ast_] =
+        auto&& [_, ast_, found_end_] =
             ::pltxt2htm::details::simply_parse_pltext<ndebug, ::pltxt2htm::details::U8LiteralString<0>{}>(
                 ::pltxt2htm::details::u8string_view_subview<ndebug>(content, 0, content_end));
         ast = ::std::move(ast_);
@@ -3737,7 +3746,7 @@ constexpr auto try_parse_md_code_fence_(::fast_io::u8string_view pltext) noexcep
     }
     else {
         // No valid closing fence: content runs to the end of the input.
-        auto&& [advance_count, ast_] =
+        auto&& [advance_count, ast_, found_end_] =
             ::pltxt2htm::details::simply_parse_pltext<ndebug, ::pltxt2htm::details::U8LiteralString<0>{}>(content);
         ast = ::std::move(ast_);
         current_index += advance_count;
@@ -3910,8 +3919,10 @@ constexpr auto try_parse_md_block_quotes(::fast_io::u8string_view pltext) noexce
 
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseMdCodeSpanResult {
-    ::std::size_t advance_count; ///< Number of characters consumed.
-    ::pltxt2htm::Ast<ndebug> subast; ///< Parsed AST for the code span.
+    ::std::size_t advance_count; ///< Number of characters consumed (both delimiters and content).
+    ::std::size_t content_begin; ///< Offset of the content within `pltext` (equals the delimiter size).
+    ::std::size_t content_size; ///< Length of the content (excluding both delimiters).
+    ::pltxt2htm::Ast<ndebug> subast; ///< Parsed AST for the code span content.
 };
 
 /**
@@ -3930,6 +3941,8 @@ struct TryParseMdCodeSpanResult {
  * @note The content is parsed as plain text and converted to appropriate AST nodes.
  * @note Code spans cannot contain newline characters - they must be single-line.
  * @note Empty code spans are valid and will be parsed.
+ * @note An opening delimiter without a matching closing delimiter is NOT a code span;
+ *       the function returns nullopt so the input stays literal text.
  * @see https://spec.commonmark.org/0.31.2/#code-spans
  */
 template<::pltxt2htm::Contracts ndebug, ::pltxt2htm::details::U8LiteralString embraced_string>
@@ -3941,10 +3954,17 @@ constexpr auto try_parse_md_code_span(::fast_io::u8string_view pltext) noexcept
         return ::exception::nullopt;
     }
 
-    auto&& [advance_count, ast] = ::pltxt2htm::details::simply_parse_pltext<ndebug, embraced_string>(
+    auto&& [advance_count, ast, found_end] = ::pltxt2htm::details::simply_parse_pltext<ndebug, embraced_string>(
         ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, embraced_size));
+    if (found_end == false) {
+        // The closing delimiter is missing: `advance_count` only reaches the end of the
+        // input, so treating this as a code span would silently drop the unclosed backticks.
+        return ::exception::nullopt;
+    }
 
     return ::pltxt2htm::details::TryParseMdCodeSpanResult<ndebug>{.advance_count = advance_count + embraced_size,
+                                                                  .content_begin = embraced_size,
+                                                                  .content_size = advance_count - embraced_size,
                                                                   .subast = ::std::move(ast)};
 }
 

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -3919,8 +3919,6 @@ constexpr auto try_parse_md_block_quotes(::fast_io::u8string_view pltext) noexce
 
 template<::pltxt2htm::Contracts ndebug>
 struct TryParseMdCodeSpanResult {
-    ::std::size_t advance_count; ///< Number of characters consumed (both delimiters and content).
-    ::std::size_t content_begin; ///< Offset of the content within `pltext` (equals the delimiter size).
     ::std::size_t content_size; ///< Length of the content (excluding both delimiters).
     ::pltxt2htm::Ast<ndebug> subast; ///< Parsed AST for the code span content.
 };
@@ -3935,7 +3933,7 @@ struct TryParseMdCodeSpanResult {
  * @tparam ndebug When set to `::pltxt2htm::Contracts::ignore`, runtime assertions are disabled for performance.
  * @tparam embraced_string The delimiter string enclosing the code span.
  * @param[in] pltext The input text to parse, starting at the opening delimiter.
- * @return The parsed result containing the code content AST and continuation index, or nullopt if parsing fails.
+ * @return The parsed result containing the content length and the code content AST, or nullopt if parsing fails.
  * @note The delimiter length determines the minimum number of consecutive backticks that can appear
  *       in the code content without prematurely ending the span.
  * @note The content is parsed as plain text and converted to appropriate AST nodes.
@@ -3962,9 +3960,7 @@ constexpr auto try_parse_md_code_span(::fast_io::u8string_view pltext) noexcept
         return ::exception::nullopt;
     }
 
-    return ::pltxt2htm::details::TryParseMdCodeSpanResult<ndebug>{.advance_count = advance_count + embraced_size,
-                                                                  .content_begin = embraced_size,
-                                                                  .content_size = advance_count - embraced_size,
+    return ::pltxt2htm::details::TryParseMdCodeSpanResult<ndebug>{.content_size = advance_count - embraced_size,
                                                                   .subast = ::std::move(ast)};
 }
 

--- a/include/pltxt2htm/details/parser/try_parse.hh
+++ b/include/pltxt2htm/details/parser/try_parse.hh
@@ -3938,7 +3938,7 @@ struct TryParseMdCodeSpanResult {
  *       in the code content without prematurely ending the span.
  * @note The content is parsed as plain text and converted to appropriate AST nodes.
  * @note Code spans cannot contain newline characters - they must be single-line.
- * @note Empty code spans are valid and will be parsed.
+ * @note Empty code spans are NOT code spans; the function returns nullopt so the input stays literal text.
  * @note An opening delimiter without a matching closing delimiter is NOT a code span;
  *       the function returns nullopt so the input stays literal text.
  * @see https://spec.commonmark.org/0.31.2/#code-spans
@@ -3959,8 +3959,13 @@ constexpr auto try_parse_md_code_span(::fast_io::u8string_view pltext) noexcept
         // input, so treating this as a code span would silently drop the unclosed backticks.
         return ::exception::nullopt;
     }
+    ::std::size_t const content_size{advance_count - embraced_size};
+    if (content_size == 0) {
+        // Empty content: an empty code span is not meaningful, so it stays literal text.
+        return ::exception::nullopt;
+    }
 
-    return ::pltxt2htm::details::TryParseMdCodeSpanResult<ndebug>{.content_size = advance_count - embraced_size,
+    return ::pltxt2htm::details::TryParseMdCodeSpanResult<ndebug>{.content_size = content_size,
                                                                   .subast = ::std::move(ast)};
 }
 

--- a/include/pltxt2htm/inline_parser.hh
+++ b/include/pltxt2htm/inline_parser.hh
@@ -280,12 +280,11 @@ entry:
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
                 opt_code_span_3_backtick.has_value()) {
                 // parsing markdown ```example```
-                auto&& [advance_count, content_begin, content_size, subast] =
+                auto&& [content_size, subast] =
                     opt_code_span_3_backtick.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                 if (::pltxt2htm::details::is_inline_code_span_content<ndebug>(
-                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + content_begin,
-                                                                            content_size))) {
-                    current_index += advance_count;
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 3, content_size))) {
+                    current_index += content_size + 6;
                     result.push_back(
                         ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdCodeSpan3Backtick<ndebug>{::std::move(subast)}));
                     continue;
@@ -295,12 +294,11 @@ entry:
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
                 opt_code_span_2_backtick.has_value()) {
                 // parsing markdown ``example``
-                auto&& [advance_count, content_begin, content_size, subast] =
+                auto&& [content_size, subast] =
                     opt_code_span_2_backtick.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                 if (::pltxt2htm::details::is_inline_code_span_content<ndebug>(
-                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + content_begin,
-                                                                            content_size))) {
-                    current_index += advance_count;
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2, content_size))) {
+                    current_index += content_size + 4;
                     result.push_back(
                         ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdCodeSpan2Backtick<ndebug>{::std::move(subast)}));
                     continue;
@@ -310,12 +308,11 @@ entry:
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
                 opt_code_span_1_backtick.has_value()) {
                 // parsing markdown `example`
-                auto&& [advance_count, content_begin, content_size, subast] =
+                auto&& [content_size, subast] =
                     opt_code_span_1_backtick.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                 if (::pltxt2htm::details::is_inline_code_span_content<ndebug>(
-                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + content_begin,
-                                                                            content_size))) {
-                    current_index += advance_count;
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 1, content_size))) {
+                    current_index += content_size + 2;
                     result.push_back(
                         ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdCodeSpan1Backtick<ndebug>{::std::move(subast)}));
                     continue;

--- a/include/pltxt2htm/inline_parser.hh
+++ b/include/pltxt2htm/inline_parser.hh
@@ -280,11 +280,11 @@ entry:
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
                 opt_code_span_3_backtick.has_value()) {
                 // parsing markdown ```example```
-                auto&& [advance_count, subast] =
+                auto&& [advance_count, content_begin, content_size, subast] =
                     opt_code_span_3_backtick.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                 if (::pltxt2htm::details::is_inline_code_span_content<ndebug>(
-                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 3,
-                                                                            advance_count - 6))) {
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + content_begin,
+                                                                            content_size))) {
                     current_index += advance_count;
                     result.push_back(
                         ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdCodeSpan3Backtick<ndebug>{::std::move(subast)}));
@@ -295,11 +295,11 @@ entry:
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
                 opt_code_span_2_backtick.has_value()) {
                 // parsing markdown ``example``
-                auto&& [advance_count, subast] =
+                auto&& [advance_count, content_begin, content_size, subast] =
                     opt_code_span_2_backtick.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                 if (::pltxt2htm::details::is_inline_code_span_content<ndebug>(
-                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 2,
-                                                                            advance_count - 4))) {
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + content_begin,
+                                                                            content_size))) {
                     current_index += advance_count;
                     result.push_back(
                         ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdCodeSpan2Backtick<ndebug>{::std::move(subast)}));
@@ -310,11 +310,11 @@ entry:
                     ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index));
                 opt_code_span_1_backtick.has_value()) {
                 // parsing markdown `example`
-                auto&& [advance_count, subast] =
+                auto&& [advance_count, content_begin, content_size, subast] =
                     opt_code_span_1_backtick.template value<ndebug == ::pltxt2htm::Contracts::ignore>();
                 if (::pltxt2htm::details::is_inline_code_span_content<ndebug>(
-                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + 1,
-                                                                            advance_count - 2))) {
+                        ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index + content_begin,
+                                                                            content_size))) {
                     current_index += advance_count;
                     result.push_back(
                         ::pltxt2htm::PlTxtNode<ndebug>(::pltxt2htm::MdCodeSpan1Backtick<ndebug>{::std::move(subast)}));
@@ -439,7 +439,7 @@ entry:
                         auto const tag_len = a_tag.tag_len;
                         auto const span =
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index, tag_len + 2);
-                        auto&& [_, literal_ast] =
+                        auto&& [_, literal_ast, found_end_] =
                             ::pltxt2htm::details::simply_parse_pltext<ndebug,
                                                                       ::pltxt2htm::details::U8LiteralString<0>{}>(span);
                         result.append_range(::std::move(literal_ast));
@@ -634,7 +634,7 @@ entry:
                         auto const tag_len = external_tag.tag_len;
                         auto const span =
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index, tag_len + 3);
-                        auto&& [_, literal_ast] =
+                        auto&& [_, literal_ast, found_end_] =
                             ::pltxt2htm::details::simply_parse_pltext<ndebug,
                                                                       ::pltxt2htm::details::U8LiteralString<0>{}>(span);
                         result.append_range(::std::move(literal_ast));
@@ -734,7 +734,7 @@ entry:
                         auto const tag_len = link_tag.tag_len;
                         auto const span =
                             ::pltxt2htm::details::u8string_view_subview<ndebug>(pltext, current_index, tag_len + 3);
-                        auto&& [_, literal_ast] =
+                        auto&& [_, literal_ast, found_end_] =
                             ::pltxt2htm::details::simply_parse_pltext<ndebug,
                                                                       ::pltxt2htm::details::U8LiteralString<0>{}>(span);
                         result.append_range(::std::move(literal_ast));

--- a/tests/test_md_code_fence.cc
+++ b/tests/test_md_code_fence.cc
@@ -230,12 +230,11 @@ print("Hello World")
     }
 
     {
-        // 5 backticks: first 3 open an inline code span, remaining 2 are content.
-        // A space after some "language-like" text, followed by content without a newline,
-        // causes the block-level fence parser to bail out, falling through to
-        // inline code span parsing.
+        // 5 backticks followed by content without a newline: the block-level fence parser
+        // bails out, and the inline code-span branches only ever match empty content
+        // (e.g. the first two backticks), which is rejected. The whole input stays literal.
         auto html = ::pltxt2htm_test::pltxt2fixedadv_htmld(u8"`````a bc");
-        auto answer = ::fast_io::u8string_view{u8"<code></code>`a&nbsp;bc"};
+        auto answer = ::fast_io::u8string_view{u8"`````a&nbsp;bc"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_md_code_fence.cc
+++ b/tests/test_md_code_fence.cc
@@ -235,7 +235,7 @@ print("Hello World")
         // causes the block-level fence parser to bail out, falling through to
         // inline code span parsing.
         auto html = ::pltxt2htm_test::pltxt2fixedadv_htmld(u8"`````a bc");
-        auto answer = ::fast_io::u8string_view{u8"<code>``a&nbsp;bc</code>"};
+        auto answer = ::fast_io::u8string_view{u8"<code></code>`a&nbsp;bc"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 

--- a/tests/test_md_code_span.cc
+++ b/tests/test_md_code_span.cc
@@ -102,14 +102,15 @@ int main() {
         auto answer = ::fast_io::u8string_view{u8"`"};
         pltxt2htm_test_assert_equal(html, answer);
     }
+    // A delimiter run with no content is NOT a code span and stays literal text.
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"``");
-        auto answer = ::fast_io::u8string_view{u8"<code></code>"};
+        auto answer = ::fast_io::u8string_view{u8"``"};
         pltxt2htm_test_assert_equal(html, answer);
     }
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"```");
-        auto answer = ::fast_io::u8string_view{u8"<code></code>`"};
+        auto answer = ::fast_io::u8string_view{u8"```"};
         pltxt2htm_test_assert_equal(html, answer);
     }
     // Content long enough to fill an unclosed span still must not be consumed by it.
@@ -120,12 +121,12 @@ int main() {
     }
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"``ab");
-        auto answer = ::fast_io::u8string_view{u8"<code></code>ab"};
+        auto answer = ::fast_io::u8string_view{u8"``ab"};
         pltxt2htm_test_assert_equal(html, answer);
     }
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"```x");
-        auto answer = ::fast_io::u8string_view{u8"<code></code>`x"};
+        auto answer = ::fast_io::u8string_view{u8"```x"};
         pltxt2htm_test_assert_equal(html, answer);
     }
     // A backslash-escaped backtick at the end is consumed as content, not a closing delimiter.
@@ -134,15 +135,15 @@ int main() {
         auto answer = ::fast_io::u8string_view{u8"`a`"};
         pltxt2htm_test_assert_equal(html, answer);
     }
-    // Valid empty code spans remain valid.
+    // Even balanced delimiter runs with no content stay literal.
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"````");
-        auto answer = ::fast_io::u8string_view{u8"<code></code>"};
+        auto answer = ::fast_io::u8string_view{u8"````"};
         pltxt2htm_test_assert_equal(html, answer);
     }
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"``````");
-        auto answer = ::fast_io::u8string_view{u8"<code></code>"};
+        auto answer = ::fast_io::u8string_view{u8"``````"};
         pltxt2htm_test_assert_equal(html, answer);
     }
     // The fuzzer crash input: an unclosed code span inside a Markdown list item.

--- a/tests/test_md_code_span.cc
+++ b/tests/test_md_code_span.cc
@@ -54,11 +54,11 @@ int main() {
         pltxt2htm_test_assert_equal(html, answer);
     }
 
-    // Note: this does not follow commonmark
-    // This is an implement defined behavior
+    // An opening backtick without a matching closing backtick is literal text,
+    // not an unterminated code span.
     {
         auto html = ::pltxt2htm_test::pltxt4unittest(u8"`t");
-        auto answer = ::fast_io::u8string_view{u8"<code>t</code>"};
+        auto answer = ::fast_io::u8string_view{u8"`t"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 
@@ -89,6 +89,83 @@ int main() {
     {
         auto html = ::pltxt2htm_test::pltxt2plunity_introduction(u8"ab```test```cd");
         auto answer = ::fast_io::u8string_view{u8"ab<font=\"PhysicsLab-SarasaMonoSC SDF\"> test </font>cd"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+
+    // Regression: an opening delimiter without a matching closing delimiter must not be
+    // accepted as a code span. Before the fix, the 2-backtick branch in the inline parser
+    // subtracted the delimiters from the consumed count and underflowed to a huge size_t,
+    // terminating (quick_enforce) or forming an out-of-bounds subview (ignore). See
+    // fixedadv_fuzzer_crash_analysis.md. Delimiter lengths 1, 2, 3 at top level.
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"`");
+        auto answer = ::fast_io::u8string_view{u8"`"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"``");
+        auto answer = ::fast_io::u8string_view{u8"<code></code>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"```");
+        auto answer = ::fast_io::u8string_view{u8"<code></code>`"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // Content long enough to fill an unclosed span still must not be consumed by it.
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"`t");
+        auto answer = ::fast_io::u8string_view{u8"`t"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"``ab");
+        auto answer = ::fast_io::u8string_view{u8"<code></code>ab"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"```x");
+        auto answer = ::fast_io::u8string_view{u8"<code></code>`x"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // A backslash-escaped backtick at the end is consumed as content, not a closing delimiter.
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"`a\\`");
+        auto answer = ::fast_io::u8string_view{u8"`a`"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // Valid empty code spans remain valid.
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"````");
+        auto answer = ::fast_io::u8string_view{u8"<code></code>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"``````");
+        auto answer = ::fast_io::u8string_view{u8"<code></code>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // The fuzzer crash input: an unclosed code span inside a Markdown list item.
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"* `");
+        auto answer = ::fast_io::u8string_view{u8"<ul><li>`</li></ul>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"* ``");
+        auto answer = ::fast_io::u8string_view{u8"<ul><li>``</li></ul>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"* ```");
+        auto answer = ::fast_io::u8string_view{u8"<ul><li>```</li></ul>"};
+        pltxt2htm_test_assert_equal(html, answer);
+    }
+    // Unclosed code span inside a table cell.
+    {
+        auto html = ::pltxt2htm_test::pltxt4unittest(u8"| a |\n|---|\n| `` |");
+        auto answer = ::fast_io::u8string_view{
+            u8"<table><thead><tr><th>a</th></tr></thead><tbody><tr><td>``</td></tr></tbody></table>"};
         pltxt2htm_test_assert_equal(html, answer);
     }
 


### PR DESCRIPTION
## Summary

Fixes a crash (fuzzer-reported) triggered by an opening Markdown code-span
delimiter without a matching closing delimiter, and makes code-span parsing
stricter so unterminated and empty spans stay literal text.

## Problem

The inline/block code-span parser computed the content length as
`advance_count - delimiter_size` at the call sites. When the closing delimiter
was missing, `simply_parse_pltext` consumed only the content and stopped at the
end of the input, so `advance_count` was smaller than the delimiter size and the
subtraction underflowed to a huge `size_t`:

- with `Contracts::quick_enforce` this terminated via `quick_enforce`;
- with `Contracts::ignore` it formed an out-of-bounds `string_view` subview.

Repro inputs included `* `` ` (unclosed span in a list item), `` ``ab `` and
`` ```x ``.

Additionally, a delimiter run with no content at all (` `` `, `` ```` `) was
recognized as a code span and rendered as `<code></code>`, which is not
meaningful.

## Changes

- **`simply_parse_pltext`** now reports whether `end_string` was actually
  matched (`found_end`).
- **`try_parse_md_code_span`** returns `nullopt` when the closing delimiter is
  missing (`found_end == false`) or when the content is empty, so the input
  stays literal text instead of silently dropping the unclosed backticks.
- **`try_parse_html_pre_code_block`** likewise bails out (returns `nullopt`)
  when `</code></pre>` is never found, keeping the input literal.
- **`TryParseMdCodeSpanResult`** now carries `{content_size, subast}` instead of
  `{advance_count, subast}`; call sites recompute the consumed length as
  `content_size + 2 * delimiter_size` from the compile-time delimiter.
- Updated `tests/test_md_code_span.cc` and `tests/test_md_code_fence.cc` to
  cover the crash inputs and the new literal-text behavior for unterminated and
  empty spans.